### PR TITLE
Respect application non-client frame policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Prevent the first Word Design-tab load from stalling on queued Direct2D work.
+- Respect application frame preferences and prevent Office window borders from blinking.
 - Stop only the selected Wine environment, with a graceful ten-second deadline.
 - Fully remove Manager files after installs and updates, with visible removal progress.
 

--- a/dlls/win32u/window.c
+++ b/dlls/win32u/window.c
@@ -28,6 +28,7 @@
 #include "ntstatus.h"
 #include "ntgdi_private.h"
 #include "ntuser_private.h"
+#include "wine/dwmapi.h"
 #include "wine/opengl_driver.h"
 #include "wine/server.h"
 #include "wine/debug.h"
@@ -2302,9 +2303,13 @@ done:
 static RECT get_visible_rect( HWND hwnd, BOOL shaped, UINT style, UINT ex_style, const struct window_rects *rects )
 {
     struct ratio dpi = get_dpi_for_window( hwnd );
+    enum DWMNCRENDERINGPOLICY policy;
     UINT style_mask, ex_style_mask;
     RECT visible_rect, rect = {0};
 
+    policy = wine_dwm_decode_window_attribute(
+        NtUserGetProp( hwnd, wine_dwm_nc_rendering_policy_prop ), DWMNCRP_USEWINDOWSTYLE );
+    if (policy == DWMNCRP_DISABLED) return rects->window;
     if (get_present_rect( hwnd, &rect, get_thread_dpi() )) return rect;
     if (IsRectEmpty( &rects->window ) || EqualRect( &rects->window, &rects->client ) || shaped || !decorated_mode) return rects->window;
     if (!user_driver->pGetWindowStyleMasks( hwnd, style, ex_style, &style_mask, &ex_style_mask )) return rects->window;

--- a/dlls/winex11.drv/window.c
+++ b/dlls/winex11.drv/window.c
@@ -47,6 +47,7 @@
 #include "ntstatus.h"
 
 #include "x11drv.h"
+#include "dwmapi.h"
 #include "wingdi.h"
 #include "winuser.h"
 
@@ -104,6 +105,9 @@ static const WCHAR clip_window_prop[] =
     {'_','_','w','i','n','e','_','x','1','1','_','c','l','i','p','_','w','i','n','d','o','w',0};
 static const WCHAR focus_time_prop[] =
     {'_','_','w','i','n','e','_','x','1','1','_','f','o','c','u','s','_','t','i','m','e',0};
+static const WCHAR dwm_nc_rendering_policy_prop[] =
+    {'_','_','w','i','n','e','_','d','w','m','_','n','c','_','r','e','n','d','e','r','i','n','g','_',
+     'p','o','l','i','c','y',0};
 
 static const char *debugstr_mwm_hints( const MwmHints *hints )
 {
@@ -611,7 +615,14 @@ static unsigned long get_mwm_decorations_for_style( DWORD style, DWORD ex_style 
  */
 static unsigned long get_mwm_decorations( struct x11drv_win_data *data, DWORD style, DWORD ex_style )
 {
-    if (EqualRect( &data->rects.window, &data->rects.visible )) return 0;
+    enum DWMNCRENDERINGPOLICY policy;
+
+    /* The visible rect is produced from the decoration policy, so using it to choose that policy
+     * creates a configure feedback loop when the window manager changes the frame extents. */
+    if (!decorated_mode || !data->managed) return 0;
+    policy = HandleToULong( NtUserGetProp( data->hwnd, dwm_nc_rendering_policy_prop ) );
+    policy = policy ? policy - 1 : DWMNCRP_USEWINDOWSTYLE;
+    if (policy == DWMNCRP_DISABLED) return 0;
     return get_mwm_decorations_for_style( style, ex_style );
 }
 

--- a/dlls/winex11.drv/window.c
+++ b/dlls/winex11.drv/window.c
@@ -619,7 +619,7 @@ static unsigned long get_mwm_decorations( struct x11drv_win_data *data, DWORD st
 
     /* The visible rect is produced from the decoration policy, so using it to choose that policy
      * creates a configure feedback loop when the window manager changes the frame extents. */
-    if (!decorated_mode || !data->managed) return 0;
+    if (!decorated_mode || !data->managed || data->shaped) return 0;
     policy = HandleToULong( NtUserGetProp( data->hwnd, dwm_nc_rendering_policy_prop ) );
     policy = policy ? policy - 1 : DWMNCRP_USEWINDOWSTYLE;
     if (policy == DWMNCRP_DISABLED) return 0;

--- a/dlls/winex11.drv/x11drv.h
+++ b/dlls/winex11.drv/x11drv.h
@@ -488,6 +488,7 @@ extern BOOL use_take_focus;
 extern BOOL use_primary_selection;
 extern BOOL use_system_cursors;
 extern BOOL grab_fullscreen;
+extern BOOL decorated_mode;
 extern BOOL usexcomposite;
 extern BOOL managed_mode;
 extern BOOL private_color_map;

--- a/dlls/winex11.drv/x11drv_main.c
+++ b/dlls/winex11.drv/x11drv_main.c
@@ -72,6 +72,7 @@ BOOL use_take_focus = TRUE;
 BOOL use_primary_selection = FALSE;
 BOOL use_system_cursors = TRUE;
 BOOL grab_fullscreen = FALSE;
+BOOL decorated_mode = TRUE;
 BOOL managed_mode = TRUE;
 BOOL private_color_map = FALSE;
 int primary_monitor = 0;
@@ -452,6 +453,9 @@ static void setup_options(void)
 
     if (!get_config_key( hkey, appkey, "Managed", buffer, sizeof(buffer) ))
         managed_mode = IS_OPTION_TRUE( buffer[0] );
+
+    if (!get_config_key( hkey, appkey, "Decorated", buffer, sizeof(buffer) ))
+        decorated_mode = IS_OPTION_TRUE( buffer[0] );
 
     if (!get_config_key( hkey, appkey, "UseEGL", buffer, sizeof(buffer) ))
         use_egl = IS_OPTION_TRUE( buffer[0] );


### PR DESCRIPTION
## Summary

- honor `DWMNCRP_DISABLED` in win32u visible-rectangle calculation and X11 Motif decoration hints
- keep Wine `Decorated` global/app-default behavior while removing geometry-dependent decoration decisions
- prevent Word/KWin decoration and configure feedback loops without executable or window-class rules
- update the changelog

## Validation

- incremental combined-WoW64 build of `win32u.so` and `winex11.so`
- reproduced on current `origin/main` with Word under canonical KWin Wayland/Xwayland environment
- baseline trace: 83 Motif hint changes and 78 client geometry changes
- fixed trace: four expected startup hint transitions and one initial geometry sync; no recurring loop
- 14 steady-state VNC captures stable (two hashes only because the desktop clock crossed a minute)
- policy control: default captioned window gets decorations
- policy control: `DWMNCRP_DISABLED` withdraws decorations
- policy control: Wine `Decorated=N` disables decorations from startup


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of application frame preferences for windows.
  * Prevented blinking borders around Office windows.
  * Corrected window decoration behavior when application-managed frame rendering is disabled.

* **New Features**
  * Added support for configuring decorated window mode through the X11 driver settings, enabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->