### PR TITLE
Direct2D: avoid first-open Word Design tab stalls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Prevent the first Word Design-tab load from stalling on queued Direct2D work.
+
 ## 0.2.0-alpha.2 — 2026-08-18
 
 - Restore Office proofing and language-pack discovery.

--- a/dlls/d2d1/factory.c
+++ b/dlls/d2d1/factory.c
@@ -548,8 +548,11 @@ HRESULT d2d_factory_create_device(ID2D1Factory1 *factory, IDXGIDevice *dxgi_devi
     struct d2d_device *object;
     HRESULT hr;
 
-    if (GetEnvironmentVariableA("WINE_D2D_SYNC_EXTERNAL_DEVICE", NULL, 0)
-            && SUCCEEDED(IDXGIDevice_QueryInterface(dxgi_device,
+    /* Direct2D uses the immediate context of the supplied device for
+     * synchronous bitmap and composition work. Keep that work on the calling
+     * thread; an asynchronous command stream can leave the UI thread waiting
+     * for a long sequence of small map and flush operations. */
+    if (SUCCEEDED(IDXGIDevice_QueryInterface(dxgi_device,
             &d2d_IID_IWineDXGIDevice, (void **)&wine_device)))
     {
         IWineDXGIDevice_use_sync_command_stream(wine_device);


### PR DESCRIPTION
## Summary

- Switch Wine DXGI devices supplied to Direct2D onto the existing synchronous command stream.
- Keep the fix at the Direct2D/DXGI boundary, without executable checks or environment-variable workarounds.
- Prevent Word's first Design-gallery load from stalling behind many small queued bitmap, map, and flush operations.

## Testing

- Built `d2d1.dll` for both i386 and x86_64 in the combined WoW64 build.
- Full Direct2D test executable: 17,415 tests with 48 failures, exactly matching the `0.2.0-alpha.2` baseline.
- Controlled Word A/B: baseline first Design-gallery load was about 8 seconds; the candidate populated by 2 seconds under low load, with later opens at 0.5 seconds or less.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the first Word Design-tab load could stall while waiting for queued graphics work.
  * Improved synchronization with supported graphics devices for a smoother initial display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->