### PR TITLE
wintrust: Avoid stale input data during state cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Let Office finish proofing-language updates without crashing Click-to-Run.
 - Prevent the first Word Design-tab load from stalling on queued Direct2D work.
 - Stop only the selected Wine environment, with a graceful ten-second deadline.
 - Fully remove Manager files after installs and updates, with visible removal progress.

--- a/dlls/wintrust/softpub.c
+++ b/dlls/wintrust/softpub.c
@@ -1428,6 +1428,16 @@ HRESULT WINAPI SoftpubCleanup(CRYPT_PROVIDER_DATA *data)
 {
     DWORD i, j;
 
+    if (data->fOpenedFile)
+    {
+        if (data->pPDSip && data->pPDSip->psSipSubjectInfo)
+        {
+            CloseHandle(data->pPDSip->psSipSubjectInfo->hFile);
+            data->pPDSip->psSipSubjectInfo->hFile = INVALID_HANDLE_VALUE;
+        }
+        data->fOpenedFile = FALSE;
+    }
+
     for (i = 0; i < data->csSigners; i++)
     {
         for (j = 0; j < data->pasSigners[i].csCertChain; j++)
@@ -1459,15 +1469,6 @@ HRESULT WINAPI SoftpubCleanup(CRYPT_PROVIDER_DATA *data)
         data->psPfns->pfnFree(data->pSigState);
     }
     CryptMsgClose(data->hMsg);
-
-    if (data->fOpenedFile &&
-     data->pWintrustData->dwUnionChoice == WTD_CHOICE_FILE &&
-     data->pWintrustData->pFile)
-    {
-        CloseHandle(data->pWintrustData->pFile->hFile);
-        data->pWintrustData->pFile->hFile = INVALID_HANDLE_VALUE;
-        data->fOpenedFile = FALSE;
-    }
 
     return S_OK;
 }

--- a/dlls/wintrust/tests/softpub.c
+++ b/dlls/wintrust/tests/softpub.c
@@ -1815,6 +1815,7 @@ static void test_multiple_signatures(void)
     WINTRUST_SIGNATURE_SETTINGS settings = { sizeof(settings) };
     WINTRUST_FILE_INFO file_info = { sizeof(file_info) };
     WINTRUST_DATA data = { sizeof(data) };
+    WINTRUST_DATA close_data = { sizeof(close_data) };
     CRYPT_PROVIDER_DATA *prov;
     WCHAR pathW[MAX_PATH];
     CERT_INFO *cert_info;
@@ -1823,6 +1824,7 @@ static void test_multiple_signatures(void)
     DWORD written;
     LONG status;
     HANDLE file;
+    HANDLE state, trust_file;
     DWORD size;
     BOOL bret;
 
@@ -1882,9 +1884,24 @@ static void test_multiple_signatures(void)
         }
     }
 
-    data.dwStateAction = WTD_STATEACTION_CLOSE;
-    status = WinVerifyTrust(NULL, &WVTPolicyGUID, &data);
+    state = data.hWVTStateData;
+    trust_file = prov->pPDSip && prov->pPDSip->psSipSubjectInfo
+            ? prov->pPDSip->psSipSubjectInfo->hFile : INVALID_HANDLE_VALUE;
+    data.dwUnionChoice = 0;
+    close_data.dwStateAction = WTD_STATEACTION_CLOSE;
+    close_data.hWVTStateData = state;
+    status = WinVerifyTrust(NULL, &WVTPolicyGUID, &close_data);
     ok(status == S_OK, "Failed, ret %#lx\n", status);
+    data.hWVTStateData = NULL;
+    if (trust_file != INVALID_HANDLE_VALUE)
+    {
+        SetLastError(0xdeadbeef);
+        ok(GetFileType(trust_file) == FILE_TYPE_UNKNOWN
+                && GetLastError() == ERROR_INVALID_HANDLE,
+                "Trust provider file handle was not closed, error %lu.\n", GetLastError());
+    }
+    data.dwUnionChoice = WTD_CHOICE_FILE;
+    file_info.hFile = NULL;
 
     data.dwStateAction = WTD_STATEACTION_VERIFY;
     settings.dwFlags = WSS_GET_SECONDARY_SIG_COUNT;

--- a/dlls/wintrust/wintrust_main.c
+++ b/dlls/wintrust/wintrust_main.c
@@ -302,13 +302,19 @@ static LONG WINTRUST_DefaultClose(HWND hwnd, GUID *actionID,
 {
     DWORD err = ERROR_SUCCESS;
     CRYPT_PROVIDER_DATA *provData = data->hWVTStateData;
+    BOOL opened_file;
 
     TRACE("(%p, %s, %p)\n", hwnd, debugstr_guid(actionID), data);
 
     if (provData)
     {
+        opened_file = provData->fOpenedFile;
         if (provData->psPfns->pfnCleanupPolicy)
             err = provData->psPfns->pfnCleanupPolicy(provData);
+
+        if (opened_file && provData->pWintrustData == data &&
+            data->dwUnionChoice == WTD_CHOICE_FILE && data->pFile)
+            data->pFile->hFile = INVALID_HANDLE_VALUE;
 
         free(provData->padwTrustStepErrors);
         free(provData->pPDSip);


### PR DESCRIPTION
## Summary

- close provider-owned SIP file handles without dereferencing expired caller input
- preserve same-structure close behavior safely in the default close path
- cover state close through a separate WINTRUST_DATA structure
- document the Office proofing-language fix

## Verification

- x86_64 wintrust_test.exe softpub: 255 tests, 16 todos, 0 failures
- i386 wintrust_test.exe softpub: 255 tests, 16 todos, 0 failures
- patched Click-to-Run completed download (487/487 files) and UPDATEAPPLY
- German de-de.16 package and proofing dictionary registered and installed

Fixes Wine4Office remaining Issue #3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Office proofing-language updates can now complete without causing Click-to-Run to crash.
  - Improved cleanup of files opened during trust and signature verification, helping prevent resource-handling issues when processing files with multiple signatures.

- **Improvements**
  - Manager files are now fully removed, with visible progress shown after installations and updates.

- **Changelog**
  - Added unreleased entries covering the Office proofing-language stability fix and Manager-file removal improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->