### PR TITLE
docs: add 0.1.8 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.1.8 — 2026-08-01
+
+- Reduce blank windows and flicker when Office starts.
+- Improve menu and popup reliability on Wayland and X11.
+- Prevent freezes caused by popup stacking on Wayland.
+
+[Full changes](https://github.com/ttv20/wine4office/compare/wine4office-v0.1.7...wine4office-v0.1.8)
+
 ## 0.1.7 — 2026-07-31
 
 - Complete updates started by older managers on the first restart: stop Wine,


### PR DESCRIPTION
## What changed

- Add a concise Wine4Office 0.1.8 changelog entry.
- Link the full 0.1.7 to 0.1.8 comparison.

## Why

The 0.1.8 release was published with artifacts, but the changelog stopped at 0.1.7.

## Validation

- `git diff --check`