### PR TITLE
Manager: stop only the selected Wine environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Stop only the selected Wine environment, with a graceful ten-second deadline.
+
 ## 0.2.0-alpha.2 — 2026-08-18
 
 - Restore Office proofing and language-pack discovery.

--- a/programs/wine4officeclose/tests/Makefile.in
+++ b/programs/wine4officeclose/tests/Makefile.in
@@ -1,4 +1,4 @@
-TESTDLL   = wine4officeclose_test.exe
+TESTDLL   = wine4officeclose.exe
 IMPORTS   = user32
 
 SOURCES = \

--- a/programs/wine4officeclose/tests/wine4officeclose.c
+++ b/programs/wine4officeclose/tests/wine4officeclose.c
@@ -89,6 +89,24 @@ static BOOL run_close_utility_without_targets(const WCHAR *utility, DWORD *exit_
     return TRUE;
 }
 
+static BOOL run_close_utility_discovery(const WCHAR *utility, DWORD *exit_code)
+{
+    PROCESS_INFORMATION process_info = {0};
+    STARTUPINFOW startup_info = {0};
+    WCHAR command[32768];
+
+    startup_info.cb = sizeof(startup_info);
+    swprintf(command, ARRAY_SIZE(command), L"\"%s\" --discover-office", utility);
+    if (!CreateProcessW(NULL, command, NULL, NULL, FALSE, 0, NULL, NULL,
+                        &startup_info, &process_info))
+        return FALSE;
+    WaitForSingleObject(process_info.hProcess, INFINITE);
+    GetExitCodeProcess(process_info.hProcess, exit_code);
+    CloseHandle(process_info.hThread);
+    CloseHandle(process_info.hProcess);
+    return TRUE;
+}
+
 static void test_owned_window_is_the_only_close_target(void)
 {
     WCHAR module[32768], utility[32768], full_utility[32768];
@@ -167,6 +185,32 @@ static void test_owned_window_is_the_only_close_target(void)
 
     TerminateProcess(child_info.hProcess, 0);
     CloseHandle(child_info.hProcess);
+    child_info.hProcess = NULL;
+
+    ResetEvent(ready);
+    ok(CreateProcessW(child_path, command, NULL, NULL, TRUE, 0, NULL, NULL,
+                      &startup_info, &child_info), "Could not restart owned child: %lu\n", GetLastError());
+    if (child_info.hProcess)
+    {
+        CloseHandle(child_info.hThread);
+        wait = WaitForSingleObject(ready, 5000);
+        ok(wait == WAIT_OBJECT_0, "Discovered window did not become ready: %lu\n", wait);
+        if (wait == WAIT_OBJECT_0)
+        {
+            ok(run_close_utility_discovery(utility, &exit_code),
+               "Could not launch close utility discovery\n");
+            ok(exit_code == 0, "Close utility discovery returned %lu\n", exit_code);
+            ok(WaitForSingleObject(child_info.hProcess, 5000) == WAIT_OBJECT_0,
+               "Discovered Office-like process remained open\n");
+            ok(IsWindow(unrelated), "Discovery closed an unrelated top-level window\n");
+        }
+    }
+
+    if (child_info.hProcess)
+    {
+        TerminateProcess(child_info.hProcess, 0);
+        CloseHandle(child_info.hProcess);
+    }
     DestroyWindow(unrelated);
     CloseHandle(ready);
     DeleteFileW(child_path);

--- a/programs/wine4officeclose/wine4officeclose.c
+++ b/programs/wine4officeclose/wine4officeclose.c
@@ -2,9 +2,10 @@
  * Bounded graceful closer for manager-owned Microsoft Office applications.
  *
  * The manager authenticates the selected Wine prefix and runner before it
- * supplies process ids.  This program deliberately accepts no implicit
- * process discovery: a process id is revalidated (including its creation
- * time) immediately before each window operation.
+ * supplies process ids.  If manager-side process discovery fails, the manager
+ * can request discovery inside its selected Wine environment instead.  Every
+ * process is revalidated (including its creation time) immediately before
+ * each window operation.
  */
 
 #include <windows.h>
@@ -104,6 +105,7 @@ struct collect_context
     struct window_list *list;
     const struct process_identity *targets;
     unsigned int target_count;
+    BOOL discover_office;
 };
 
 static const struct process_identity *find_target(const struct collect_context *context, DWORD pid)
@@ -121,12 +123,16 @@ static BOOL CALLBACK collect_window(HWND hwnd, LPARAM param)
     struct collect_context *context = (struct collect_context *)param;
     struct window_list *list = context->list;
     const struct process_identity *target;
+    struct process_identity discovered;
     DWORD pid;
 
     GetWindowThreadProcessId(hwnd, &pid);
     if (pid == GetCurrentProcessId() || hwnd == GetDesktopWindow() || !IsWindowVisible(hwnd))
         return TRUE;
-    if (!(target = find_target(context, pid)) || !process_identity_matches(target))
+    target = find_target(context, pid);
+    if (!target && context->discover_office && read_process_identity(pid, &discovered))
+        target = &discovered;
+    if (!target || !process_identity_matches(target))
         return TRUE;
     if (list->count == MAX_WINDOWS)
     {
@@ -157,39 +163,44 @@ int __cdecl wmain(int argc, WCHAR **argv)
 {
     struct process_identity targets[MAX_TARGETS];
     struct window_list windows = {0};
-    struct collect_context context = {&windows, targets, 0};
+    struct collect_context context = {&windows, targets, 0, FALSE};
     ULONGLONG deadline;
     unsigned int i, target_index, remaining;
     DWORD pid;
 
-    for (i = 1; i < (unsigned int)argc; ++i)
+    if (argc == 2 && !wcsicmp(argv[1], L"--discover-office"))
+        context.discover_office = TRUE;
+    else
     {
-        if (wcsicmp(argv[i], L"--pid") || i + 1 >= (unsigned int)argc
-                || !parse_pid(argv[++i], &pid))
+        for (i = 1; i < (unsigned int)argc; ++i)
         {
-            fwprintf(stderr, L"usage: wine4officeclose.exe --pid <office-process-id> [...]\n");
-            return 2;
+            if (wcsicmp(argv[i], L"--pid") || i + 1 >= (unsigned int)argc
+                    || !parse_pid(argv[++i], &pid))
+            {
+                fwprintf(stderr, L"usage: wine4officeclose.exe (--pid <office-process-id> [...] | --discover-office)\n");
+                return 2;
+            }
+            for (target_index = 0; target_index < context.target_count; ++target_index)
+                if (targets[target_index].pid == pid)
+                    break;
+            if (target_index != context.target_count)
+                continue;
+            if (context.target_count == MAX_TARGETS)
+            {
+                fwprintf(stderr, L"wine4officeclose: too many process targets\n");
+                return 2;
+            }
+            if (!read_process_identity(pid, &targets[context.target_count]))
+            {
+                fwprintf(stderr, L"wine4officeclose: refusing unowned or non-Office process %lu\n", pid);
+                return 2;
+            }
+            ++context.target_count;
         }
-        for (target_index = 0; target_index < context.target_count; ++target_index)
-            if (targets[target_index].pid == pid)
-                break;
-        if (target_index != context.target_count)
-            continue;
-        if (context.target_count == MAX_TARGETS)
-        {
-            fwprintf(stderr, L"wine4officeclose: too many process targets\n");
-            return 2;
-        }
-        if (!read_process_identity(pid, &targets[context.target_count]))
-        {
-            fwprintf(stderr, L"wine4officeclose: refusing unowned or non-Office process %lu\n", pid);
-            return 2;
-        }
-        ++context.target_count;
     }
-    if (!context.target_count)
+    if (!context.target_count && !context.discover_office)
     {
-        fwprintf(stderr, L"usage: wine4officeclose.exe --pid <office-process-id> [...]\n");
+        fwprintf(stderr, L"usage: wine4officeclose.exe (--pid <office-process-id> [...] | --discover-office)\n");
         return 2;
     }
 

--- a/tools/wine4office-manager/tests/test_backend.py
+++ b/tools/wine4office-manager/tests/test_backend.py
@@ -717,6 +717,30 @@ touch "$WINEPREFIX/system.reg" "$WINEPREFIX/user.reg"
             ],
         )
 
+    def test_stop_wine_force_stops_when_discovery_helper_fails(self):
+        prefix = self._make_prefix(self.home / ".wine4office")
+        with mock.patch.object(
+            backend, "_owned_office_pids",
+            side_effect=RuntimeError("tasklist unavailable"),
+        ), mock.patch.object(
+            backend.subprocess, "run",
+            side_effect=[
+                subprocess.CalledProcessError(2, "wine4officeclose.exe"),
+                mock.DEFAULT,
+                mock.DEFAULT,
+            ],
+        ) as run:
+            backend.stop_wine(str(prefix), str(self.wine))
+
+        self.assertEqual(
+            [call.args[0] for call in run.call_args_list],
+            [
+                [str(self.wine), "wine4officeclose.exe", "--discover-office"],
+                [str(self.runner / "wineserver"), "-k"],
+                [str(self.runner / "wineserver"), "-w"],
+            ],
+        )
+
     def test_office_detection_uses_windows_pid_from_selected_tasklist(self):
         prefix = self._make_prefix(self.home / ".wine4office")
         completed = mock.Mock(

--- a/tools/wine4office-manager/tests/test_backend.py
+++ b/tools/wine4office-manager/tests/test_backend.py
@@ -604,13 +604,15 @@ touch "$WINEPREFIX/system.reg" "$WINEPREFIX/user.reg"
 
     def test_stop_wine_gracefully_closes_windows_before_server(self):
         prefix = self._make_prefix(self.home / ".wine4office")
-        with mock.patch.object(backend.subprocess, "run") as run:
+        with mock.patch.object(
+            backend, "_owned_office_pids", return_value=[4132]
+        ), mock.patch.object(backend.subprocess, "run") as run:
             backend.stop_wine(str(prefix), str(self.wine))
 
         self.assertEqual(
             [call.args[0] for call in run.call_args_list],
             [
-                [str(self.wine), "wine4officeclose.exe"],
+                [str(self.wine), "wine4officeclose.exe", "--pid", "4132"],
                 [str(self.runner / "wineserver"), "-w"],
             ],
         )
@@ -637,6 +639,8 @@ touch "$WINEPREFIX/system.reg" "$WINEPREFIX/user.reg"
     def test_stop_wine_hard_kills_when_graceful_close_fails(self):
         prefix = self._make_prefix(self.home / ".wine4office")
         with mock.patch.object(
+            backend, "_owned_office_pids", return_value=[4132]
+        ), mock.patch.object(
             backend.subprocess, "run",
             side_effect=[
                 subprocess.CalledProcessError(2, "wine4officeclose.exe"),
@@ -649,7 +653,7 @@ touch "$WINEPREFIX/system.reg" "$WINEPREFIX/user.reg"
         self.assertEqual(
             [call.args[0] for call in run.call_args_list],
             [
-                [str(self.wine), "wine4officeclose.exe"],
+                [str(self.wine), "wine4officeclose.exe", "--pid", "4132"],
                 [str(self.runner / "wineserver"), "-k"],
                 [str(self.runner / "wineserver"), "-w"],
             ],
@@ -659,6 +663,8 @@ touch "$WINEPREFIX/system.reg" "$WINEPREFIX/user.reg"
         prefix = self._make_prefix(self.home / ".wine4office")
         timeout = subprocess.TimeoutExpired("wineserver -w", 15)
         with mock.patch.object(
+            backend, "_owned_office_pids", return_value=[4132]
+        ), mock.patch.object(
             backend.subprocess, "run",
             side_effect=[
                 mock.DEFAULT, timeout, mock.DEFAULT, timeout,
@@ -675,6 +681,63 @@ touch "$WINEPREFIX/system.reg" "$WINEPREFIX/user.reg"
         self.assertNotIn(
             [str(self.runner / "wineserver"), "-k9"],
             [call.args[0] for call in run.call_args_list],
+        )
+
+    def test_stop_wine_without_office_skips_invalid_empty_close_request(self):
+        prefix = self._make_prefix(self.home / ".wine4office")
+        with mock.patch.object(
+            backend, "_owned_office_pids", return_value=[]
+        ), mock.patch.object(backend.subprocess, "run") as run:
+            backend.stop_wine(str(prefix), str(self.wine))
+
+        self.assertEqual(
+            [call.args[0] for call in run.call_args_list],
+            [
+                [str(self.runner / "wineserver"), "-k"],
+                [str(self.runner / "wineserver"), "-w"],
+            ],
+        )
+
+    def test_office_detection_uses_windows_pid_from_selected_tasklist(self):
+        prefix = self._make_prefix(self.home / ".wine4office")
+        completed = mock.Mock(
+            returncode=0,
+            stdout='"WINWORD.EXE","4242","Console","1","12 K"\n'
+                   '"services.exe","43","Services","0","8 K"\n',
+            stderr="",
+        )
+        with mock.patch.object(
+            backend.subprocess, "run", return_value=completed
+        ) as run:
+            self.assertEqual(
+                backend._owned_office_pids(prefix, self.wine, False), [4242]
+            )
+
+        self.assertEqual(
+            run.call_args.args[0],
+            [str(self.wine), "tasklist.exe", "/FO", "CSV", "/NH"],
+        )
+
+    def test_force_kill_accepts_selected_runner_wine_preloader(self):
+        prefix = self._make_prefix(self.home / ".wine4office")
+        proc_root = self.root / "proc"
+        process = proc_root / "1234"
+        process.mkdir(parents=True)
+        preloader = self.runner.parent / "lib/wine/x86_64-unix/wine-preloader"
+        preloader.parent.mkdir(parents=True)
+        preloader.write_bytes(b"preloader")
+        (process / "exe").symlink_to(preloader)
+        (process / "environ").write_bytes(
+            os.fsencode(f"WINEPREFIX={prefix.resolve()}") + b"\0"
+        )
+        stat_fields = ["S"] + ["0"] * 18 + ["42"]
+        (process / "stat").write_text(
+            "1234 (wine-preloader) " + " ".join(stat_fields)
+        )
+
+        self.assertEqual(
+            backend._owned_wine_processes(prefix, self.wine, proc_root),
+            [(1234, "42")],
         )
 
     def test_force_kill_skips_pid_when_identity_changes(self):
@@ -2632,7 +2695,7 @@ touch "$WINEPREFIX/system.reg" "$WINEPREFIX/user.reg"
 
         self.assertEqual(found, [])
 
-    def test_stop_refuses_active_or_unknown_office_without_systemctl_stop(self):
+    def test_stop_service_does_not_refuse_when_office_is_active(self):
         binding = self._preload_binding()
         backend._preload_json_write(backend.preload_binding_path(), binding)
         backend._preload_atomic_write(
@@ -2642,24 +2705,18 @@ touch "$WINEPREFIX/system.reg" "$WINEPREFIX/user.reg"
             backend, "_systemd_user_capability", return_value=(True, "")
         ), mock.patch.object(
             backend, "preload_office_processes", return_value=["EXCEL.EXE"]
-        ), mock.patch.object(backend, "_systemctl_user") as systemctl:
-            with self.assertRaisesRegex(RuntimeError, "Office is active"):
-                backend.manage_preload_service(
-                    "stop", binding["prefix"], binding["wine"], True
-                )
-        systemctl.assert_not_called()
+        ) as office, mock.patch.object(
+            backend, "_stop_preload_unit_and_wait"
+        ) as stop, mock.patch.object(
+            backend, "preload_service_status", return_value={"state": "inactive"}
+        ):
+            result = backend.manage_preload_service(
+                "stop", binding["prefix"], binding["wine"], True
+            )
 
-        with mock.patch.object(
-            backend, "_systemd_user_capability", return_value=(True, "")
-        ), mock.patch.object(
-            backend, "preload_office_processes",
-            side_effect=RuntimeError("tasklist timeout"),
-        ), mock.patch.object(backend, "_systemctl_user") as systemctl:
-            with self.assertRaisesRegex(RuntimeError, "tasklist timeout"):
-                backend.manage_preload_service(
-                    "stop", binding["prefix"], binding["wine"], True
-                )
-        systemctl.assert_not_called()
+        self.assertEqual(result["state"], "inactive")
+        office.assert_not_called()
+        stop.assert_called_once_with(binding=binding)
 
     def test_clicktorun_process_detection_requires_prefix_and_runner(self):
         binding = self._preload_binding()
@@ -2879,7 +2936,7 @@ touch "$WINEPREFIX/system.reg" "$WINEPREFIX/user.reg"
             actions,
             [("start", "ClickToRunSvc"), ("stop", "ClickToRunSvc")],
         )
-        office.assert_called_once()
+        office.assert_not_called()
         appv_start.assert_called_once_with(binding)
         appv_stop.assert_called_once_with(appv_process)
         voip_start.assert_called_once_with(binding)
@@ -2980,7 +3037,7 @@ touch "$WINEPREFIX/system.reg" "$WINEPREFIX/user.reg"
         )
         self.assertFalse(heartbeat["components"]["ClickToRunSvc"]["owned"])
 
-    def test_worker_refuses_signal_cleanup_when_activity_check_fails(self):
+    def test_worker_cleanup_does_not_depend_on_tasklist(self):
         binding = self._preload_binding()
         backend._preload_json_write(backend.preload_binding_path(), binding)
         handlers = {}
@@ -2998,22 +3055,22 @@ touch "$WINEPREFIX/system.reg" "$WINEPREFIX/user.reg"
         ), mock.patch.object(
             backend, "_preload_component_state", return_value=("running", "running")
         ), mock.patch.object(
-            backend, "_preload_component_action"
+            backend, "_preload_component_action", return_value=(True, "stopped")
         ) as action, mock.patch.object(
             backend, "preload_office_processes",
             side_effect=RuntimeError("unknown"),
-        ), mock.patch.object(
+        ) as office, mock.patch.object(
             backend.signal, "signal", side_effect=install_signal
         ), mock.patch.object(backend.time, "sleep", side_effect=stop_sleep):
             result = backend.run_preload_worker(
                 backend.preload_binding_path(), backend.preload_runtime_status_path()
             )
-        self.assertEqual(result, 1)
-        action.assert_not_called()
+        self.assertEqual(result, 0)
+        office.assert_not_called()
         heartbeat = __import__("json").loads(
             backend.preload_runtime_status_path().read_text()
         )
-        self.assertEqual(heartbeat["state"], "stop-refused")
+        self.assertEqual(heartbeat["state"], "stopped")
 
     def test_worker_reports_degraded_component_without_claiming_ownership(self):
         binding = self._preload_binding()

--- a/tools/wine4office-manager/tests/test_backend.py
+++ b/tools/wine4office-manager/tests/test_backend.py
@@ -698,6 +698,25 @@ touch "$WINEPREFIX/system.reg" "$WINEPREFIX/user.reg"
             ],
         )
 
+    def test_stop_wine_discovers_office_in_prefix_when_tasklist_fails(self):
+        prefix = self._make_prefix(self.home / ".wine4office")
+        with mock.patch.object(
+            backend, "_owned_office_pids",
+            side_effect=RuntimeError("tasklist unavailable"),
+        ) as detect, mock.patch.object(backend.subprocess, "run") as run:
+            backend.stop_wine(str(prefix), str(self.wine))
+
+        self.assertLessEqual(
+            detect.call_args.kwargs["timeout"], backend.STOP_DETECTION_SECONDS
+        )
+        self.assertEqual(
+            [call.args[0] for call in run.call_args_list],
+            [
+                [str(self.wine), "wine4officeclose.exe", "--discover-office"],
+                [str(self.runner / "wineserver"), "-w"],
+            ],
+        )
+
     def test_office_detection_uses_windows_pid_from_selected_tasklist(self):
         prefix = self._make_prefix(self.home / ".wine4office")
         completed = mock.Mock(

--- a/tools/wine4office-manager/tests/test_backend.py
+++ b/tools/wine4office-manager/tests/test_backend.py
@@ -2568,6 +2568,29 @@ touch "$WINEPREFIX/system.reg" "$WINEPREFIX/user.reg"
         office.assert_not_called()
         systemctl.assert_not_called()
 
+    def test_disable_refuses_selected_environment_mismatch(self):
+        binding = self._preload_binding()
+        backend._preload_json_write(backend.preload_binding_path(), binding)
+        backend._preload_atomic_write(
+            backend.preload_unit_path(), backend._PRELOAD_UNIT_MARKER + "\n", 0o644
+        )
+        different_prefix = self._make_prefix(self.home / "different prefix")
+        different_wine = str(self.home / "different runner/bin/wine")
+        with mock.patch.object(
+            backend, "_systemd_user_capability", return_value=(True, "")
+        ), mock.patch.object(
+            backend, "_systemctl_property"
+        ) as property_state, mock.patch.object(
+            backend, "_systemctl_user"
+        ) as systemctl:
+            with self.assertRaisesRegex(RuntimeError, "does not match"):
+                backend.manage_preload_service(
+                    "disable", str(different_prefix), different_wine, True
+                )
+
+        property_state.assert_not_called()
+        systemctl.assert_not_called()
+
     def test_stop_wine_tool_restarts_matching_active_background_service(self):
         prefix = self._make_prefix(self.home / "stop-and-restart")
         with mock.patch.object(

--- a/tools/wine4office-manager/tests/test_backend.py
+++ b/tools/wine4office-manager/tests/test_backend.py
@@ -2591,6 +2591,33 @@ touch "$WINEPREFIX/system.reg" "$WINEPREFIX/user.reg"
         property_state.assert_not_called()
         systemctl.assert_not_called()
 
+    def test_disable_refuses_partial_environment_selection(self):
+        binding = self._preload_binding()
+        backend._preload_json_write(backend.preload_binding_path(), binding)
+        backend._preload_atomic_write(
+            backend.preload_unit_path(), backend._PRELOAD_UNIT_MARKER + "\n", 0o644
+        )
+        selections = (
+            (binding["prefix"], None),
+            (None, binding["wine"]),
+        )
+        with mock.patch.object(
+            backend, "_systemd_user_capability", return_value=(True, "")
+        ), mock.patch.object(
+            backend, "_systemctl_property"
+        ) as property_state, mock.patch.object(
+            backend, "_systemctl_user"
+        ) as systemctl:
+            for prefix_value, wine_value in selections:
+                with self.subTest(prefix=prefix_value, wine=wine_value):
+                    with self.assertRaisesRegex(RuntimeError, "does not match"):
+                        backend.manage_preload_service(
+                            "disable", prefix_value, wine_value, True
+                        )
+
+        property_state.assert_not_called()
+        systemctl.assert_not_called()
+
     def test_stop_wine_tool_restarts_matching_active_background_service(self):
         prefix = self._make_prefix(self.home / "stop-and-restart")
         with mock.patch.object(

--- a/tools/wine4office-manager/wine4office_backend.py
+++ b/tools/wine4office-manager/wine4office_backend.py
@@ -818,68 +818,86 @@ def wine_environment(prefix: str | Path, wine: str | Path,
     return env
 
 
+def _runner_executable_matches(executable: Path, wine: PathValue) -> bool:
+    """Return whether a host process executable belongs to the selected runner."""
+    selected_wine = normalize_path(wine)
+    executable = executable.resolve()
+    runner_bin = selected_wine.parent
+    if executable.parent == runner_bin:
+        return True
+    if runner_bin.name != "bin":
+        return False
+    try:
+        relative = executable.relative_to(runner_bin.parent)
+    except ValueError:
+        return False
+    return (
+        len(relative.parts) >= 4
+        and relative.parts[:2] == ("lib", "wine")
+        and relative.name in {"wine", "wine-preloader"}
+    )
+
+
+
+
+def _office_tasklist(prefix: Path, wine: Path, use_x11: bool,
+                     timeout: float) -> list[tuple[str, int]]:
+    """Query Windows PIDs from the exact selected prefix and runner."""
+    try:
+        completed = subprocess.run(
+            [str(wine), "tasklist.exe", "/FO", "CSV", "/NH"],
+            env=wine_environment(prefix, wine, use_x11),
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as error:
+        raise RuntimeError("Wine process detection timed out.") from error
+    except OSError as error:
+        raise RuntimeError(f"Wine process detection failed: {error}") from error
+    if completed.returncode:
+        detail = (completed.stderr or completed.stdout).strip()
+        raise RuntimeError(
+            f"Wine process detection failed: {detail or completed.returncode}"
+        )
+
+    processes: list[tuple[str, int]] = []
+    try:
+        rows = csv.reader(io.StringIO(completed.stdout), strict=True)
+        for row in rows:
+            if not row:
+                continue
+            if len(row) < 2 or not row[1].strip().isdigit():
+                raise csv.Error("tasklist returned an invalid process row")
+            pid = int(row[1].strip())
+            if not pid or pid > 0xffffffff:
+                raise csv.Error("tasklist returned an invalid process id")
+            processes.append((row[0].strip(), pid))
+    except (csv.Error, ValueError) as error:
+        raise RuntimeError(f"Wine process output was invalid: {error}") from error
+    return processes
 
 
 def _owned_office_pids(prefix: PathValue, wine: PathValue,
-                       use_x11: bool = True) -> list[int]:
-    """Return Office PIDs authenticated to this prefix, runner, and display.
-
-    The close helper must never discover windows on its own.  Read-only procfs
-    identity checks bind each supplied PID to the selected Wine prefix and
-    runner, while the display variables bind it to this manager session.
-    """
-    selected_prefix = normalize_path(prefix)
-    runner_dir = Path(wine).resolve().parent
-    selected_environment = wine_environment(selected_prefix, wine, use_x11)
-    expected_prefix = os.fsencode(str(selected_prefix))
-    expected_arch = os.fsencode(selected_environment["WINEARCH"])
-    office_names = (
-        b"excel.exe", b"msaccess.exe", b"mspub.exe", b"onenote.exe",
-        b"outlook.exe", b"powerpnt.exe", b"visio.exe", b"winproj.exe",
-        b"winword.exe",
-    )
-    display_names = ("DISPLAY", "WAYLAND_DISPLAY")
-    pids: list[int] = []
-
-    try:
-        entries = list(Path("/proc").iterdir())
-    except OSError:
-        return pids
-    for entry in entries:
-        if not entry.name.isdigit():
-            continue
-        try:
-            if entry.stat().st_uid != os.getuid():
-                continue
-            environment = {}
-            for item in (entry / "environ").read_bytes().split(b"\0"):
-                if b"=" in item:
-                    key, value = item.split(b"=", 1)
-                    environment[key] = value
-            if (environment.get(b"WINEPREFIX") != expected_prefix
-                    or environment.get(b"WINEARCH") != expected_arch):
-                continue
-            for name in display_names:
-                expected = selected_environment.get(name)
-                if (expected is not None
-                        and environment.get(name.encode()) != os.fsencode(expected)):
-                    break
-            else:
-                executable = Path(os.readlink(entry / "exe")).resolve()
-                if executable.parent != runner_dir:
-                    continue
-                command_line = (entry / "cmdline").read_bytes().lower().replace(b"\0", b" ")
-                if any(re.search(rb"(?:^|[\\/\s\"'])" + re.escape(name)
-                                + rb"(?:$|[\s\"'])", command_line)
-                           for name in office_names):
-                    pids.append(int(entry.name))
-        except (OSError, RuntimeError, UnicodeError, ValueError):
-            continue
-    return sorted(set(pids))
+                       use_x11: bool = True,
+                       timeout: float = STOP_GRACE_SECONDS) -> list[int]:
+    """Return Windows Office PIDs from the exact selected Wine environment."""
+    selected_prefix = validate_prefix(prefix)
+    selected_wine = require_wine(str(wine))
+    office_names = {name.casefold() for name in OFFICE_X11_EXECUTABLES}
+    return sorted({
+        pid for image, pid in _office_tasklist(
+            selected_prefix, selected_wine, use_x11, timeout
+        )
+        if image.casefold() in office_names
+    })
 
 
 def _wine_process_identity(
-    process: Path, prefix: Path, runner_dir: Path
+    process: Path, prefix: Path, wine: PathValue
 ) -> tuple[int, str] | None:
     """Return a stable identity only for a current-user process in this Wine environment."""
     try:
@@ -892,7 +910,7 @@ def _wine_process_identity(
         if environment.get(b"WINEPREFIX") != os.fsencode(str(prefix)):
             return None
         executable = Path(os.readlink(process / "exe")).resolve()
-        if executable.parent != runner_dir:
+        if not _runner_executable_matches(executable, wine):
             return None
         stat_text = process.joinpath("stat").read_text(encoding="ascii")
         closing_paren = stat_text.rfind(")")
@@ -906,7 +924,6 @@ def _owned_wine_processes(prefix: PathValue, wine: PathValue,
                           proc_root: Path = Path("/proc")) -> list[tuple[int, str]]:
     """Snapshot processes authenticated to the selected prefix and runner."""
     selected_prefix = normalize_path(prefix)
-    runner_dir = Path(wine).resolve().parent
     try:
         processes = tuple(proc_root.iterdir())
     except OSError:
@@ -914,7 +931,7 @@ def _owned_wine_processes(prefix: PathValue, wine: PathValue,
     return sorted(
         identity for process in processes
         if process.name.isdigit()
-        if (identity := _wine_process_identity(process, selected_prefix, runner_dir)) is not None
+        if (identity := _wine_process_identity(process, selected_prefix, wine)) is not None
     )
 
 
@@ -922,9 +939,8 @@ def _kill_owned_wine_processes(prefix: PathValue, wine: PathValue,
                                proc_root: Path = Path("/proc")) -> None:
     """SIGKILL only processes whose PID and start time still match an owned snapshot."""
     selected_prefix = normalize_path(prefix)
-    runner_dir = Path(wine).resolve().parent
     for pid, starttime in _owned_wine_processes(selected_prefix, wine, proc_root):
-        current = _wine_process_identity(proc_root / str(pid), selected_prefix, runner_dir)
+        current = _wine_process_identity(proc_root / str(pid), selected_prefix, wine)
         if current != (pid, starttime):
             continue
         try:
@@ -1185,19 +1201,27 @@ def stop_wine(prefix_value: str, wine_value: str, use_x11: bool = True,
         else time.monotonic() + STOP_GRACE_SECONDS
     )
     graceful_close = False
+    try:
+        office_pids = _owned_office_pids(
+            prefix, wine, use_x11,
+            timeout=max(0.001, deadline - time.monotonic()),
+        )
+    except RuntimeError:
+        office_pids = []
     close_command = [str(wine), "wine4officeclose.exe"]
-    for pid in _owned_office_pids(prefix, wine, use_x11):
+    for pid in office_pids:
         close_command.extend(("--pid", str(pid)))
     try:
-        subprocess.run(
-            close_command,
-            env=env,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            timeout=max(0.001, deadline - time.monotonic()),
-            check=True,
-        )
-        graceful_close = True
+        if office_pids:
+            subprocess.run(
+                close_command,
+                env=env,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=max(0.001, deadline - time.monotonic()),
+                check=True,
+            )
+            graceful_close = True
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
         # Continue with wineserver termination when a window cannot close cleanly.
         pass
@@ -4605,48 +4629,19 @@ def preload_office_processes(prefix_value: str, wine_value: str,
                              use_x11: bool = True) -> list[str]:
     prefix = validate_prefix(prefix_value)
     wine = require_wine(wine_value)
-    try:
-        completed = subprocess.run(
-            [str(wine), "tasklist.exe", "/FO", "CSV", "/NH"],
-            env=wine_environment(prefix, wine, use_x11),
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            timeout=_PRELOAD_WINE_TIMEOUT,
-            check=False,
-        )
-    except subprocess.TimeoutExpired as error:
-        raise RuntimeError("Wine process detection timed out; refusing to stop preload.") from error
-    except OSError as error:
-        raise RuntimeError(f"Wine process detection failed; refusing to stop preload: {error}") from error
-    if completed.returncode:
-        detail = (completed.stderr or completed.stdout).strip()
-        raise RuntimeError(
-            f"Wine process detection failed; refusing to stop preload: {detail or completed.returncode}"
-        )
     office_names = {
         metadata["exe"].casefold()
         for metadata in APP_META.values()
         if metadata.get("preload_process", True)
     }
     found: list[str] = []
-    try:
-        rows = csv.reader(io.StringIO(completed.stdout), strict=True)
-        for row in rows:
-            if not row:
-                continue
-            if len(row) < 2:
-                raise csv.Error("tasklist returned a non-CSV status line")
-            image = row[0].strip()
-            if image.casefold() in office_names and image.casefold() not in {
-                value.casefold() for value in found
-            }:
-                found.append(image)
-    except csv.Error as error:
-        raise RuntimeError(
-            f"Wine process output was invalid; refusing to stop preload: {error}"
-        ) from error
+    for image, _pid in _office_tasklist(
+        prefix, wine, use_x11, _PRELOAD_WINE_TIMEOUT
+    ):
+        if image.casefold() in office_names and image.casefold() not in {
+            value.casefold() for value in found
+        }:
+            found.append(image)
     return found
 
 
@@ -4681,18 +4676,12 @@ def manage_preload_service(action: str, prefix_value: str | None = None,
         raise RuntimeError(
             "The selected Wine environment does not match the fixed preload binding."
         )
-    if action == "stop":
-        if not _preload_selected_matches(binding, prefix_value, wine_value, use_x11):
-            raise RuntimeError(
-                "The selected Wine environment does not match the fixed preload binding."
-            )
-        active_office = preload_office_processes(
-            binding["prefix"], binding["wine"], binding["use_x11"]
+    if action == "stop" and not _preload_selected_matches(
+        binding, prefix_value, wine_value, use_x11
+    ):
+        raise RuntimeError(
+            "The selected Wine environment does not match the fixed preload binding."
         )
-        if active_office:
-            raise RuntimeError(
-                "Office is active; refusing to stop preload: " + ", ".join(active_office)
-            )
     if action == "stop":
         _stop_preload_unit_and_wait(binding=binding)
     else:
@@ -5278,23 +5267,6 @@ def run_preload_worker(snapshot_path: PathValue, status_path: PathValue) -> int:
                 cleanup_failed.append(PRELOAD_APPV_COMPONENT)
             _write_preload_heartbeat(status, components, "stopping")
 
-        try:
-            active_office = preload_office_processes(
-                binding["prefix"], binding["wine"], binding["use_x11"]
-            )
-        except RuntimeError as error:
-            _write_preload_heartbeat(
-                status, components, "stop-refused",
-                f"Process state unknown; owned services were preserved: {error}",
-            )
-            return 1
-        if active_office:
-            _write_preload_heartbeat(
-                status, components, "stop-refused",
-                "Office became active; owned components were preserved: "
-                + ", ".join(active_office),
-            )
-            return 1
         for component in reversed(PRELOAD_COMPONENTS):
             record = components[component]
             if not record["owned"]:

--- a/tools/wine4office-manager/wine4office_backend.py
+++ b/tools/wine4office-manager/wine4office_backend.py
@@ -4670,12 +4670,6 @@ def manage_preload_service(action: str, prefix_value: str | None = None,
         raise RuntimeError(
             "Refusing to control an unowned user service unit: " + str(unit_path)
         )
-    if action == "disable":
-        enabled, _ = _systemctl_property("is-enabled")
-        if enabled:
-            _systemctl_user(["disable", PRELOAD_UNIT])
-        return preload_service_status(prefix_value, wine_value, use_x11)
-
     binding = _read_preload_binding()
     if not _preload_selected_matches(
         binding, prefix_value, wine_value, use_x11
@@ -4683,6 +4677,11 @@ def manage_preload_service(action: str, prefix_value: str | None = None,
         raise RuntimeError(
             "The selected Wine environment does not match the fixed preload binding."
         )
+    if action == "disable":
+        enabled, _ = _systemctl_property("is-enabled")
+        if enabled:
+            _systemctl_user(["disable", PRELOAD_UNIT])
+        return preload_service_status(prefix_value, wine_value, use_x11)
     if action == "stop":
         _stop_preload_unit_and_wait(binding=binding)
     else:

--- a/tools/wine4office-manager/wine4office_backend.py
+++ b/tools/wine4office-manager/wine4office_backend.py
@@ -4101,8 +4101,10 @@ def systemd_user_available() -> bool:
 def _preload_selected_matches(binding: dict, prefix_value: str | None,
                               wine_value: str | None, _use_x11: bool | None) -> bool:
     """Match the Wine environment; display mode is a foreground-app choice."""
-    if prefix_value is None or wine_value is None:
+    if prefix_value is None and wine_value is None:
         return True
+    if prefix_value is None or wine_value is None:
+        return False
     try:
         prefix = validate_prefix(prefix_value)
         wine = normalize_path(wine_value)

--- a/tools/wine4office-manager/wine4office_backend.py
+++ b/tools/wine4office-manager/wine4office_backend.py
@@ -45,6 +45,7 @@ OFFICE_X11_EXECUTABLES = (
     "ONENOTE.EXE", "MSACCESS.EXE", "MSPUB.EXE", "VISIO.EXE", "WINPROJ.EXE",
 )
 STOP_GRACE_SECONDS = 10.0
+STOP_DETECTION_SECONDS = 4.0
 OFFICE_COMPATIBILITY_POLICIES = {
     "disable_animations": {
         "label": "Disable Office animations",
@@ -1201,18 +1202,25 @@ def stop_wine(prefix_value: str, wine_value: str, use_x11: bool = True,
         else time.monotonic() + STOP_GRACE_SECONDS
     )
     graceful_close = False
+    detection_failed = False
     try:
         office_pids = _owned_office_pids(
             prefix, wine, use_x11,
-            timeout=max(0.001, deadline - time.monotonic()),
+            timeout=max(
+                0.001,
+                min(STOP_DETECTION_SECONDS, deadline - time.monotonic()),
+            ),
         )
     except RuntimeError:
         office_pids = []
+        detection_failed = True
     close_command = [str(wine), "wine4officeclose.exe"]
     for pid in office_pids:
         close_command.extend(("--pid", str(pid)))
+    if detection_failed:
+        close_command.append("--discover-office")
     try:
-        if office_pids:
+        if office_pids or detection_failed:
             subprocess.run(
                 close_command,
                 env=env,
@@ -4669,14 +4677,7 @@ def manage_preload_service(action: str, prefix_value: str | None = None,
         return preload_service_status(prefix_value, wine_value, use_x11)
 
     binding = _read_preload_binding()
-    if (
-        action == "start"
-        and not _preload_selected_matches(binding, prefix_value, wine_value, use_x11)
-    ):
-        raise RuntimeError(
-            "The selected Wine environment does not match the fixed preload binding."
-        )
-    if action == "stop" and not _preload_selected_matches(
+    if not _preload_selected_matches(
         binding, prefix_value, wine_value, use_x11
     ):
         raise RuntimeError(


### PR DESCRIPTION
## Summary

- Resolve Office processes to Windows PIDs from `tasklist` in the selected Wine environment.
- Gracefully close Office within one shared ten-second deadline, then force-stop only exact remaining process identities, including the matching Wine preloader.
- Let service shutdown proceed while Office is active without affecting unrelated Wine environments.

## Testing

- `uvx --from pytest pytest -q tools/wine4office-manager/tests/test_backend.py`: 147 passed, 33 subtests passed.
- `wine4officeclose` regression: 20/20 passed on i386 and 20/20 passed on x86_64 in isolated KDE/Wayland prefixes.
- Runtime isolation: selected environment went from 11 matching processes to 0; an unrelated environment remained at 10.
- Unsaved Word shutdown completed in 6.08 seconds.
