### PR TITLE
dxgi: preserve full frames for sparse Present1 updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Fix Office color picker popups on Wayland.
 - Fix resizing Office windows with DirectComposition content on Wayland.
 - Keep Wine and background-service shutdowns bounded and environment-specific.
-- Fix Office dialogs that stayed blank until pointer movement.
+- Fix Office dialogs turning white during pointer movement.
 
 [Full changes](https://github.com/ttv20/wine4office/compare/0.2.0-alpha...0.2.0-alpha.2)
 

--- a/dlls/dxgi/swapchain.c
+++ b/dlls/dxgi/swapchain.c
@@ -532,8 +532,18 @@ static HRESULT STDMETHODCALLTYPE DECLSPEC_HOTPATCH d3d11_swapchain_Present(IDXGI
     HRESULT hr;
 
     TRACE("iface %p, sync_interval %u, flags %#x.\n", iface, sync_interval, flags);
+    if (flags & DXGI_PRESENT_TEST)
+        return d3d11_swapchain_present(swapchain, sync_interval, flags);
+
+    /* Applications may follow a complete Present() with sparse Present1()
+     * updates.  Keep the complete frame available for those dirty updates. */
+    if (FAILED(hr = d3d11_swapchain_preserve_present1_contents(swapchain, NULL)))
+    {
+        swapchain->present1_shadow_valid = FALSE;
+        WARN("Failed to update presentation shadow, hr %#lx.\n", hr);
+    }
     hr = d3d11_swapchain_present(swapchain, sync_interval, flags);
-    if (SUCCEEDED(hr) && !(flags & DXGI_PRESENT_TEST))
+    if (FAILED(hr))
         swapchain->present1_shadow_valid = FALSE;
     return hr;
 }


### PR DESCRIPTION
## Summary

- preserve complete regular `Present()` frames for later sparse `Present1()` updates
- invalidate the shadow on preservation or presentation failure
- clarify the Office dialog repaint changelog entry

## Root cause

Office renders the complete dialog with `Present()` and then submits button-hover changes as dirty rectangles through `Present1()`. The regular present path invalidated the persistent frame, so sparse updates were merged against a white/incorrect buffer.

## Validation

- combined WoW64 DXGI build: i386 and x86_64
- Word unsaved-document dialog: repeated hover across all three buttons
- SETLANG: 11 hover targets across buttons, language rows, and link
- repeated Word open/edit/close cycles; no crash or stale frame

The reused production build was configured with `--disable-tests`; validation used the exact visual regressions in the canonical KWin Wayland/VNC environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Office dialogs turning white during pointer movement.
  * Improved graphics presentation behavior, helping preserve complete frames and maintain correct display contents during presentation checks and failed display updates.

* **Documentation**
  * Updated the 0.2.0-alpha.2 changelog with the Office dialog rendering fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->