### PR TITLE
winewayland: fix Office color picker popups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix Office color picker popups on Wayland.
+
 ## 0.2.0-alpha — 2026-08-11
 
 - Make release archives reproducible without breaking linked files.

--- a/dlls/winewayland.drv/window.c
+++ b/dlls/winewayland.drv/window.c
@@ -778,12 +778,16 @@ void WAYLAND_WindowPosChanged(HWND hwnd, HWND insert_after, HWND owner_hint, UIN
     /* Get the managed state with win_data unlocked, as is_window_managed
      * may need to query win_data information about other HWNDs and thus
      * acquire the lock itself internally. */
-    if (!(managed = is_window_managed(hwnd, swp_flags, fullscreen)))
+    if (!(managed = is_window_managed(hwnd, swp_flags, fullscreen)) && surface)
     {
         DWORD style = NtUserGetWindowLongW(hwnd, GWL_STYLE);
         LONG width = new_rects->window.right - new_rects->window.left;
         LONG height = new_rects->window.bottom - new_rects->window.top;
 
+        /* owner_hint is only meaningful for windows with a driver surface.
+         * Client-surface-only windows acquire their parent when presented;
+         * storing the hint early changes desktop-relative coordinates into
+         * parent-relative ones. */
         owner = owner_hint;
         if (!transient_owner && (style & WS_POPUP) && !(style & WS_THICKFRAME) &&
             (width <= 16 || height <= 16) &&


### PR DESCRIPTION
## Root cause

The 0.2.0 Wayland lifetime hardening removed the existing `surface` gate when selecting an owner for unmanaged windows. Office's DirectComposition color picker is initially client-surface-only, so it could store an `owner_hint` before it had a driver window surface. When GPU presentation later attached it, desktop-relative coordinates were interpreted as parent-relative coordinates and the popup was placed offscreen.

The old gate is a valid generic window-lifecycle constraint, not an Office-specific workaround.

## Fix

- Only consume the inferred `owner_hint` when a driver surface exists.
- Keep client-surface-only ownership deferred until presentation.
- Add the user-visible fix to the changelog.

## Validation

- `git diff --check`
- Combined WoW64 configure: `--enable-archs=i386,x86_64 --without-x --with-wayland`
- `make -j2 dlls/winewayland.drv/winewayland.so`
- `make -j2 dlls/user32/tests/x86_64-windows/popup.o dlls/user32/tests/i386-windows/popup.o`
- Exact 0.2.0 Office/KDE/KRDP baseline reproduced in isolated `fontcolor-20260811` QA environment.

The full `popup.ok` executions could not run from the narrow local build because the complete PE runtime was not built. Office after-fix visual confirmation is also currently confounded by the independently reproduced 0.2.0 NUIDialog white/repaint regression tracked in the separate visual-fix work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Office color picker popups appearing incorrectly or failing to display on Wayland.
  * Improved handling of certain application windows without native display surfaces, helping popups and adjacent windows behave more reliably.

* **Documentation**
  * Added an entry to the unreleased changelog documenting the Wayland color picker fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->