### PR TITLE
manager: complete uninstall with visible progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Prevent the first Word Design-tab load from stalling on queued Direct2D work.
 - Stop only the selected Wine environment, with a graceful ten-second deadline.
+- Fully remove Manager files after installs and updates, with visible removal progress.
 
 ## 0.2.0-alpha.2 — 2026-08-18
 

--- a/install.sh
+++ b/install.sh
@@ -247,6 +247,7 @@ set -euo pipefail
 SELF=$(readlink -f "$0")
 ROOT=$(CDPATH= cd -- "$(dirname -- "$SELF")/.." && pwd)
 CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
+DATA_HOME=${XDG_DATA_HOME:-$HOME/.local/share}
 BIN_HOME=${WINE4OFFICE_BIN_HOME:-$HOME/.local/bin}
 MANAGER=$ROOT/bin/Wine4OfficeManager
 PURGE_RUNNER=false
@@ -278,9 +279,13 @@ cleanup_args=(--prepare-uninstall)
 if [[ -n $REMOVE_PREFIX ]]; then cleanup_args+=(--remove-prefix "$REMOVE_PREFIX"); fi
 "$MANAGER" "${cleanup_args[@]}"
 
-for link in "$BIN_HOME/Wine4OfficeManager" "$BIN_HOME/wine4office-manager"; do
-    if [[ -L $link && $(readlink -f "$link") == "$MANAGER" ]]; then rm -f -- "$link"; fi
+for link in "$BIN_HOME/Wine4OfficeManager" "$BIN_HOME/wine4office-manager" \
+        "$BIN_HOME/wine4office-launcher"; do
+    if [[ -L $link && $(readlink "$link") == "$ROOT"/bin/* ]]; then rm -f -- "$link"; fi
 done
+rm -rf -- "$ROOT/lib" "$ROOT/icons"
+rm -f -- "$ROOT/bin/wine4office-manager" "$ROOT/bin/wine4office-launcher" \
+    "$ROOT/bin/wine4office-preload-worker"
 if $PURGE_RUNNER; then
     rm -rf -- "$ROOT/runner"
     rm -f -- "$ROOT/VERSION" "$ROOT/WINE_VERSION" "$ROOT/UPDATE_URL" \
@@ -289,6 +294,7 @@ if $PURGE_RUNNER; then
     rm -rf -- "$CONFIG_HOME/wine4office"
 fi
 rm -f -- "$MANAGER" "$MANAGER.version" "$SELF"
+rmdir -- "$DATA_HOME/icons/wine4office" 2>/dev/null || true
 rmdir -- "$ROOT/bin" "$ROOT" 2>/dev/null || true
 
 if $PURGE_RUNNER; then

--- a/tools/wine4office-manager/tests/test_backend.py
+++ b/tools/wine4office-manager/tests/test_backend.py
@@ -1659,6 +1659,29 @@ touch "$WINEPREFIX/system.reg" "$WINEPREFIX/user.reg"
             [str(uninstaller), "--purge-runner", "--remove-prefix", str(ordinary.resolve())],
         )
 
+    def test_uninstaller_reports_progress_around_verified_removal(self):
+        root = self.home / "installed"
+        uninstaller = root / "bin/wine4office-uninstall"
+        uninstaller.parent.mkdir(parents=True)
+        uninstaller.write_text("#!/bin/sh\n")
+        uninstaller.chmod(uninstaller.stat().st_mode | stat.S_IXUSR)
+        progress = []
+
+        with mock.patch.object(backend, "installed_root", return_value=root), \
+             mock.patch.object(backend, "_stream_command") as stream:
+            result = backend.remove_wine4office(
+                str(self.home / "preserved-prefix"), False, lambda line: None,
+                progress=lambda label, value: progress.append((label, value)),
+            )
+
+        stream.assert_called_once()
+        self.assertEqual(result, "Wine4Office removed.")
+        self.assertEqual(progress, [
+            ("Preparing Wine4Office removal", 0),
+            ("Removing Wine4Office files and shortcuts", None),
+            ("Wine4Office removed", 100),
+        ])
+
     def test_initialization_cancellation_removes_only_the_new_target(self):
         prefix = self.home / "cancelled-prefix"
         cancel = mock.Mock()

--- a/tools/wine4office-manager/tests/test_curl_install.sh
+++ b/tools/wine4office-manager/tests/test_curl_install.sh
@@ -39,7 +39,10 @@ fi
 
 write_metadata() {
     manager_digest=$1
-    RELEASE="$RELEASE" MANAGER_DIGEST="$manager_digest" python3 - <<'PY'
+    manager_version=${2:-0.1.0}
+    wine_version=${3:-0.1.0}
+    RELEASE="$RELEASE" MANAGER_DIGEST="$manager_digest" \
+        MANAGER_VERSION="$manager_version" WINE_VERSION="$wine_version" python3 - <<'PY'
 import hashlib
 import json
 import os
@@ -52,13 +55,13 @@ payload = {
     "channel": "stable",
     "metadata_url": "https://example.invalid/release.json",
     "manager": {
-        "version": "0.1.0",
+        "version": os.environ["MANAGER_VERSION"],
         "url": "Wine4OfficeManager",
         "sha256": os.environ["MANAGER_DIGEST"],
         "size": manager.stat().st_size,
     },
     "wine": {
-        "version": "0.1.0",
+        "version": os.environ["WINE_VERSION"],
         "url": "wine.tar.zst",
         "sha256": hashlib.sha256(wine.read_bytes()).hexdigest(),
         "size": wine.stat().st_size,
@@ -136,6 +139,18 @@ PATH="$FAKE_BIN:$PATH" "$HERE/install.sh" >/dev/null &
 SECOND_INSTALL=$!
 wait "$FIRST_INSTALL"
 wait "$SECOND_INSTALL"
+
+printf '# updated manager\n' >> "$RELEASE/Wine4OfficeManager"
+printf 'runner payload v2\n' > "$RELEASE/runner/identity"
+tar -C "$RELEASE" -cf - runner | zstd -q -f -o "$RELEASE/wine.tar.zst"
+MANAGER_DIGEST=$(sha256sum "$RELEASE/Wine4OfficeManager")
+MANAGER_DIGEST=${MANAGER_DIGEST%% *}
+write_metadata "$MANAGER_DIGEST" 0.2.0 0.2.0
+PATH="$FAKE_BIN:$PATH" "$HERE/install.sh" >/dev/null
+[[ $(cat "$WINE4OFFICE_HOME/VERSION") == 0.2.0 ]]
+[[ $(cat "$WINE4OFFICE_HOME/WINE_VERSION") == 0.2.0 ]]
+[[ $(cat "$WINE4OFFICE_HOME/runner/identity") == "runner payload v2" ]]
+
 BEFORE_MANAGER=$(sha256sum "$WINE4OFFICE_HOME/bin/Wine4OfficeManager")
 BEFORE_RUNNER=$(sha256sum "$WINE4OFFICE_HOME/runner/identity")
 
@@ -178,8 +193,17 @@ fi
 [[ $(sha256sum "$WINE4OFFICE_HOME/bin/Wine4OfficeManager") == "$BEFORE_MANAGER" ]]
 [[ $(sha256sum "$WINE4OFFICE_HOME/runner/identity") == "$BEFORE_RUNNER" ]]
 
+mkdir -p "$WINE4OFFICE_HOME/lib" "$WINE4OFFICE_HOME/icons"
+printf 'legacy\n' > "$WINE4OFFICE_HOME/lib/legacy-manager"
+printf 'legacy\n' > "$WINE4OFFICE_HOME/icons/legacy-icon"
+printf 'legacy\n' > "$WINE4OFFICE_HOME/bin/wine4office-preload-worker"
+ln -sfn "$WINE4OFFICE_HOME/bin/wine4office-preload-worker" \
+    "$WINE4OFFICE_BIN_HOME/wine4office-launcher"
 PATH="$FAKE_BIN:$PATH" "$WINE4OFFICE_HOME/bin/wine4office-uninstall" --purge-runner >/dev/null
 [[ ! -e $WINE4OFFICE_HOME ]]
-[[ ! -e $WINE4OFFICE_BIN_HOME/Wine4OfficeManager ]]
+[[ ! -e $WINE4OFFICE_BIN_HOME/Wine4OfficeManager &&
+   ! -L $WINE4OFFICE_BIN_HOME/Wine4OfficeManager ]]
+[[ ! -e $WINE4OFFICE_BIN_HOME/wine4office-launcher &&
+   ! -L $WINE4OFFICE_BIN_HOME/wine4office-launcher ]]
 
 echo "curl installer verified install, uninstall, locking, rollback, and archive safety: PASS"

--- a/tools/wine4office-manager/tests/test_qt.py
+++ b/tools/wine4office-manager/tests/test_qt.py
@@ -583,11 +583,11 @@ class QtManagerTests(unittest.TestCase):
         cancel.assert_not_called()
         self.assertTrue(self.window._close_when_idle)
 
-        allow_removal.set()
-        self._wait_task()
         with mock.patch.object(
             qt_module.QTimer, "singleShot"
         ) as single_shot:
+            allow_removal.set()
+            self._wait_task()
             self.window.refresh_state()
 
         callbacks = [call.args[1] for call in single_shot.call_args_list]

--- a/tools/wine4office-manager/tests/test_qt.py
+++ b/tools/wine4office-manager/tests/test_qt.py
@@ -504,6 +504,30 @@ class QtManagerTests(unittest.TestCase):
         close.assert_called_once()
         self.assertTrue(self.window._automatic_close)
 
+    def test_removal_shows_noncancellable_progress_and_wires_progress_updates(self):
+        with mock.patch.object(
+            self.window, "save_config", return_value=dict(self.config)
+        ), mock.patch.object(
+            qt_module.QMessageBox, "warning",
+            return_value=QMessageBox.StandardButton.Yes,
+        ), mock.patch.object(
+            self.state, "start_task"
+        ) as start_task, mock.patch.object(
+            backend, "remove_wine4office", return_value="removed"
+        ) as remove:
+            self.window.remove_wine4office()
+            operation = start_task.call_args.args[1]
+            operation()
+
+        self.assertEqual(start_task.call_args.args[0], "remove")
+        remove.assert_called_once_with(
+            self.config["prefix"], False, self.state.output,
+            progress=self.state.set_progress,
+        )
+        self.assertEqual(self.window.update_progress_task_kind, "remove")
+        self.assertEqual(self.window.update_progress_button.text(), "Please wait")
+        self.assertFalse(self.window.update_progress_button.isEnabled())
+
     def test_failed_removal_keeps_manager_open_without_success_confirmation(self):
         snapshot = self._preload_snapshot(task={
             "running": False,

--- a/tools/wine4office-manager/tests/test_qt.py
+++ b/tools/wine4office-manager/tests/test_qt.py
@@ -16,6 +16,7 @@ sys.path.insert(0, str(MANAGER_DIR))
 try:
     from PySide6.QtCore import Qt
     from PySide6.QtGui import QBrush, QCloseEvent
+    from PySide6.QtTest import QTest
     from PySide6.QtWidgets import (
         QApplication,
         QCheckBox,
@@ -527,6 +528,12 @@ class QtManagerTests(unittest.TestCase):
         self.assertEqual(self.window.update_progress_task_kind, "remove")
         self.assertEqual(self.window.update_progress_button.text(), "Please wait")
         self.assertFalse(self.window.update_progress_button.isEnabled())
+        dialog = self.window.update_progress_dialog
+        self.application.processEvents()
+        self.assertTrue(dialog.isVisible())
+        QTest.keyClick(dialog, Qt.Key.Key_Escape)
+        self.application.processEvents()
+        self.assertTrue(dialog.isVisible())
 
     def test_failed_removal_keeps_manager_open_without_success_confirmation(self):
         snapshot = self._preload_snapshot(task={

--- a/tools/wine4office-manager/tests/test_qt.py
+++ b/tools/wine4office-manager/tests/test_qt.py
@@ -534,6 +534,9 @@ class QtManagerTests(unittest.TestCase):
         QTest.keyClick(dialog, Qt.Key.Key_Escape)
         self.application.processEvents()
         self.assertTrue(dialog.isVisible())
+        dialog.close()
+        self.application.processEvents()
+        self.assertTrue(dialog.isVisible())
 
     def test_failed_removal_keeps_manager_open_without_success_confirmation(self):
         snapshot = self._preload_snapshot(task={
@@ -555,6 +558,55 @@ class QtManagerTests(unittest.TestCase):
         information.assert_not_called()
         close.assert_not_called()
         self.assertFalse(self.window._automatic_close)
+        self.assertEqual(
+            self.window.statusBar().currentMessage(),
+            "Wine4Office removal failed; see the log.",
+        )
+
+    def test_close_during_removal_waits_without_cancelling(self):
+        removal_started = threading.Event()
+        allow_removal = threading.Event()
+
+        def remove():
+            removal_started.set()
+            allow_removal.wait(1)
+            return "removed"
+
+        self.state.start_task("remove", remove)
+        self.assertTrue(removal_started.wait(1))
+        self.window.last_task_state = "True:running"
+        close_event = QCloseEvent()
+        with mock.patch.object(self.state, "cancel") as cancel:
+            self.window.closeEvent(close_event)
+
+        self.assertFalse(close_event.isAccepted())
+        cancel.assert_not_called()
+        self.assertTrue(self.window._close_when_idle)
+
+        allow_removal.set()
+        self._wait_task()
+        with mock.patch.object(
+            qt_module.QTimer, "singleShot"
+        ) as single_shot:
+            self.window.refresh_state()
+
+        callbacks = [call.args[1] for call in single_shot.call_args_list]
+        self.assertIn(self.window.finish_successful_removal, callbacks)
+
+    def test_interrupted_removal_does_not_claim_settings_were_restored(self):
+        snapshot = self._preload_snapshot(task={
+            "running": False,
+            "kind": "remove",
+            "status": "cancelled",
+        })
+        self.window.last_task_state = "True:running"
+        with mock.patch.object(self.state, "snapshot", return_value=snapshot):
+            self.window.refresh_state()
+
+        self.assertEqual(
+            self.window.statusBar().currentMessage(),
+            "Wine4Office removal was interrupted.",
+        )
 
 
 

--- a/tools/wine4office-manager/tests/test_uninstaller.py
+++ b/tools/wine4office-manager/tests/test_uninstaller.py
@@ -205,6 +205,41 @@ def remove_app_shortcuts(_apps):
         self.assertTrue(unit.exists())
         self.assertTrue((self.root / "bin/wine4office-manager").exists())
 
+    def test_purge_removes_complete_updated_source_layout_from_custom_home(self):
+        self._backend("""
+APP_META = {}
+def uninstall_preload_service():
+    pass
+def uninstall_automatic_update_schedule():
+    pass
+def remove_app_shortcuts(_apps):
+    pass
+""")
+        (self.root / "bin/wine4office-preload-worker").write_text("worker")
+        (self.root / "icons").mkdir()
+        (self.root / "runner").mkdir()
+        for name in (
+                "VERSION", "WINE_VERSION", "UPDATE_URL", "UPDATE_CHANNEL",
+                "install.json", ".wine4office-update.lock"):
+            (self.root / name).write_text("updated")
+        bin_home = Path(self.env["WINE4OFFICE_BIN_HOME"])
+        bin_home.mkdir(parents=True)
+        manager_link = bin_home / "wine4office-manager"
+        worker_link = bin_home / "wine4office-launcher"
+        manager_link.symlink_to(self.root / "bin/wine4office-manager")
+        worker_link.symlink_to(self.root / "bin/wine4office-preload-worker")
+
+        result = subprocess.run(
+            [str(UNINSTALLER), "--purge-runner"], env=self.env,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertFalse(self.root.exists())
+        self.assertFalse(manager_link.exists() or manager_link.is_symlink())
+        self.assertFalse(worker_link.exists() or worker_link.is_symlink())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/wine4office-manager/uninstall-user.sh
+++ b/tools/wine4office-manager/uninstall-user.sh
@@ -74,18 +74,24 @@ for file in "$DATA_HOME/applications/wine4office-manager.desktop" "${XDG_DESKTOP
     if [[ -f "$file" ]] && grep -q '^X-Wine4Office-Managed=true$' "$file"; then rm -f "$file"; fi
 done
 rm -f "$DATA_HOME/icons/wine4office"/wine4office-manager*.png
-for link in "$BIN_HOME/wine4office-manager" "$BIN_HOME/wine4office-launcher"; do
+for link in "$BIN_HOME/Wine4OfficeManager" "$BIN_HOME/wine4office-manager" \
+        "$BIN_HOME/wine4office-launcher"; do
     if [[ -L "$link" ]] && [[ $(readlink "$link") == "$ROOT"/bin/* ]]; then rm -f "$link"; fi
 done
 
 rm -rf "$ROOT/lib" "$ROOT/icons"
-rm -f "$ROOT/bin/wine4office-manager" "$ROOT/bin/wine4office-launcher"
+rm -f "$ROOT/bin/Wine4OfficeManager" "$ROOT/bin/Wine4OfficeManager.version" \
+    "$ROOT/bin/wine4office-manager" "$ROOT/bin/wine4office-launcher" \
+    "$ROOT/bin/wine4office-preload-worker"
 if $PURGE_RUNNER; then
     rm -rf "$ROOT/runner"
-    rm -f "$ROOT/VERSION" "$ROOT/UPDATE_URL" "$ROOT/UPDATE_CHANNEL" "$ROOT/install.json"
+    rm -f "$ROOT/VERSION" "$ROOT/WINE_VERSION" "$ROOT/UPDATE_URL" \
+        "$ROOT/UPDATE_CHANNEL" "$ROOT/STANDALONE" "$ROOT/install.json" \
+        "$ROOT/.wine4office-update.lock"
     rm -rf "$CONFIG_HOME/wine4office"
 fi
 rm -f "$ROOT/bin/wine4office-uninstall"
+rmdir "$DATA_HOME/icons/wine4office" 2>/dev/null || true
 rmdir "$ROOT/bin" "$ROOT" 2>/dev/null || true
 
 if $PURGE_RUNNER; then

--- a/tools/wine4office-manager/wine4office_backend.py
+++ b/tools/wine4office-manager/wine4office_backend.py
@@ -3905,7 +3905,10 @@ def install_release_updates(metadata: dict, components: Iterable[str], output: O
     return "Selected updates installed." + suffix
 
 
-def remove_wine4office(prefix_value: str, remove_prefix: bool, output: Output) -> str:
+def remove_wine4office(prefix_value: str, remove_prefix: bool, output: Output,
+                       progress: Callable[[str, int | None], None] | None = None) -> str:
+    if progress:
+        progress("Preparing Wine4Office removal", 0)
     root = installed_root()
     if root is None:
         raise RuntimeError("Removal is available only from an installed Wine4Office Manager.")
@@ -3918,8 +3921,12 @@ def remove_wine4office(prefix_value: str, remove_prefix: bool, output: Output) -
         if classify_prefix(str(prefix)) != "valid":
             raise ValueError(f"Refusing to remove a path that is not a Wine prefix: {prefix}")
         command.extend(["--remove-prefix", str(prefix)])
+    if progress:
+        progress("Removing Wine4Office files and shortcuts", None)
     _stream_command(command, os.environ.copy(), output)
-    return "Wine4Office removed. You may close this browser tab."
+    if progress:
+        progress("Wine4Office removed", 100)
+    return "Wine4Office removed."
 
 
 PRELOAD_UNIT = "wine4office-preload.service"

--- a/tools/wine4office-manager/wine4office_qt.py
+++ b/tools/wine4office-manager/wine4office_qt.py
@@ -2219,8 +2219,8 @@ class ManagerWindow(QMainWindow):
         )
 
     def _show_task_progress(self, task_kind: str, title: str, heading_text: str,
-                            preparing_text: str,
-                            messages: dict[str, str]) -> None:
+                            preparing_text: str, messages: dict[str, str],
+                            *, cancellable: bool = True) -> None:
         if self.update_progress_dialog is not None:
             self.update_progress_dialog.close()
         dialog = QDialog(self)
@@ -2246,8 +2246,13 @@ class ManagerWindow(QMainWindow):
         layout.addWidget(details)
         buttons = QHBoxLayout()
         buttons.addStretch()
-        cancel = QPushButton("Cancel update" if task_kind == "update" else "Cancel")
-        cancel.clicked.connect(self.cancel_task)
+        cancel = QPushButton(
+            "Cancel update" if task_kind == "update" else
+            "Cancel" if cancellable else "Please wait"
+        )
+        cancel.setEnabled(cancellable)
+        if cancellable:
+            cancel.clicked.connect(self.cancel_task)
         buttons.addWidget(cancel)
         layout.addLayout(buttons)
         self.update_progress_dialog = dialog
@@ -2316,6 +2321,7 @@ class ManagerWindow(QMainWindow):
             except RuntimeError:
                 pass
             self.update_progress_button.setText("Close")
+            self.update_progress_button.setEnabled(True)
             self.update_progress_button.clicked.connect(dialog.accept)
         if task.get("kind") == "update" and task.get("restart_required"):
             QTimer.singleShot(500, dialog.accept)
@@ -2350,6 +2356,8 @@ class ManagerWindow(QMainWindow):
             self.show_error(f"Could not restart Wine4Office Manager: {error}")
 
     def finish_successful_removal(self) -> None:
+        if self.update_progress_dialog is not None:
+            self.update_progress_dialog.accept()
         QMessageBox.information(
             self,
             "Wine4Office Uninstalled",
@@ -2374,7 +2382,23 @@ class ManagerWindow(QMainWindow):
         try:
             self.state.start_task(
                 "remove",
-                lambda: backend.remove_wine4office(config["prefix"], remove_prefix, self.state.output),
+                lambda: backend.remove_wine4office(
+                    config["prefix"], remove_prefix, self.state.output,
+                    progress=self.state.set_progress,
+                ),
+            )
+            self.last_task_state = "True:running"
+            self._show_task_progress(
+                "remove",
+                "Removing Wine4Office",
+                "Wine4Office Manager and runner",
+                "Preparing Wine4Office removal…",
+                {
+                    "completed": "Wine4Office removal completed.",
+                    "cancelled": "Wine4Office removal was interrupted.",
+                    "failed": "Wine4Office removal failed. Review the details below.",
+                },
+                cancellable=False,
             )
             self.notify("Removal started.")
             self.refresh_state()
@@ -2489,7 +2513,9 @@ class ManagerWindow(QMainWindow):
         self.task_label.setText(task_text)
         for button in self.task_sensitive_buttons:
             button.setDisabled(task["running"])
-        self.cancel_button.setEnabled(task["running"])
+        self.cancel_button.setEnabled(
+            task["running"] and task.get("kind") != "remove"
+        )
         self._update_preload_status(snapshot)
         if (self.pending_environment_transition
                 and task["kind"] == "environment-switch" and not task["running"]):
@@ -2539,12 +2565,18 @@ class ManagerWindow(QMainWindow):
     def closeEvent(self, event: QCloseEvent) -> None:
         with self.state.lock:
             running = bool(self.state.task["running"])
+            task_kind = str(self.state.task.get("kind") or "")
         if running:
             self._close_when_idle = True
             self._automatic_close = False
-            self.state.cancel()
+            if task_kind != "remove":
+                self.state.cancel()
             self.timer.start(100)
-            self.notify("Cancellation requested; closing after the operation rolls back.")
+            self.notify(
+                "Removal is finishing; the Manager will close when it completes."
+                if task_kind == "remove" else
+                "Cancellation requested; closing after the operation rolls back."
+            )
             event.ignore()
             return
         self.timer.stop()

--- a/tools/wine4office-manager/wine4office_qt.py
+++ b/tools/wine4office-manager/wine4office_qt.py
@@ -122,6 +122,12 @@ class _OperationProgressDialog(QDialog):
         if self.cancellable:
             super().reject()
 
+    def closeEvent(self, event: QCloseEvent) -> None:
+        if self.cancellable:
+            super().closeEvent(event)
+        else:
+            event.ignore()
+
 
 
 class ManagerWindow(QMainWindow):
@@ -2546,9 +2552,17 @@ class ManagerWindow(QMainWindow):
                     self.timer.stop()
                     QTimer.singleShot(0, self.finish_successful_removal)
             elif task["status"] == "cancelled":
-                self.notify("Operation cancelled; settings restored.")
+                self.notify(
+                    "Wine4Office removal was interrupted."
+                    if task.get("kind") == "remove" else
+                    "Operation cancelled; settings restored."
+                )
             else:
-                self.notify("Operation failed; settings restored. See the log.")
+                self.notify(
+                    "Wine4Office removal failed; see the log."
+                    if task.get("kind") == "remove" else
+                    "Operation failed; settings restored. See the log."
+                )
                 task_kind = str(task.get("kind") or "")
                 if "preload" in task_kind:
                     failure = (str(task.get("log") or "").strip()

--- a/tools/wine4office-manager/wine4office_qt.py
+++ b/tools/wine4office-manager/wine4office_qt.py
@@ -111,6 +111,18 @@ class _UiDispatcher(QObject):
         callback()
 
 
+class _OperationProgressDialog(QDialog):
+    """Keep destructive non-cancellable operations visible until completion."""
+
+    def __init__(self, cancellable: bool, parent=None) -> None:
+        super().__init__(parent)
+        self.cancellable = cancellable
+
+    def reject(self) -> None:
+        if self.cancellable:
+            super().reject()
+
+
 
 class ManagerWindow(QMainWindow):
     ENVIRONMENT_PAGE = 0
@@ -2223,7 +2235,7 @@ class ManagerWindow(QMainWindow):
                             *, cancellable: bool = True) -> None:
         if self.update_progress_dialog is not None:
             self.update_progress_dialog.close()
-        dialog = QDialog(self)
+        dialog = _OperationProgressDialog(cancellable, self)
         dialog.setWindowTitle(title)
         dialog.setWindowModality(Qt.WindowModality.WindowModal)
         dialog.setWindowFlag(Qt.WindowType.WindowCloseButtonHint, False)


### PR DESCRIPTION
## Summary

- fully remove source, standalone, and mixed post-update Manager layouts
- remove orphan preload workers, update locks, shortcuts, icons, and version metadata
- show live non-cancellable removal progress so a destructive uninstall cannot be falsely reported as cancelled
- preserve the selected Wine environment unless explicit prefix removal is requested

## Validation

- 334 Manager Python tests passed
- 4 focused Qt removal/progress tests passed in isolated KDE/Wayland
- release artifact test passed
- curl installer test passed across initial install, version update, rollback, mixed-layout cleanup, and purge
- source installer with custom home/root and post-update lock passed full purge
- `git diff --check`, Python compilation, and shell syntax checks passed

## Visual evidence

Removal progress was verified in the canonical isolated KDE Wayland/KRFB environment and sent through the project Telegram evidence channel.

Scope: Issue #9 only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Uninstallation now displays preparation, removal, and completion progress.
  * Removal dialogs remain visible and cannot be dismissed until the process finishes.
  * Updated installations now replace application files and version information correctly.

* **Bug Fixes**
  * Uninstallation now removes launcher links, icons, metadata, update files, and related remnants.
  * Improved cleanup ensures complete removal of Wine4Office files and shortcuts.
  * Removal completion, interruption, and failure messages are clearer and more accurate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->