### PR TITLE
ntdll: Reclaim free heap pages with MADV_FREE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Build Wine4Office releases and agent runners from the same reproducible 18-job environment.
+- Reduce Office background-service RAM by making unused heap pages reclaimable.
 - Display background-service RAM without reclaimable inactive file cache and hide it when the service is stopped.
 - Activate Microsoft 365 licenses after signing in to Office.
 - Keep Wine environment recreation responsive and show live progress and logs in the Manager.

--- a/dlls/kernel32/tests/virtual.c
+++ b/dlls/kernel32/tests/virtual.c
@@ -360,6 +360,22 @@ static void test_VirtualAllocEx(void)
     CloseHandle(hProcess);
 }
 
+static void test_mem_reset_host_page_neighbors(void)
+{
+    void *addr, *ret;
+
+    addr = VirtualAlloc( NULL, 0x10000, MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE );
+    ok( addr != NULL, "VirtualAlloc failed, error %lu\n", GetLastError() );
+    if (!addr) return;
+
+    memset( (char *)addr + 0x1000, 0xa5, 0x3000 );
+    ret = VirtualAlloc( addr, 0x1000, MEM_RESET, PAGE_NOACCESS );
+    ok( ret == addr, "VirtualAlloc MEM_RESET failed, error %lu\n", GetLastError() );
+    ok( *((BYTE *)addr + 0x1000) == 0xa5, "MEM_RESET modified the following page.\n" );
+    ok( *((BYTE *)addr + 0x3fff) == 0xa5, "MEM_RESET modified the end of the host-page neighbour.\n" );
+    ok( VirtualFree( addr, 0, MEM_RELEASE ), "VirtualFree failed, error %lu\n", GetLastError() );
+}
+
 static void test_VirtualAlloc(void)
 {
     void *addr1, *addr2;
@@ -4856,6 +4872,11 @@ START_TEST(virtual)
             test_shared_memory_ro(TRUE, strtol(argv[3], NULL, 16));
             return;
         }
+        if (!strcmp( argv[2], "mem_reset_neighbors" ))
+        {
+            test_mem_reset_host_page_neighbors();
+            return;
+        }
         while (1)
         {
             void *mem;
@@ -4910,6 +4931,7 @@ START_TEST(virtual)
     test_VirtualProtect();
     test_VirtualAllocEx();
     test_VirtualAlloc();
+    test_mem_reset_host_page_neighbors();
     test_MapViewOfFile();
     test_NtAreMappedFilesTheSame();
     test_CreateFileMapping();

--- a/dlls/ntdll/heap.c
+++ b/dlls/ntdll/heap.c
@@ -441,6 +441,23 @@ static inline struct block *next_block( const SUBHEAP *subheap, const struct blo
     return (struct block *)next;
 }
 
+static BOOL get_free_block_discard_range( const SUBHEAP *subheap, const struct block *block,
+                                          void **addr, SIZE_T *size )
+{
+    const UINT_PTR page_mask = page_size - 1;
+    char *start, *end, *commit_end = (char *)subheap_commit_end( subheap );
+
+    /* Preserve the free-list entry and the following block's back pointer. */
+    start = ROUND_ADDR( (char *)((const struct entry *)block + 1) + page_mask, page_mask );
+    end = ROUND_ADDR( (char *)block + block_get_size( block ) - sizeof(void *), page_mask );
+    if (end > commit_end) end = ROUND_ADDR( commit_end, page_mask );
+    if (end <= start) return FALSE;
+
+    *addr = start;
+    *size = end - start;
+    return TRUE;
+}
+
 static inline BOOL check_subheap( const SUBHEAP *subheap, const struct heap *heap )
 {
     if (subheap->user_value != heap) return FALSE;
@@ -905,6 +922,19 @@ static struct block *heap_delay_free( struct heap *heap, ULONG flags, struct blo
     return tmp;
 }
 
+static void discard_free_block_pages( ULONG flags, const SUBHEAP *subheap, const struct block *block )
+{
+    SIZE_T size;
+    void *addr;
+
+    if ((flags & HEAP_FREE_CHECKING_ENABLED) || RUNNING_ON_VALGRIND) return;
+    if (!get_free_block_discard_range( subheap, block, &addr, &size )) return;
+
+    /* Keep the address range committed. The Unix backend marks its physical
+     * pages as lazily reclaimable, so immediate reuse stays cheap. */
+    NtAllocateVirtualMemory( NtCurrentProcess(), &addr, 0, &size, MEM_RESET, PAGE_NOACCESS );
+}
+
 
 static NTSTATUS heap_free_block( struct heap *heap, ULONG flags, struct block *block )
 {
@@ -947,6 +977,7 @@ static NTSTATUS heap_free_block( struct heap *heap, ULONG flags, struct block *b
 
     /* keep room for a full committed block as hysteresis */
     if (!next) subheap_decommit( heap, subheap, (char *)((struct entry *)block + 1) + REGION_ALIGN );
+    discard_free_block_pages( flags, subheap, block );
 
     return STATUS_SUCCESS;
 }
@@ -1719,6 +1750,7 @@ static NTSTATUS heap_allocate_block( struct heap *heap, ULONG flags, SIZE_T bloc
     {
         block_init_free( next, flags, subheap, old_block_size - block_size );
         insert_free_block( heap, flags, subheap, next );
+        discard_free_block_pages( flags, subheap, next );
     }
 
     block_set_type( block, BLOCK_TYPE_USED );
@@ -2160,6 +2192,7 @@ static NTSTATUS heap_resize_block( struct heap *heap, ULONG flags, struct block 
     {
         block_init_free( next, flags, subheap, old_block_size - block_size );
         insert_free_block( heap, flags, subheap, next );
+        discard_free_block_pages( flags, subheap, next );
     }
 
     valgrind_notify_resize( block + 1, *old_size, size );

--- a/dlls/ntdll/unix/virtual.c
+++ b/dlls/ntdll/unix/virtual.c
@@ -5216,7 +5216,21 @@ static NTSTATUS allocate_virtual_memory( void **ret, SIZE_T *size_ptr, ULONG typ
     else if (type & MEM_RESET)
     {
         if (!(view = find_view( base, size ))) status = STATUS_NOT_MAPPED_VIEW;
-        else madvise( base, size, MADV_DONTNEED );
+        else
+        {
+            char *host_start = (char *)ROUND_SIZE( 0, base, host_page_mask );
+            char *host_end = ROUND_ADDR( (char *)base + size, host_page_mask );
+
+            /* madvise() operates on host pages. Clamp inward so a Windows-page
+             * MEM_RESET range cannot discard neighbouring data on larger-page hosts. */
+            if (host_start < host_end)
+            {
+#ifdef MADV_FREE
+                if (madvise( host_start, host_end - host_start, MADV_FREE ))
+#endif
+                    madvise( host_start, host_end - host_start, MADV_DONTNEED );
+            }
+        }
     }
     else  /* commit the pages */
     {


### PR DESCRIPTION
## Why

Wine keeps physical pages behind ordinary free heap blocks. The previous PR design reclaimed them with delayed reset and bounded true decommit, but Word/C2R testing showed that the true-decommit path added CPU and VMA churn without improving memory savings. Its 250 ms delay and five-second cooldown also encoded workload-specific timing guesses.

## What changed

- Mark complete interior pages of ordinary free heap blocks with `MEM_RESET` immediately after free/coalescing and after allocation or realloc creates a free remainder.
- Preserve the free-list entry, following-block back pointer, partial Windows pages, and partial host pages.
- Implement Unix `MEM_RESET` with `MADV_FREE`, falling back to the existing `MADV_DONTNEED` behavior when lazy discard is unavailable.
- Keep the ranges committed, allowing cheap immediate reuse while Linux can discard their physical contents under memory pressure without swap I/O.
- Skip automatic discard for free-checking heaps and Valgrind.
- Leave explicit `MEM_DECOMMIT`, tail decommit, subheap release, heap walking, accounting, and public virtual-memory state unchanged.

There are no timers, sleeps, worker threads, decommit flags, heap-wide scans, range counters, cooldowns, executable-name checks, or Segment Heap policy in this patch.

## Word/C2R A/B

Each run used a fresh prefix, opened the same 57 MiB, 81-page DOCX, and sampled Word and C2R once per second for 90 seconds. The table uses medians; memory is averaged over the final 30 seconds. `non-lazy PSS` subtracts private pages reported by Linux as `LazyFree` and therefore immediately reclaimable.

| C2R | PSS | LazyFree | non-lazy PSS | CPU / 90 s | minor faults | VMAs |
|---|---:|---:|---:|---:|---:|---:|
| `main` (6 runs) | 112.7 MiB | 0 | 112.7 MiB | 2.89 s | 52,837 | 1,029.2 |
| patched (5 runs) | 114.5 MiB | 33.5 MiB | 80.8 MiB | 3.03 s | 49,619 | 1,027.2 |

The patch made about 32 MiB (28%) of C2R's PSS lazily reclaimable. Visible PSS remains high until Linux needs the pages; an earlier pressure run showed the kernel reclaiming them. VMAs stayed at baseline. C2R used about 0.14 additional CPU second over 90 seconds; Word CPU and memory were effectively unchanged. All Word/C2R runs completed without a crash.

The replaced true-decommit implementation used 4.22 CPU seconds and about 1,048 VMAs in the same workload, without reducing non-lazy PSS below the soft-discard result.

## Validation

- Based on `main` commit `5d05c4d7c35703b79903c93bb7e3efe68b4a3c4e` and built in the canonical combined i386/x86-64 environment.
- Rebuilt both PE `ntdll.dll` architectures and Unix `ntdll.so` through the focused dry-run gate.
- Complete kernel32 heap suite passed independently on x86-64 and i386.
- Complete kernel32 virtual suite passed on x86-64.
- Focused `MEM_RESET` neighbouring-page test passed 5/5 on i386 in the KDE/Wayland test environment. The complete headless i386 virtual suite still contains unrelated window tests that require a display.
- Final committed runner opened Word and completed the 90-second C2R sample.
- `git diff --check` passed.

## Review disposition

The earlier reviews correctly identified complexity and scaling risks in the interior-decommit implementation. The replacement removes the reviewed decommit tracking, recommit, heap-walk synthesis, LFH rollback, Segment Heap frontend, cooldown, threshold, counter, and full-heap-scan code rather than carrying those mechanisms forward. Issues #53 and #54 are therefore obsolete.
