### PR TITLE
Fix blank Office dialogs before first presentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fix Office color picker popups on Wayland.
+- Fix Office dialogs that stayed blank until pointer movement.
 
 ## 0.2.0-alpha — 2026-08-11
 

--- a/dlls/winewayland.drv/window.c
+++ b/dlls/winewayland.drv/window.c
@@ -379,11 +379,13 @@ static BOOL wayland_win_data_create_wayland_surface(struct wayland_win_data *dat
         (state->layered_flags & LWA_ALPHA) && !state->layered_alpha)
         visible = FALSE;
 
-    /* A newly visible surface without a class background brush has no
-     * application-defined contents yet. Keep it role-less until the first
+    /* A newly visible unmanaged toplevel without a class background brush has
+     * no application-defined contents yet. Keep it role-less until the first
      * software flush or GPU presentation instead of exposing the driver's
-     * generic initialization buffer. */
-    if (visible && !data->contents_presented && !state->has_background)
+     * generic initialization buffer. Managed application windows need their
+     * initial xdg configure before they can produce the first presentation. */
+    if (visible && !data->managed && !owner_surface &&
+        !data->contents_presented && !state->has_background)
         visible = FALSE;
 
     /* A DirectComposition-only notification host is a logical Win32 target,


### PR DESCRIPTION
## Summary

- create managed Wayland toplevels before their first application presentation so they can receive the initial xdg configure
- retain delayed mapping only for unowned unmanaged no-background surfaces
- document the Office dialog repaint fix

## Root cause

The 0.2.0 lifecycle hardening broadened the delayed-presentation guard from unowned unmanaged toplevels to every no-background window. Managed Office dialogs then waited for a presentation that itself depended on the initial xdg configure, producing white/black shells whose individual controls appeared only after hover invalidation. This restores the generic managed/owner contract from the last working behavior without restoring the old `NUIDialog` class-name workaround.

Both reported symptoms share this lifecycle path, so this is one atomic fix.

## Verification

- clean combined WoW64 configure/build/install with `--enable-archs=i386,x86_64`
- rebuilt `winewayland.so`; baseline SHA-256 `e989dfef2ae7dce1875b6552ace8fd1b3486ec7b77250f666493af157271e3f5`, fixed SHA-256 `d24f92440435402d9163b337b51ff55d5e91e105049002f9b32885d2a557f2c9`
- built user32 tests for i386 and x86_64
- `user32_test.exe popup`: 12/12 passed on x86_64 and 12/12 passed on i386
- KRDP/KWin virtual desktop reproduced the pre-fix modal as a white shell with only the focused control painted; the rebuilt driver renders the managed modal fully and accepts keyboard input

## Visual review

Human review is required for the exact Word Options and unsaved-document hover flows. Screenshots were captured over the persistent KRDP path and sent to Telegram. The cloned Office prefix entered its persisted crash-recovery splash during the final exact-dialog pass; this does not affect the generic modal before/after result, but the reviewer should repeat both named Word flows before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Office dialogs that could remain blank until the pointer was moved.
  * Improved window visibility behavior so managed and owned windows can appear before their first content presentation.
* **Documentation**
  * Added an entry documenting the Office dialog display fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->