### PR TITLE
winrt: Implement application environment probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Let modern Office identify the current user without exposing machine, account,
+  or application identifiers.
+- Let packaged Office components discover their local application-data folders
+  and education-environment state.
+
 ## 0.2.0-beta.1 — 2026-08-19
 
 - Let Office finish proofing-language updates without crashing Click-to-Run.

--- a/dlls/twinapi.appcore/Makefile.in
+++ b/dlls/twinapi.appcore/Makefile.in
@@ -11,5 +11,6 @@ SOURCES = \
 	core_application.c \
 	lifecycle.c \
 	data_transfer.c \
+	education_settings.c \
 	main.c \
 	retail_info.c

--- a/dlls/twinapi.appcore/classes.idl
+++ b/dlls/twinapi.appcore/classes.idl
@@ -39,6 +39,7 @@ namespace Windows.Security.ExchangeActiveSyncProvisioning {
 }
 namespace Windows.System.Profile {
     runtimeclass AnalyticsInfo;
+    runtimeclass EducationSettings;
     runtimeclass RetailInfo;
 }
 namespace Windows.System.UserProfile {

--- a/dlls/twinapi.appcore/education_settings.c
+++ b/dlls/twinapi.appcore/education_settings.c
@@ -1,0 +1,153 @@
+/*
+ * Windows.System.Profile.EducationSettings implementation
+ *
+ * Copyright 2026
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ */
+
+#include "private.h"
+
+WINE_DEFAULT_DEBUG_CHANNEL(twinapi);
+
+struct education_settings_factory
+{
+    IActivationFactory IActivationFactory_iface;
+    IEducationSettingsStatics IEducationSettingsStatics_iface;
+    LONG ref;
+};
+
+static inline struct education_settings_factory *impl_from_IActivationFactory( IActivationFactory *iface )
+{
+    return CONTAINING_RECORD( iface, struct education_settings_factory, IActivationFactory_iface );
+}
+
+static HRESULT WINAPI factory_QueryInterface( IActivationFactory *iface, REFIID iid, void **out )
+{
+    struct education_settings_factory *impl = impl_from_IActivationFactory( iface );
+
+    TRACE( "iface %p, iid %s, out %p.\n", iface, debugstr_guid( iid ), out );
+
+    if (!out) return E_POINTER;
+    *out = NULL;
+    if (!iid) return E_POINTER;
+
+    if (IsEqualGUID( iid, &IID_IUnknown ) || IsEqualGUID( iid, &IID_IInspectable ) ||
+        IsEqualGUID( iid, &IID_IAgileObject ) || IsEqualGUID( iid, &IID_IActivationFactory ))
+    {
+        *out = &impl->IActivationFactory_iface;
+        IActivationFactory_AddRef( (IActivationFactory *)*out );
+        return S_OK;
+    }
+    if (IsEqualGUID( iid, &IID_IEducationSettingsStatics ))
+    {
+        *out = &impl->IEducationSettingsStatics_iface;
+        IEducationSettingsStatics_AddRef( (IEducationSettingsStatics *)*out );
+        return S_OK;
+    }
+
+    FIXME( "%s not implemented, returning E_NOINTERFACE.\n", debugstr_guid( iid ) );
+    return E_NOINTERFACE;
+}
+
+static ULONG WINAPI factory_AddRef( IActivationFactory *iface )
+{
+    struct education_settings_factory *impl = impl_from_IActivationFactory( iface );
+    ULONG ref = InterlockedIncrement( &impl->ref );
+
+    TRACE( "iface %p, ref %lu.\n", iface, ref );
+    return ref;
+}
+
+static ULONG WINAPI factory_Release( IActivationFactory *iface )
+{
+    struct education_settings_factory *impl = impl_from_IActivationFactory( iface );
+    ULONG ref = InterlockedDecrement( &impl->ref );
+
+    TRACE( "iface %p, ref %lu.\n", iface, ref );
+    return ref;
+}
+
+static HRESULT WINAPI factory_GetIids( IActivationFactory *iface, ULONG *iid_count, IID **iids )
+{
+    TRACE( "iface %p, iid_count %p, iids %p.\n", iface, iid_count, iids );
+
+    if (iid_count) *iid_count = 0;
+    if (iids) *iids = NULL;
+    if (!iid_count || !iids) return E_POINTER;
+    return E_NOTIMPL;
+}
+
+static HRESULT WINAPI factory_GetRuntimeClassName( IActivationFactory *iface, HSTRING *class_name )
+{
+    TRACE( "iface %p, class_name %p.\n", iface, class_name );
+
+    if (!class_name) return E_POINTER;
+    *class_name = NULL;
+    return WindowsCreateString( RuntimeClass_Windows_System_Profile_EducationSettings,
+                                wcslen( RuntimeClass_Windows_System_Profile_EducationSettings ), class_name );
+}
+
+static HRESULT WINAPI factory_GetTrustLevel( IActivationFactory *iface, TrustLevel *trust_level )
+{
+    TRACE( "iface %p, trust_level %p.\n", iface, trust_level );
+
+    if (!trust_level) return E_POINTER;
+    *trust_level = BaseTrust;
+    return S_OK;
+}
+
+static HRESULT WINAPI factory_ActivateInstance( IActivationFactory *iface, IInspectable **instance )
+{
+    TRACE( "iface %p, instance %p.\n", iface, instance );
+
+    if (!instance) return E_POINTER;
+    *instance = NULL;
+    return E_NOTIMPL;
+}
+
+static const IActivationFactoryVtbl factory_vtbl =
+{
+    factory_QueryInterface,
+    factory_AddRef,
+    factory_Release,
+    factory_GetIids,
+    factory_GetRuntimeClassName,
+    factory_GetTrustLevel,
+    factory_ActivateInstance,
+};
+
+DEFINE_IINSPECTABLE( statics, IEducationSettingsStatics, struct education_settings_factory,
+                     IActivationFactory_iface );
+
+static HRESULT WINAPI statics_get_IsEducationEnvironment( IEducationSettingsStatics *iface, boolean *value )
+{
+    TRACE( "iface %p, value %p.\n", iface, value );
+
+    if (!value) return E_POINTER;
+    *value = FALSE;
+    return S_OK;
+}
+
+static const IEducationSettingsStaticsVtbl statics_vtbl =
+{
+    statics_QueryInterface,
+    statics_AddRef,
+    statics_Release,
+    statics_GetIids,
+    statics_GetRuntimeClassName,
+    statics_GetTrustLevel,
+    statics_get_IsEducationEnvironment,
+};
+
+static struct education_settings_factory factory =
+{
+    {&factory_vtbl},
+    {&statics_vtbl},
+    1,
+};
+
+IActivationFactory *education_settings_factory = &factory.IActivationFactory_iface;

--- a/dlls/twinapi.appcore/education_settings.c
+++ b/dlls/twinapi.appcore/education_settings.c
@@ -78,7 +78,10 @@ static HRESULT WINAPI factory_GetIids( IActivationFactory *iface, ULONG *iid_cou
     if (iid_count) *iid_count = 0;
     if (iids) *iids = NULL;
     if (!iid_count || !iids) return E_POINTER;
-    return E_NOTIMPL;
+    if (!(*iids = CoTaskMemAlloc( sizeof(**iids) ))) return E_OUTOFMEMORY;
+    **iids = IID_IEducationSettingsStatics;
+    *iid_count = 1;
+    return S_OK;
 }
 
 static HRESULT WINAPI factory_GetRuntimeClassName( IActivationFactory *iface, HSTRING *class_name )

--- a/dlls/twinapi.appcore/main.c
+++ b/dlls/twinapi.appcore/main.c
@@ -43,27 +43,37 @@ HRESULT WINAPI DllGetClassObject( REFCLSID clsid, REFIID riid, void **out )
     return CLASS_E_CLASSNOTAVAILABLE;
 }
 
+static BOOL hstring_equals( HSTRING string, const WCHAR *value )
+{
+    UINT32 length = WindowsGetStringLen( string );
+    SIZE_T value_length = wcslen( value );
+
+    return length == value_length && !memcmp( WindowsGetStringRawBuffer( string, NULL ), value,
+            length * sizeof(*value) );
+}
+
 HRESULT WINAPI DllGetActivationFactory( HSTRING classid, IActivationFactory **factory )
 {
-    const WCHAR *buffer = WindowsGetStringRawBuffer( classid, NULL );
 
     TRACE( "class %s, factory %p.\n", debugstr_hstring(classid), factory );
 
     *factory = NULL;
 
-    if (!wcscmp( buffer, RuntimeClass_Windows_Security_ExchangeActiveSyncProvisioning_EasClientDeviceInformation ))
+    if (hstring_equals( classid, RuntimeClass_Windows_Security_ExchangeActiveSyncProvisioning_EasClientDeviceInformation ))
         IActivationFactory_QueryInterface( client_device_information_factory, &IID_IActivationFactory, (void **)factory );
-    else if (!wcscmp( buffer, RuntimeClass_Windows_System_Profile_AnalyticsInfo ))
+    else if (hstring_equals( classid, RuntimeClass_Windows_System_Profile_AnalyticsInfo ))
         IActivationFactory_QueryInterface( analytics_info_factory, &IID_IActivationFactory, (void **)factory );
-    else if (!wcscmp( buffer, RuntimeClass_Windows_System_Profile_RetailInfo ))
+    else if (hstring_equals( classid, RuntimeClass_Windows_System_Profile_EducationSettings ))
+        IActivationFactory_QueryInterface( education_settings_factory, &IID_IActivationFactory, (void **)factory );
+    else if (hstring_equals( classid, RuntimeClass_Windows_System_Profile_RetailInfo ))
         IActivationFactory_QueryInterface( retail_info_factory, &IID_IActivationFactory, (void **)factory );
-    else if (!wcscmp( buffer, RuntimeClass_Windows_System_UserProfile_AdvertisingManager ))
+    else if (hstring_equals( classid, RuntimeClass_Windows_System_UserProfile_AdvertisingManager ))
         IActivationFactory_QueryInterface( advertising_manager_factory, &IID_IActivationFactory, (void **)factory );
-    else if (!wcscmp( buffer, RuntimeClass_Windows_UI_ViewManagement_ApplicationView ))
+    else if (hstring_equals( classid, RuntimeClass_Windows_UI_ViewManagement_ApplicationView ))
         IActivationFactory_QueryInterface( application_view_factory, &IID_IActivationFactory, (void **)factory );
-    else if (!wcscmp( buffer, RuntimeClass_Windows_ApplicationModel_Core_CoreApplication ))
+    else if (hstring_equals( classid, RuntimeClass_Windows_ApplicationModel_Core_CoreApplication ))
         IActivationFactory_QueryInterface( core_application_factory, &IID_IActivationFactory, (void **)factory );
-    else if (!wcscmp( buffer, RuntimeClass_Windows_ApplicationModel_DataTransfer_DataTransferManager ))
+    else if (hstring_equals( classid, RuntimeClass_Windows_ApplicationModel_DataTransfer_DataTransferManager ))
         IActivationFactory_QueryInterface( data_transfer_manager_statics_factory, &IID_IActivationFactory, (void **)factory );
 
     if (*factory) return S_OK;

--- a/dlls/twinapi.appcore/main.c
+++ b/dlls/twinapi.appcore/main.c
@@ -57,7 +57,9 @@ HRESULT WINAPI DllGetActivationFactory( HSTRING classid, IActivationFactory **fa
 
     TRACE( "class %s, factory %p.\n", debugstr_hstring(classid), factory );
 
+    if (!factory) return E_POINTER;
     *factory = NULL;
+    if (!classid) return CLASS_E_CLASSNOTAVAILABLE;
 
     if (hstring_equals( classid, RuntimeClass_Windows_Security_ExchangeActiveSyncProvisioning_EasClientDeviceInformation ))
         IActivationFactory_QueryInterface( client_device_information_factory, &IID_IActivationFactory, (void **)factory );

--- a/dlls/twinapi.appcore/private.h
+++ b/dlls/twinapi.appcore/private.h
@@ -52,6 +52,7 @@
 extern IActivationFactory *application_view_factory;
 extern IActivationFactory *client_device_information_factory;
 extern IActivationFactory *analytics_info_factory;
+extern IActivationFactory *education_settings_factory;
 extern IActivationFactory *retail_info_factory;
 extern IActivationFactory *advertising_manager_factory;
 extern IActivationFactory *core_application_factory;

--- a/dlls/twinapi.appcore/tests/twinapi.c
+++ b/dlls/twinapi.appcore/tests/twinapi.c
@@ -368,6 +368,142 @@ static void test_AnalyticsVersionInfo(void)
     ok( ref == 1, "got ref %ld.\n", ref );
 }
 
+static void test_EducationSettings(void)
+{
+    static const WCHAR *class_name = RuntimeClass_Windows_System_Profile_EducationSettings;
+    static const GUID unsupported_iid =
+        {0xdeadbeef, 0xbeef, 0x4bad, {0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}};
+    IEducationSettingsStatics *statics = NULL;
+    IActivationFactory *factory = NULL;
+    IUnknown *identity = NULL;
+    HSTRING str = NULL, returned_name = NULL;
+    TrustLevel trust_level = (TrustLevel)-1;
+    boolean value = TRUE;
+    void *unsupported;
+    INT32 compare;
+    HRESULT hr;
+
+    hr = WindowsCreateString( class_name, wcslen( class_name ), &str );
+    ok( hr == S_OK, "got hr %#lx.\n", hr );
+    if (FAILED(hr)) return;
+
+    hr = RoGetActivationFactory( str, &IID_IActivationFactory, NULL );
+    ok( hr == E_INVALIDARG, "null output returned %#lx.\n", hr );
+    {
+        WCHAR invalid_name[ARRAY_SIZE(RuntimeClass_Windows_System_Profile_EducationSettings) + 5];
+        HSTRING invalid_class = NULL;
+        IActivationFactory *invalid_factory = (void *)(ULONG_PTR)0xdeadbeef;
+        UINT32 length = wcslen( class_name );
+
+        memcpy( invalid_name, class_name, length * sizeof(*invalid_name) );
+        invalid_name[length] = 0;
+        memcpy( invalid_name + length + 1, L"junk", 4 * sizeof(*invalid_name) );
+        hr = WindowsCreateString( invalid_name, length + 5, &invalid_class );
+        ok( hr == S_OK, "embedded-NUL class creation returned %#lx.\n", hr );
+        if (SUCCEEDED(hr))
+        {
+            hr = RoGetActivationFactory( invalid_class, &IID_IActivationFactory,
+                    (void **)&invalid_factory );
+            ok( hr == CLASS_E_CLASSNOTAVAILABLE && !invalid_factory,
+                    "embedded-NUL class activation returned %#lx, %p.\n", hr, invalid_factory );
+            WindowsDeleteString( invalid_class );
+        }
+    }
+
+    hr = RoGetActivationFactory( str, &IID_IActivationFactory, (void **)&factory );
+    ok( hr == S_OK || broken( hr == REGDB_E_CLASSNOTREG ), "got hr %#lx.\n", hr );
+    if (hr == REGDB_E_CLASSNOTREG)
+    {
+        win_skip( "%s runtimeclass not registered, skipping tests.\n", wine_dbgstr_w( class_name ) );
+        WindowsDeleteString( str );
+        return;
+    }
+    if (FAILED(hr) || !factory)
+    {
+        ok( !!factory, "got no activation factory for hr %#lx.\n", hr );
+        if (factory) IActivationFactory_Release( factory );
+        WindowsDeleteString( str );
+        return;
+    }
+
+    unsupported = (void *)(ULONG_PTR)0xdeadbeef;
+    hr = RoGetActivationFactory( str, &unsupported_iid, &unsupported );
+    ok( hr == E_NOINTERFACE && !unsupported, "unsupported RoGetActivationFactory returned %#lx, %p.\n",
+            hr, unsupported );
+
+    check_interface( factory, &IID_IUnknown, TRUE );
+    check_interface( factory, &IID_IInspectable, TRUE );
+    check_interface( factory, &IID_IAgileObject, TRUE );
+    check_interface( factory, &IID_IActivationFactory, TRUE );
+    check_interface( factory, &IID_IEducationSettingsStatics, TRUE );
+
+    unsupported = (void *)(ULONG_PTR)0xdeadbeef;
+    hr = IActivationFactory_QueryInterface( factory, &unsupported_iid, &unsupported );
+    ok( hr == E_NOINTERFACE && !unsupported, "unsupported QI returned %#lx, %p.\n", hr, unsupported );
+
+    hr = IActivationFactory_GetRuntimeClassName( factory, &returned_name );
+    ok( hr == S_OK && !!returned_name, "GetRuntimeClassName returned %#lx, %p.\n", hr, returned_name );
+    if (returned_name)
+    {
+        hr = WindowsCompareStringOrdinal( returned_name, str, &compare );
+        ok( hr == S_OK && !compare, "got class name %s.\n", debugstr_hstring( returned_name ) );
+        WindowsDeleteString( returned_name );
+    }
+    hr = IActivationFactory_GetRuntimeClassName( factory, NULL );
+    ok( hr == E_POINTER, "null class name output returned %#lx.\n", hr );
+
+    hr = IActivationFactory_GetTrustLevel( factory, &trust_level );
+    ok( hr == S_OK && trust_level == BaseTrust, "GetTrustLevel returned %#lx, level %d.\n", hr, trust_level );
+    hr = IActivationFactory_GetTrustLevel( factory, NULL );
+    ok( hr == E_POINTER, "null trust level output returned %#lx.\n", hr );
+
+    hr = RoGetActivationFactory( str, &IID_IEducationSettingsStatics, (void **)&statics );
+    ok( hr == S_OK && !!statics, "statics activation returned %#lx, %p.\n", hr, statics );
+    if (FAILED(hr) || !statics)
+    {
+        IActivationFactory_Release( factory );
+        WindowsDeleteString( str );
+        return;
+    }
+
+    check_interface( statics, &IID_IUnknown, TRUE );
+    check_interface( statics, &IID_IInspectable, TRUE );
+    check_interface( statics, &IID_IAgileObject, TRUE );
+    check_interface( statics, &IID_IActivationFactory, TRUE );
+    check_interface( statics, &IID_IEducationSettingsStatics, TRUE );
+
+    unsupported = (void *)(ULONG_PTR)0xdeadbeef;
+    hr = IEducationSettingsStatics_QueryInterface( statics, &unsupported_iid, &unsupported );
+    ok( hr == E_NOINTERFACE && !unsupported, "unsupported statics QI returned %#lx, %p.\n", hr, unsupported );
+
+    hr = IActivationFactory_QueryInterface( factory, &IID_IUnknown, (void **)&identity );
+    ok( hr == S_OK && identity == (IUnknown *)factory, "factory identity returned %#lx, %p.\n", hr, identity );
+    if (identity) IUnknown_Release( identity );
+    identity = NULL;
+    hr = IEducationSettingsStatics_QueryInterface( statics, &IID_IUnknown, (void **)&identity );
+    ok( hr == S_OK && identity == (IUnknown *)factory, "statics identity returned %#lx, %p.\n", hr, identity );
+    if (identity) IUnknown_Release( identity );
+
+    IActivationFactory_AddRef( factory );
+    IActivationFactory_Release( factory );
+
+    hr = IEducationSettingsStatics_get_IsEducationEnvironment( statics, &value );
+    ok( hr == S_OK, "get_IsEducationEnvironment returned %#lx.\n", hr );
+    if (!strcmp( winetest_platform, "wine" )) ok( !value, "expected a non-education Wine environment.\n" );
+    hr = IEducationSettingsStatics_get_IsEducationEnvironment( statics, NULL );
+    ok( hr == E_POINTER, "null value output returned %#lx.\n", hr );
+
+    IActivationFactory_Release( factory );
+    factory = NULL;
+    value = TRUE;
+    hr = IEducationSettingsStatics_get_IsEducationEnvironment( statics, &value );
+    ok( hr == S_OK, "statics did not survive factory release, hr %#lx.\n", hr );
+    if (!strcmp( winetest_platform, "wine" )) ok( !value, "statics returned TRUE after factory release.\n" );
+
+    IEducationSettingsStatics_Release( statics );
+    WindowsDeleteString( str );
+}
+
 static void test_AdvertisingManager(void)
 {
     static const WCHAR *class_name = RuntimeClass_Windows_System_UserProfile_AdvertisingManager;
@@ -897,6 +1033,7 @@ START_TEST(twinapi)
 
     test_EasClientDeviceInformation();
     test_AnalyticsVersionInfo();
+    test_EducationSettings();
     test_AdvertisingManager();
     test_ApplicationView();
     test_CoreApplication();

--- a/dlls/twinapi.appcore/tests/twinapi.c
+++ b/dlls/twinapi.appcore/tests/twinapi.c
@@ -56,14 +56,15 @@ static void check_interface_( unsigned int line, void *iface_ptr, REFIID iid, BO
 {
     HRESULT hr, expected_hr, broken_hr;
     IUnknown *iface = iface_ptr;
-    IUnknown *unk;
+    IUnknown *unk = NULL;
 
     expected_hr = supported ? S_OK : E_NOINTERFACE;
     broken_hr = supported ? E_NOINTERFACE : S_OK;
     hr = IUnknown_QueryInterface( iface, iid, (void **)&unk );
     ok_(__FILE__, line)( hr == expected_hr || broken( is_broken && hr == broken_hr ),
                          "got hr %#lx, expected %#lx.\n", hr, expected_hr );
-    if (SUCCEEDED(hr)) IUnknown_Release( unk );
+    if (SUCCEEDED(hr)) ok_(__FILE__, line)( !!unk, "QueryInterface returned a NULL interface.\n" );
+    if (unk) IUnknown_Release( unk );
 }
 static LONG lifecycle_callback_order;
 
@@ -375,8 +376,10 @@ static void test_EducationSettings(void)
         {0xdeadbeef, 0xbeef, 0x4bad, {0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}};
     IEducationSettingsStatics *statics = NULL;
     IActivationFactory *factory = NULL;
-    IUnknown *identity = NULL;
+    IUnknown *factory_identity = NULL, *statics_identity = NULL;
     HSTRING str = NULL, returned_name = NULL;
+    IID *iids = NULL;
+    ULONG count;
     TrustLevel trust_level = (TrustLevel)-1;
     boolean value = TRUE;
     void *unsupported;
@@ -449,13 +452,21 @@ static void test_EducationSettings(void)
         ok( hr == S_OK && !compare, "got class name %s.\n", debugstr_hstring( returned_name ) );
         WindowsDeleteString( returned_name );
     }
-    hr = IActivationFactory_GetRuntimeClassName( factory, NULL );
-    ok( hr == E_POINTER, "null class name output returned %#lx.\n", hr );
-
     hr = IActivationFactory_GetTrustLevel( factory, &trust_level );
     ok( hr == S_OK && trust_level == BaseTrust, "GetTrustLevel returned %#lx, level %d.\n", hr, trust_level );
-    hr = IActivationFactory_GetTrustLevel( factory, NULL );
-    ok( hr == E_POINTER, "null trust level output returned %#lx.\n", hr );
+    if (!strcmp( winetest_platform, "wine" ))
+    {
+        hr = IActivationFactory_GetRuntimeClassName( factory, NULL );
+        ok( hr == E_POINTER, "null class name output returned %#lx.\n", hr );
+        hr = IActivationFactory_GetTrustLevel( factory, NULL );
+        ok( hr == E_POINTER, "null trust level output returned %#lx.\n", hr );
+    }
+    count = 99;
+    hr = IActivationFactory_GetIids( factory, &count, &iids );
+    ok( hr == S_OK && count == 1 && iids && IsEqualGUID( &iids[0], &IID_IEducationSettingsStatics ),
+            "factory GetIids returned %#lx, count %lu, iids %p.\n", hr, count, iids );
+    if (iids) CoTaskMemFree( iids );
+    iids = NULL;
 
     hr = RoGetActivationFactory( str, &IID_IEducationSettingsStatics, (void **)&statics );
     ok( hr == S_OK && !!statics, "statics activation returned %#lx, %p.\n", hr, statics );
@@ -472,17 +483,24 @@ static void test_EducationSettings(void)
     check_interface( statics, &IID_IActivationFactory, TRUE );
     check_interface( statics, &IID_IEducationSettingsStatics, TRUE );
 
+    count = 99;
+    hr = IEducationSettingsStatics_GetIids( statics, &count, &iids );
+    ok( hr == S_OK && count == 1 && iids && IsEqualGUID( &iids[0], &IID_IEducationSettingsStatics ),
+            "statics GetIids returned %#lx, count %lu, iids %p.\n", hr, count, iids );
+    if (iids) CoTaskMemFree( iids );
+    iids = NULL;
+
     unsupported = (void *)(ULONG_PTR)0xdeadbeef;
     hr = IEducationSettingsStatics_QueryInterface( statics, &unsupported_iid, &unsupported );
     ok( hr == E_NOINTERFACE && !unsupported, "unsupported statics QI returned %#lx, %p.\n", hr, unsupported );
 
-    hr = IActivationFactory_QueryInterface( factory, &IID_IUnknown, (void **)&identity );
-    ok( hr == S_OK && identity == (IUnknown *)factory, "factory identity returned %#lx, %p.\n", hr, identity );
-    if (identity) IUnknown_Release( identity );
-    identity = NULL;
-    hr = IEducationSettingsStatics_QueryInterface( statics, &IID_IUnknown, (void **)&identity );
-    ok( hr == S_OK && identity == (IUnknown *)factory, "statics identity returned %#lx, %p.\n", hr, identity );
-    if (identity) IUnknown_Release( identity );
+    hr = IActivationFactory_QueryInterface( factory, &IID_IUnknown, (void **)&factory_identity );
+    ok( hr == S_OK && factory_identity, "factory identity returned %#lx, %p.\n", hr, factory_identity );
+    hr = IEducationSettingsStatics_QueryInterface( statics, &IID_IUnknown, (void **)&statics_identity );
+    ok( hr == S_OK && statics_identity == factory_identity,
+            "statics identity returned %#lx, %p, expected %p.\n", hr, statics_identity, factory_identity );
+    if (statics_identity) IUnknown_Release( statics_identity );
+    if (factory_identity) IUnknown_Release( factory_identity );
 
     IActivationFactory_AddRef( factory );
     IActivationFactory_Release( factory );
@@ -490,8 +508,11 @@ static void test_EducationSettings(void)
     hr = IEducationSettingsStatics_get_IsEducationEnvironment( statics, &value );
     ok( hr == S_OK, "get_IsEducationEnvironment returned %#lx.\n", hr );
     if (!strcmp( winetest_platform, "wine" )) ok( !value, "expected a non-education Wine environment.\n" );
-    hr = IEducationSettingsStatics_get_IsEducationEnvironment( statics, NULL );
-    ok( hr == E_POINTER, "null value output returned %#lx.\n", hr );
+    if (!strcmp( winetest_platform, "wine" ))
+    {
+        hr = IEducationSettingsStatics_get_IsEducationEnvironment( statics, NULL );
+        ok( hr == E_POINTER, "null value output returned %#lx.\n", hr );
+    }
 
     IActivationFactory_Release( factory );
     factory = NULL;

--- a/dlls/windows.storage.applicationdata/Makefile.in
+++ b/dlls/windows.storage.applicationdata/Makefile.in
@@ -1,5 +1,5 @@
 MODULE  = windows.storage.applicationdata.dll
-IMPORTS = combase
+IMPORTS = combase ntdll shell32
 
 SOURCES = \
 	applicationdata.c \

--- a/dlls/windows.storage.applicationdata/applicationdata.c
+++ b/dlls/windows.storage.applicationdata/applicationdata.c
@@ -694,11 +694,27 @@ static NTSTATUS add_checked_directory( struct directory_handle_chain *chain, con
 
 static HRESULT create_package_local_state( const WCHAR *local_appdata, HSTRING package_family )
 {
+    static const WCHAR creation_mutex_name[] =
+            L"Global\\WineWindowsStorageApplicationDataLocalStateCreation";
     static const WCHAR packages[] = L"Packages";
     static const WCHAR local_state[] = L"LocalState";
     const WCHAR *family = WindowsGetStringRawBuffer( package_family, NULL );
     struct directory_handle_chain chain = {0};
+    HANDLE mutex;
+    DWORD wait;
     NTSTATUS status;
+    HRESULT hr;
+
+    if (!(mutex = CreateMutexW( NULL, FALSE, creation_mutex_name )))
+        return HRESULT_FROM_WIN32( GetLastError() );
+    wait = WaitForSingleObject( mutex, 30000 );
+    if (wait != WAIT_OBJECT_0 && wait != WAIT_ABANDONED)
+    {
+        hr = HRESULT_FROM_WIN32( wait == WAIT_FAILED ? GetLastError() :
+                wait == WAIT_TIMEOUT ? ERROR_TIMEOUT : ERROR_GEN_FAILURE );
+        CloseHandle( mutex );
+        return hr;
+    }
 
     status = open_local_appdata_directory( local_appdata, &chain );
     if (!status) status = add_checked_directory( &chain, packages, ARRAY_SIZE(packages) - 1,
@@ -709,6 +725,8 @@ static HRESULT create_package_local_state( const WCHAR *local_appdata, HSTRING p
             FILE_TRAVERSE );
     if (status) directory_handle_chain_rollback( &chain );
     else directory_handle_chain_clear( &chain );
+    ReleaseMutex( mutex );
+    CloseHandle( mutex );
     return status ? HRESULT_FROM_WIN32( RtlNtStatusToDosError( status ) ) : S_OK;
 }
 

--- a/dlls/windows.storage.applicationdata/applicationdata.c
+++ b/dlls/windows.storage.applicationdata/applicationdata.c
@@ -631,8 +631,7 @@ static NTSTATUS open_local_appdata_directory( const WCHAR *path, struct director
         goto done;
     }
 
-    status = open_checked_directory( NULL, nt_path.Buffer, 7,
-            FILE_TRAVERSE | FILE_ADD_SUBDIRECTORY, FILE_OPEN, &next, &created );
+    status = open_checked_directory( NULL, nt_path.Buffer, 7, FILE_TRAVERSE, FILE_OPEN, &next, &created );
     if (status) goto done;
     if (!directory_handle_chain_add( chain, next, FALSE ))
     {
@@ -657,7 +656,8 @@ static NTSTATUS open_local_appdata_directory( const WCHAR *path, struct director
 
         parent = chain->entries[chain->count - 1].handle;
         status = open_checked_directory( parent, start, separator - start,
-                FILE_TRAVERSE | FILE_ADD_SUBDIRECTORY, FILE_OPEN_IF, &next, &created );
+                FILE_TRAVERSE | (separator == end ? FILE_ADD_SUBDIRECTORY : 0),
+                separator == end ? FILE_OPEN_IF : FILE_OPEN, &next, &created );
         if (status) break;
         if (!directory_handle_chain_add( chain, next, created ))
         {

--- a/dlls/windows.storage.applicationdata/applicationdata.c
+++ b/dlls/windows.storage.applicationdata/applicationdata.c
@@ -1113,6 +1113,30 @@ static HRESULT WINAPI application_data_manager_GetTrustLevel( IApplicationDataMa
     return IActivationFactory_GetTrustLevel( &impl->IActivationFactory_iface, trust_level );
 }
 
+static BOOL package_name_is_reserved( const WCHAR *name, UINT32 length )
+{
+    static const WCHAR *reserved[] =
+    {
+        L"con", L"prn", L"aux", L"nul",
+        L"com1", L"com2", L"com3", L"com4", L"com5", L"com6", L"com7", L"com8", L"com9",
+        L"lpt1", L"lpt2", L"lpt3", L"lpt4", L"lpt5", L"lpt6", L"lpt7", L"lpt8", L"lpt9",
+    };
+    UINT32 i;
+
+    for (i = 0; i < ARRAY_SIZE(reserved); ++i)
+    {
+        UINT32 reserved_length = wcslen( reserved[i] );
+
+        if (length >= reserved_length && !wcsnicmp( name, reserved[i], reserved_length ) &&
+                (length == reserved_length || name[reserved_length] == L'.'))
+            return TRUE;
+    }
+    if (length >= 4 && !wcsnicmp( name, L"xn--", 4 )) return TRUE;
+    for (i = 0; i + 5 <= length; ++i)
+        if (name[i] == L'.' && !wcsnicmp( name + i + 1, L"xn--", 4 )) return TRUE;
+    return FALSE;
+}
+
 static BOOL valid_package_family( HSTRING package_family )
 {
     const WCHAR *str;
@@ -1133,7 +1157,9 @@ static BOOL valid_package_family( HSTRING package_family )
     if (!separator || separator == length) return FALSE;
 
     name_length = separator - 1;
-    if (name_length < 3 || name_length > 50 || length - separator != 13) return FALSE;
+    if (name_length < 3 || name_length > 50 || length - separator != 13 ||
+            package_name_is_reserved( str, name_length ))
+        return FALSE;
 
     for (i = 0; i < name_length; ++i)
     {

--- a/dlls/windows.storage.applicationdata/applicationdata.c
+++ b/dlls/windows.storage.applicationdata/applicationdata.c
@@ -17,7 +17,11 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
+#include "ntstatus.h"
+#define WIN32_NO_STATUS
 #include "private.h"
+#include "shlobj.h"
+#include "winternl.h"
 #include "wine/debug.h"
 
 WINE_DEFAULT_DEBUG_CHANNEL(data);
@@ -29,10 +33,19 @@ struct application_data_statics
     LONG ref;
 };
 
+struct application_data_manager_statics
+{
+    IActivationFactory IActivationFactory_iface;
+    IApplicationDataManagerStatics IApplicationDataManagerStatics_iface;
+    LONG ref;
+};
+
 static inline struct application_data_statics *impl_from_IActivationFactory( IActivationFactory *iface )
 {
     return CONTAINING_RECORD( iface, struct application_data_statics, IActivationFactory_iface );
 }
+
+static ULONG WINAPI factory_AddRef( IActivationFactory *iface );
 
 static HRESULT WINAPI factory_QueryInterface( IActivationFactory *iface, REFIID iid, void **out )
 {
@@ -40,26 +53,21 @@ static HRESULT WINAPI factory_QueryInterface( IActivationFactory *iface, REFIID 
 
     TRACE( "iface %p, iid %s, out %p.\n", iface, debugstr_guid( iid ), out );
 
+    if (!out) return E_POINTER;
+    *out = NULL;
+
     if (IsEqualGUID( iid, &IID_IUnknown ) ||
         IsEqualGUID( iid, &IID_IInspectable ) ||
         IsEqualGUID( iid, &IID_IAgileObject ) ||
         IsEqualGUID( iid, &IID_IActivationFactory ))
-    {
         *out = &impl->IActivationFactory_iface;
-        IInspectable_AddRef( *out );
-        return S_OK;
-    }
-
-    if (IsEqualGUID( iid, &IID_IApplicationDataStatics ))
-    {
+    else if (IsEqualGUID( iid, &IID_IApplicationDataStatics ))
         *out = &impl->IApplicationDataStatics_iface;
-        IInspectable_AddRef( *out );
-        return S_OK;
-    }
+    else
+        return E_NOINTERFACE;
 
-    FIXME( "%s not implemented, returning E_NOINTERFACE.\n", debugstr_guid( iid ) );
-    *out = NULL;
-    return E_NOINTERFACE;
+    factory_AddRef( iface );
+    return S_OK;
 }
 
 static ULONG WINAPI factory_AddRef( IActivationFactory *iface )
@@ -80,25 +88,35 @@ static ULONG WINAPI factory_Release( IActivationFactory *iface )
 
 static HRESULT WINAPI factory_GetIids( IActivationFactory *iface, ULONG *iid_count, IID **iids )
 {
-    FIXME( "iface %p, iid_count %p, iids %p stub!\n", iface, iid_count, iids );
-    return E_NOTIMPL;
+    if (iid_count) *iid_count = 0;
+    if (iids) *iids = NULL;
+    if (!iid_count || !iids) return E_POINTER;
+    if (!(*iids = CoTaskMemAlloc( sizeof(**iids) ))) return E_OUTOFMEMORY;
+
+    (*iids)[0] = IID_IApplicationDataStatics;
+    *iid_count = 1;
+    return S_OK;
 }
 
 static HRESULT WINAPI factory_GetRuntimeClassName( IActivationFactory *iface, HSTRING *class_name )
 {
-    FIXME( "iface %p, class_name %p stub!\n", iface, class_name );
-    return E_NOTIMPL;
+    if (class_name) *class_name = NULL;
+    if (!class_name) return E_POINTER;
+    return WindowsCreateString( RuntimeClass_Windows_Storage_ApplicationData,
+            wcslen( RuntimeClass_Windows_Storage_ApplicationData ), class_name );
 }
 
 static HRESULT WINAPI factory_GetTrustLevel( IActivationFactory *iface, TrustLevel *trust_level )
 {
-    FIXME( "iface %p, trust_level %p stub!\n", iface, trust_level );
-    return E_NOTIMPL;
+    if (!trust_level) return E_POINTER;
+    *trust_level = BaseTrust;
+    return S_OK;
 }
 
 static HRESULT WINAPI factory_ActivateInstance( IActivationFactory *iface, IInspectable **instance )
 {
-    FIXME( "iface %p, instance %p stub!\n", iface, instance );
+    if (instance) *instance = NULL;
+    if (!instance) return E_POINTER;
     return E_NOTIMPL;
 }
 
@@ -134,6 +152,7 @@ static inline struct application_data_container *impl_from_IApplicationDataConta
 static HRESULT WINAPI container_QueryInterface( IApplicationDataContainer *iface, REFIID iid, void **out )
 {
     if (!out) return E_POINTER;
+    *out = NULL;
     if (IsEqualGUID( iid, &IID_IUnknown ) || IsEqualGUID( iid, &IID_IInspectable ) ||
         IsEqualGUID( iid, &IID_IAgileObject ) || IsEqualGUID( iid, &IID_IApplicationDataContainer ))
     {
@@ -159,6 +178,8 @@ static ULONG WINAPI container_Release( IApplicationDataContainer *iface )
 
 static HRESULT WINAPI container_GetIids( IApplicationDataContainer *iface, ULONG *count, IID **iids )
 {
+    if (count) *count = 0;
+    if (iids) *iids = NULL;
     if (!count || !iids) return E_POINTER;
     if (!(*iids = CoTaskMemAlloc( sizeof(**iids) ))) return E_OUTOFMEMORY;
     **iids = IID_IApplicationDataContainer;
@@ -168,6 +189,8 @@ static HRESULT WINAPI container_GetIids( IApplicationDataContainer *iface, ULONG
 
 static HRESULT WINAPI container_GetRuntimeClassName( IApplicationDataContainer *iface, HSTRING *name )
 {
+    if (name) *name = NULL;
+    if (!name) return E_POINTER;
     return WindowsCreateString( RuntimeClass_Windows_Storage_ApplicationDataContainer,
             wcslen( RuntimeClass_Windows_Storage_ApplicationDataContainer ), name );
 }
@@ -182,6 +205,7 @@ static HRESULT WINAPI container_GetTrustLevel( IApplicationDataContainer *iface,
 static HRESULT WINAPI container_get_Name( IApplicationDataContainer *iface, HSTRING *value )
 {
     static const WCHAR name[] = L"Local";
+    if (value) *value = NULL;
     if (!value) return E_POINTER;
     return WindowsCreateString( name, ARRAY_SIZE(name) - 1, value );
 }
@@ -196,6 +220,7 @@ static HRESULT WINAPI container_get_Locality( IApplicationDataContainer *iface, 
 static HRESULT WINAPI container_get_Values( IApplicationDataContainer *iface, IPropertySet **value )
 {
     struct application_data_container *impl = impl_from_IApplicationDataContainer( iface );
+    if (value) *value = NULL;
     if (!value) return E_POINTER;
     IPropertySet_AddRef( *value = impl->values );
     return S_OK;
@@ -204,15 +229,19 @@ static HRESULT WINAPI container_get_Values( IApplicationDataContainer *iface, IP
 static HRESULT WINAPI container_get_Containers( IApplicationDataContainer *iface,
         IMapView_HSTRING_ApplicationDataContainer **value )
 {
+    if (value) *value = NULL;
     FIXME( "iface %p, value %p stub!\n", iface, value );
+    if (!value) return E_POINTER;
     return E_NOTIMPL;
 }
 
 static HRESULT WINAPI container_CreateContainer( IApplicationDataContainer *iface, HSTRING name,
         ApplicationDataCreateDisposition disposition, IApplicationDataContainer **value )
 {
+    if (value) *value = NULL;
     FIXME( "iface %p, name %s, disposition %u, value %p stub!\n", iface,
             debugstr_hstring( name ), disposition, value );
+    if (!value) return E_POINTER;
     return E_NOTIMPL;
 }
 
@@ -252,9 +281,502 @@ static BOOL CALLBACK init_local_settings( INIT_ONCE *once, void *param, void **c
     return TRUE;
 }
 
+struct storage_folder
+{
+    IStorageFolder IStorageFolder_iface;
+    IStorageItem IStorageItem_iface;
+    HSTRING path;
+    LONG ref;
+};
+
+static inline struct storage_folder *impl_from_IStorageFolder( IStorageFolder *iface )
+{
+    return CONTAINING_RECORD( iface, struct storage_folder, IStorageFolder_iface );
+}
+
+static inline struct storage_folder *impl_from_IStorageItem( IStorageItem *iface )
+{
+    return CONTAINING_RECORD( iface, struct storage_folder, IStorageItem_iface );
+}
+
+static ULONG WINAPI storage_folder_AddRef( IStorageFolder *iface );
+static ULONG WINAPI storage_folder_Release( IStorageFolder *iface );
+
+static HRESULT WINAPI storage_folder_QueryInterface( IStorageFolder *iface, REFIID iid, void **out )
+{
+    struct storage_folder *impl = impl_from_IStorageFolder( iface );
+
+    if (!out) return E_POINTER;
+    *out = NULL;
+    if (IsEqualGUID( iid, &IID_IUnknown ) || IsEqualGUID( iid, &IID_IInspectable ) ||
+        IsEqualGUID( iid, &IID_IAgileObject ) || IsEqualGUID( iid, &IID_IStorageFolder ))
+        *out = &impl->IStorageFolder_iface;
+    else if (IsEqualGUID( iid, &IID_IStorageItem ))
+        *out = &impl->IStorageItem_iface;
+    else
+        return E_NOINTERFACE;
+
+    storage_folder_AddRef( &impl->IStorageFolder_iface );
+    return S_OK;
+}
+
+static ULONG WINAPI storage_folder_AddRef( IStorageFolder *iface )
+{
+    return InterlockedIncrement( &impl_from_IStorageFolder(iface)->ref );
+}
+
+static ULONG WINAPI storage_folder_Release( IStorageFolder *iface )
+{
+    struct storage_folder *impl = impl_from_IStorageFolder( iface );
+    ULONG ref = InterlockedDecrement( &impl->ref );
+    if (!ref)
+    {
+        WindowsDeleteString( impl->path );
+        free( impl );
+    }
+    return ref;
+}
+
+static HRESULT WINAPI storage_folder_GetIids( IStorageFolder *iface, ULONG *count, IID **iids )
+{
+    if (count) *count = 0;
+    if (iids) *iids = NULL;
+    if (!count || !iids) return E_POINTER;
+    if (!(*iids = CoTaskMemAlloc( 2 * sizeof(**iids) ))) return E_OUTOFMEMORY;
+    (*iids)[0] = IID_IStorageFolder;
+    (*iids)[1] = IID_IStorageItem;
+    *count = 2;
+    return S_OK;
+}
+
+static HRESULT WINAPI storage_folder_GetRuntimeClassName( IStorageFolder *iface, HSTRING *name )
+{
+    if (name) *name = NULL;
+    if (!name) return E_POINTER;
+    return WindowsCreateString( RuntimeClass_Windows_Storage_StorageFolder,
+            wcslen(RuntimeClass_Windows_Storage_StorageFolder), name );
+}
+
+static HRESULT WINAPI storage_folder_GetTrustLevel( IStorageFolder *iface, TrustLevel *level )
+{
+    if (!level) return E_POINTER;
+    *level = BaseTrust;
+    return S_OK;
+}
+
+#define STORAGE_FOLDER_STUB(name, args) \
+static HRESULT WINAPI storage_folder_##name args \
+{ \
+    if (operation) *operation = NULL; \
+    if (!operation) return E_POINTER; \
+    FIXME( "%s stub.\n", __func__ ); \
+    return E_NOTIMPL; \
+}
+
+STORAGE_FOLDER_STUB(CreateFileAsyncOverloadDefaultOptions,
+        (IStorageFolder *iface, HSTRING name, IAsyncOperation_StorageFile **operation))
+STORAGE_FOLDER_STUB(CreateFileAsync,
+        (IStorageFolder *iface, HSTRING name, CreationCollisionOption option, IAsyncOperation_StorageFile **operation))
+STORAGE_FOLDER_STUB(CreateFolderAsyncOverloadDefaultOptions,
+        (IStorageFolder *iface, HSTRING name, IAsyncOperation_StorageFolder **operation))
+STORAGE_FOLDER_STUB(CreateFolderAsync,
+        (IStorageFolder *iface, HSTRING name, CreationCollisionOption option, IAsyncOperation_StorageFolder **operation))
+STORAGE_FOLDER_STUB(GetFileAsync,
+        (IStorageFolder *iface, HSTRING name, IAsyncOperation_StorageFile **operation))
+STORAGE_FOLDER_STUB(GetFolderAsync,
+        (IStorageFolder *iface, HSTRING name, IAsyncOperation_StorageFolder **operation))
+STORAGE_FOLDER_STUB(GetItemAsync,
+        (IStorageFolder *iface, HSTRING name, IAsyncOperation_IStorageItem **operation))
+STORAGE_FOLDER_STUB(GetFilesAsyncOverloadDefaultOptionsStartAndCount,
+        (IStorageFolder *iface, IAsyncOperation_IVectorView_StorageFile **operation))
+STORAGE_FOLDER_STUB(GetFoldersAsyncOverloadDefaultOptionsStartAndCount,
+        (IStorageFolder *iface, IAsyncOperation_IVectorView_StorageFolder **operation))
+STORAGE_FOLDER_STUB(GetItemsAsyncOverloadDefaultStartAndCount,
+        (IStorageFolder *iface, IAsyncOperation_IVectorView_IStorageItem **operation))
+
+static const IStorageFolderVtbl storage_folder_vtbl =
+{
+    storage_folder_QueryInterface, storage_folder_AddRef, storage_folder_Release,
+    storage_folder_GetIids, storage_folder_GetRuntimeClassName, storage_folder_GetTrustLevel,
+    storage_folder_CreateFileAsyncOverloadDefaultOptions, storage_folder_CreateFileAsync,
+    storage_folder_CreateFolderAsyncOverloadDefaultOptions, storage_folder_CreateFolderAsync,
+    storage_folder_GetFileAsync, storage_folder_GetFolderAsync, storage_folder_GetItemAsync,
+    storage_folder_GetFilesAsyncOverloadDefaultOptionsStartAndCount,
+    storage_folder_GetFoldersAsyncOverloadDefaultOptionsStartAndCount,
+    storage_folder_GetItemsAsyncOverloadDefaultStartAndCount,
+};
+
+static HRESULT WINAPI storage_item_QueryInterface( IStorageItem *iface, REFIID iid, void **out )
+{
+    return storage_folder_QueryInterface( &impl_from_IStorageItem(iface)->IStorageFolder_iface, iid, out );
+}
+static ULONG WINAPI storage_item_AddRef( IStorageItem *iface )
+{
+    return storage_folder_AddRef( &impl_from_IStorageItem(iface)->IStorageFolder_iface );
+}
+static ULONG WINAPI storage_item_Release( IStorageItem *iface )
+{
+    return storage_folder_Release( &impl_from_IStorageItem(iface)->IStorageFolder_iface );
+}
+static HRESULT WINAPI storage_item_GetIids( IStorageItem *iface, ULONG *count, IID **iids )
+{
+    return storage_folder_GetIids( &impl_from_IStorageItem(iface)->IStorageFolder_iface, count, iids );
+}
+static HRESULT WINAPI storage_item_GetRuntimeClassName( IStorageItem *iface, HSTRING *name )
+{
+    return storage_folder_GetRuntimeClassName( &impl_from_IStorageItem(iface)->IStorageFolder_iface, name );
+}
+static HRESULT WINAPI storage_item_GetTrustLevel( IStorageItem *iface, TrustLevel *level )
+{
+    return storage_folder_GetTrustLevel( &impl_from_IStorageItem(iface)->IStorageFolder_iface, level );
+}
+
+#define STORAGE_ITEM_STUB(name, args) \
+static HRESULT WINAPI storage_item_##name args \
+{ \
+    if (operation) *operation = NULL; \
+    if (!operation) return E_POINTER; \
+    FIXME( "%s stub.\n", __func__ ); \
+    return E_NOTIMPL; \
+}
+
+STORAGE_ITEM_STUB(RenameAsyncOverloadDefaultOptions,
+        (IStorageItem *iface, HSTRING name, IAsyncAction **operation))
+STORAGE_ITEM_STUB(RenameAsync,
+        (IStorageItem *iface, HSTRING name, NameCollisionOption option, IAsyncAction **operation))
+STORAGE_ITEM_STUB(DeleteAsyncOverloadDefaultOptions,
+        (IStorageItem *iface, IAsyncAction **operation))
+STORAGE_ITEM_STUB(DeleteAsync,
+        (IStorageItem *iface, StorageDeleteOption option, IAsyncAction **operation))
+STORAGE_ITEM_STUB(GetBasicPropertiesAsync,
+        (IStorageItem *iface, IAsyncOperation_BasicProperties **operation))
+
+static HRESULT WINAPI storage_item_get_Name( IStorageItem *iface, HSTRING *value )
+{
+    static const WCHAR name[] = L"LocalState";
+    if (value) *value = NULL;
+    if (!value) return E_POINTER;
+    return WindowsCreateString( name, ARRAY_SIZE(name) - 1, value );
+}
+
+static HRESULT WINAPI storage_item_get_Path( IStorageItem *iface, HSTRING *value )
+{
+    if (value) *value = NULL;
+    if (!value) return E_POINTER;
+    return WindowsDuplicateString( impl_from_IStorageItem(iface)->path, value );
+}
+
+static HRESULT WINAPI storage_item_get_Attributes( IStorageItem *iface, FileAttributes *value )
+{
+    if (!value) return E_POINTER;
+    *value = FileAttributes_Directory;
+    return S_OK;
+}
+
+static HRESULT WINAPI storage_item_get_DateCreated( IStorageItem *iface, DateTime *value )
+{
+    if (value) value->UniversalTime = 0;
+    if (!value) return E_POINTER;
+    FIXME( "%s stub.\n", __func__ );
+    return E_NOTIMPL;
+}
+
+static HRESULT WINAPI storage_item_IsOfType( IStorageItem *iface, StorageItemTypes type, boolean *value )
+{
+    if (!value) return E_POINTER;
+    *value = type == StorageItemTypes_Folder;
+    return S_OK;
+}
+
+static const IStorageItemVtbl storage_item_vtbl =
+{
+    storage_item_QueryInterface, storage_item_AddRef, storage_item_Release,
+    storage_item_GetIids, storage_item_GetRuntimeClassName, storage_item_GetTrustLevel,
+    storage_item_RenameAsyncOverloadDefaultOptions, storage_item_RenameAsync,
+    storage_item_DeleteAsyncOverloadDefaultOptions, storage_item_DeleteAsync,
+    storage_item_GetBasicPropertiesAsync, storage_item_get_Name, storage_item_get_Path,
+    storage_item_get_Attributes, storage_item_get_DateCreated, storage_item_IsOfType,
+};
+
+static BOOL size_add( SIZE_T *value, SIZE_T add )
+{
+    if (*value > (SIZE_T)-1 - add) return FALSE;
+    *value += add;
+    return TRUE;
+}
+
+struct directory_handle
+{
+    HANDLE handle;
+    BOOL created;
+};
+
+struct directory_handle_chain
+{
+    struct directory_handle *entries;
+    SIZE_T count;
+    SIZE_T capacity;
+};
+
+static NTSTATUS delete_directory( HANDLE handle )
+{
+    FILE_DISPOSITION_INFORMATION disposition = { TRUE };
+    IO_STATUS_BLOCK io;
+
+    return NtSetInformationFile( handle, &io, &disposition, sizeof(disposition), FileDispositionInformation );
+}
+
+static void directory_handle_chain_clear( struct directory_handle_chain *chain )
+{
+    while (chain->count) NtClose( chain->entries[--chain->count].handle );
+    free( chain->entries );
+}
+
+static void directory_handle_chain_rollback( struct directory_handle_chain *chain )
+{
+    while (chain->count)
+    {
+        struct directory_handle *entry = &chain->entries[--chain->count];
+
+        if (entry->created) delete_directory( entry->handle );
+        NtClose( entry->handle );
+    }
+    free( chain->entries );
+    chain->entries = NULL;
+    chain->capacity = 0;
+}
+
+static BOOL directory_handle_chain_add( struct directory_handle_chain *chain, HANDLE handle, BOOL created )
+{
+    struct directory_handle *entries;
+    SIZE_T capacity;
+
+    if (chain->count < chain->capacity)
+    {
+        chain->entries[chain->count++] = (struct directory_handle){ handle, created };
+        return TRUE;
+    }
+    capacity = chain->capacity ? chain->capacity * 2 : 8;
+    if (capacity < chain->capacity || capacity > (SIZE_T)-1 / sizeof(*entries)) return FALSE;
+    if (!(entries = realloc( chain->entries, capacity * sizeof(*entries) ))) return FALSE;
+    chain->entries = entries;
+    chain->capacity = capacity;
+    chain->entries[chain->count++] = (struct directory_handle){ handle, created };
+    return TRUE;
+}
+
+static NTSTATUS open_checked_directory( HANDLE parent, const WCHAR *name, SIZE_T length,
+        ACCESS_MASK access, ULONG disposition, HANDLE *value, BOOL *created )
+{
+    FILE_ATTRIBUTE_TAG_INFORMATION tag_info;
+    OBJECT_ATTRIBUTES attributes;
+    UNICODE_STRING name_string;
+    IO_STATUS_BLOCK io;
+    NTSTATUS status;
+    BOOL request_delete;
+
+    *value = NULL;
+    *created = FALSE;
+    if (!length || length > USHRT_MAX / sizeof(*name)) return STATUS_OBJECT_PATH_SYNTAX_BAD;
+
+    name_string.Buffer = (WCHAR *)name;
+    name_string.Length = name_string.MaximumLength = length * sizeof(*name);
+    InitializeObjectAttributes( &attributes, &name_string, OBJ_CASE_INSENSITIVE, parent, NULL );
+    request_delete = disposition == FILE_OPEN_IF;
+    status = NtCreateFile( value, access | FILE_READ_ATTRIBUTES | SYNCHRONIZE |
+            (request_delete ? DELETE : 0), &attributes, &io, NULL, FILE_ATTRIBUTE_NORMAL,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, disposition,
+            FILE_OPEN_REPARSE_POINT | FILE_DIRECTORY_FILE | FILE_SYNCHRONOUS_IO_NONALERT, NULL, 0 );
+    if (status == STATUS_ACCESS_DENIED && request_delete)
+    {
+        status = NtCreateFile( value, access | FILE_READ_ATTRIBUTES | SYNCHRONIZE, &attributes, &io, NULL,
+                FILE_ATTRIBUTE_NORMAL, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, FILE_OPEN,
+                FILE_OPEN_REPARSE_POINT | FILE_DIRECTORY_FILE | FILE_SYNCHRONOUS_IO_NONALERT, NULL, 0 );
+    }
+    if (status) return status;
+    *created = io.Information == FILE_CREATED;
+
+    status = NtQueryInformationFile( *value, &io, &tag_info, sizeof(tag_info), FileAttributeTagInformation );
+    if (!status && ((tag_info.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) || tag_info.ReparseTag))
+        status = STATUS_REPARSE_POINT_ENCOUNTERED;
+    if (status)
+    {
+        if (*created) delete_directory( *value );
+        NtClose( *value );
+        *value = NULL;
+        *created = FALSE;
+    }
+    return status;
+}
+
+static NTSTATUS open_local_appdata_directory( const WCHAR *path, struct directory_handle_chain *chain )
+{
+    UNICODE_STRING nt_path;
+    WCHAR *start, *end, *separator;
+    HANDLE parent, next;
+    SIZE_T length;
+    BOOL created;
+    NTSTATUS status;
+
+    status = RtlDosPathNameToNtPathName_U_WithStatus( path, &nt_path, NULL, NULL );
+    if (status) return status;
+
+    length = nt_path.Length / sizeof(*nt_path.Buffer);
+    if (length < 7 || memcmp( nt_path.Buffer, L"\\??\\", 4 * sizeof(WCHAR) ) ||
+        nt_path.Buffer[5] != L':' || nt_path.Buffer[6] != L'\\')
+    {
+        status = STATUS_OBJECT_PATH_SYNTAX_BAD;
+        goto done;
+    }
+
+    status = open_checked_directory( NULL, nt_path.Buffer, 7,
+            FILE_TRAVERSE | FILE_ADD_SUBDIRECTORY, FILE_OPEN, &next, &created );
+    if (status) goto done;
+    if (!directory_handle_chain_add( chain, next, FALSE ))
+    {
+        NtClose( next );
+        status = STATUS_NO_MEMORY;
+        goto done;
+    }
+
+    start = nt_path.Buffer + 7;
+    end = nt_path.Buffer + length;
+    while (start < end)
+    {
+        separator = start;
+        while (separator < end && *separator != L'\\') ++separator;
+        if (separator == start ||
+            (separator - start == 1 && start[0] == L'.') ||
+            (separator - start == 2 && start[0] == L'.' && start[1] == L'.'))
+        {
+            status = STATUS_OBJECT_PATH_SYNTAX_BAD;
+            break;
+        }
+
+        parent = chain->entries[chain->count - 1].handle;
+        status = open_checked_directory( parent, start, separator - start,
+                FILE_TRAVERSE | FILE_ADD_SUBDIRECTORY, FILE_OPEN_IF, &next, &created );
+        if (status) break;
+        if (!directory_handle_chain_add( chain, next, created ))
+        {
+            if (created) delete_directory( next );
+            NtClose( next );
+            status = STATUS_NO_MEMORY;
+            break;
+        }
+        start = separator + (separator < end);
+    }
+
+done:
+    RtlFreeUnicodeString( &nt_path );
+    return status;
+}
+
+static NTSTATUS add_checked_directory( struct directory_handle_chain *chain, const WCHAR *name,
+        SIZE_T length, ACCESS_MASK access )
+{
+    HANDLE parent = chain->entries[chain->count - 1].handle, next;
+    BOOL created;
+    NTSTATUS status;
+
+    status = open_checked_directory( parent, name, length, access, FILE_OPEN_IF, &next, &created );
+    if (status) return status;
+    if (!directory_handle_chain_add( chain, next, created ))
+    {
+        if (created) delete_directory( next );
+        NtClose( next );
+        return STATUS_NO_MEMORY;
+    }
+    return STATUS_SUCCESS;
+}
+
+static HRESULT create_package_local_state( const WCHAR *local_appdata, HSTRING package_family )
+{
+    static const WCHAR packages[] = L"Packages";
+    static const WCHAR local_state[] = L"LocalState";
+    const WCHAR *family = WindowsGetStringRawBuffer( package_family, NULL );
+    struct directory_handle_chain chain = {0};
+    NTSTATUS status;
+
+    status = open_local_appdata_directory( local_appdata, &chain );
+    if (!status) status = add_checked_directory( &chain, packages, ARRAY_SIZE(packages) - 1,
+            FILE_TRAVERSE | FILE_ADD_SUBDIRECTORY );
+    if (!status) status = add_checked_directory( &chain, family, WindowsGetStringLen( package_family ),
+            FILE_TRAVERSE | FILE_ADD_SUBDIRECTORY );
+    if (!status) status = add_checked_directory( &chain, local_state, ARRAY_SIZE(local_state) - 1,
+            FILE_TRAVERSE );
+    if (status) directory_handle_chain_rollback( &chain );
+    else directory_handle_chain_clear( &chain );
+    return status ? HRESULT_FROM_WIN32( RtlNtStatusToDosError( status ) ) : S_OK;
+}
+
+static HRESULT storage_folder_create( HSTRING package_family, IStorageFolder **value )
+{
+    struct storage_folder *impl;
+    const WCHAR *family;
+    WCHAR *local_appdata = NULL, *path;
+    SIZE_T length;
+    HRESULT hr;
+
+    if (value) *value = NULL;
+    if (!value) return E_POINTER;
+    if (!package_family) return E_NOTIMPL;
+    family = WindowsGetStringRawBuffer( package_family, NULL );
+    if (FAILED(hr = SHGetKnownFolderPath( &FOLDERID_LocalAppData, KF_FLAG_DONT_VERIFY, NULL, &local_appdata ))) return hr;
+
+    length = wcslen(local_appdata);
+    if (!size_add( &length, wcslen(L"\\Packages\\")) || !size_add( &length, wcslen(family)) ||
+        !size_add( &length, wcslen(L"\\LocalState")) || !size_add( &length, 1 ) ||
+        length > (SIZE_T)-1 / sizeof(*path))
+    {
+        CoTaskMemFree( local_appdata );
+        return E_OUTOFMEMORY;
+    }
+    if (!(path = malloc( length * sizeof(*path) )))
+    {
+        CoTaskMemFree( local_appdata );
+        return E_OUTOFMEMORY;
+    }
+    if (swprintf( path, length, L"%s\\Packages\\%s\\LocalState", local_appdata, family ) < 0)
+    {
+        CoTaskMemFree( local_appdata );
+        free( path );
+        return E_FAIL;
+    }
+    if (!(impl = calloc( 1, sizeof(*impl) )))
+    {
+        CoTaskMemFree( local_appdata );
+        free( path );
+        return E_OUTOFMEMORY;
+    }
+    impl->IStorageFolder_iface.lpVtbl = &storage_folder_vtbl;
+    impl->IStorageItem_iface.lpVtbl = &storage_item_vtbl;
+    impl->ref = 1;
+    hr = WindowsCreateString( path, wcslen(path), &impl->path );
+    free( path );
+    if (FAILED(hr))
+    {
+        CoTaskMemFree( local_appdata );
+        free( impl );
+        return hr;
+    }
+
+    hr = create_package_local_state( local_appdata, package_family );
+    CoTaskMemFree( local_appdata );
+    if (FAILED(hr))
+    {
+        WindowsDeleteString( impl->path );
+        free( impl );
+        return hr;
+    }
+    *value = &impl->IStorageFolder_iface;
+    return S_OK;
+}
+
 struct application_data
 {
     IApplicationData IApplicationData_iface;
+    HSTRING package_family;
     LONG ref;
 };
 
@@ -263,11 +785,16 @@ static inline struct application_data *impl_from_IApplicationData( IApplicationD
     return CONTAINING_RECORD( iface, struct application_data, IApplicationData_iface );
 }
 
+static ULONG WINAPI application_data_AddRef( IApplicationData *iface );
+
 static HRESULT WINAPI application_data_QueryInterface( IApplicationData *iface, REFIID iid, void **out )
 {
     struct application_data *impl = impl_from_IApplicationData( iface );
 
     TRACE( "iface %p, iid %s, out %p.\n", iface, debugstr_guid( iid ), out );
+
+    if (!out) return E_POINTER;
+    *out = NULL;
 
     if (IsEqualGUID( iid, &IID_IUnknown ) ||
         IsEqualGUID( iid, &IID_IInspectable ) ||
@@ -275,12 +802,10 @@ static HRESULT WINAPI application_data_QueryInterface( IApplicationData *iface, 
         IsEqualGUID( iid, &IID_IApplicationData ))
     {
         *out = &impl->IApplicationData_iface;
-        IInspectable_AddRef( *out );
+        application_data_AddRef( iface );
         return S_OK;
     }
 
-    FIXME( "%s not implemented, returning E_NOINTERFACE.\n", debugstr_guid( iid ) );
-    *out = NULL;
     return E_NOINTERFACE;
 }
 
@@ -299,58 +824,81 @@ static ULONG WINAPI application_data_Release( IApplicationData *iface )
 
     TRACE( "iface %p decreasing refcount to %lu.\n", iface, ref );
 
-    if (!ref) free( impl );
+    if (!ref)
+    {
+        WindowsDeleteString( impl->package_family );
+        free( impl );
+    }
     return ref;
 }
 
 static HRESULT WINAPI application_data_GetIids( IApplicationData *iface, ULONG *iid_count, IID **iids )
 {
-    FIXME( "iface %p, iid_count %p, iids %p stub!\n", iface, iid_count, iids );
-    return E_NOTIMPL;
+    if (iid_count) *iid_count = 0;
+    if (iids) *iids = NULL;
+    if (!iid_count || !iids) return E_POINTER;
+    if (!(*iids = CoTaskMemAlloc( sizeof(**iids) ))) return E_OUTOFMEMORY;
+    **iids = IID_IApplicationData;
+    *iid_count = 1;
+    return S_OK;
 }
 
 static HRESULT WINAPI application_data_GetRuntimeClassName( IApplicationData *iface, HSTRING *class_name )
 {
-    FIXME( "iface %p, class_name %p stub!\n", iface, class_name );
-    return E_NOTIMPL;
+    if (class_name) *class_name = NULL;
+    if (!class_name) return E_POINTER;
+    return WindowsCreateString( RuntimeClass_Windows_Storage_ApplicationData,
+            wcslen( RuntimeClass_Windows_Storage_ApplicationData ), class_name );
 }
 
 static HRESULT WINAPI application_data_GetTrustLevel( IApplicationData *iface, TrustLevel *trust_level )
 {
-    FIXME( "iface %p, trust_level %p stub!\n", iface, trust_level );
-    return E_NOTIMPL;
+    if (!trust_level) return E_POINTER;
+    *trust_level = BaseTrust;
+    return S_OK;
 }
 
 static HRESULT WINAPI application_data_get_Version( IApplicationData *iface, UINT32 *value )
 {
+    if (value) *value = 0;
     FIXME( "iface %p, value %p stub!\n", iface, value );
+    if (!value) return E_POINTER;
     return E_NOTIMPL;
 }
 
 static HRESULT WINAPI application_data_SetVersionAsync( IApplicationData *iface, UINT32 version, IApplicationDataSetVersionHandler *handler,
                                                         IAsyncAction **operation )
 {
+    if (operation) *operation = NULL;
     FIXME( "iface %p, version %d, handler %p, operation %p stub!\n", iface, version, handler, operation );
+    if (!operation) return E_POINTER;
     return E_NOTIMPL;
 }
 
 static HRESULT WINAPI application_data_ClearAllAsync( IApplicationData *iface, IAsyncAction **operation )
 {
+    if (operation) *operation = NULL;
     FIXME( "iface %p, operation %p stub!\n", iface, operation );
+    if (!operation) return E_POINTER;
     return E_NOTIMPL;
 }
 
 static HRESULT WINAPI application_data_ClearAsync( IApplicationData *iface, ApplicationDataLocality locality, IAsyncAction **operation )
 {
+    if (operation) *operation = NULL;
     FIXME( "iface %p, %d locality, operation %p stub!\n", iface, locality, operation );
+    if (!operation) return E_POINTER;
     return E_NOTIMPL;
 }
 
 static HRESULT WINAPI application_data_get_LocalSettings( IApplicationData *iface, IApplicationDataContainer **value )
 {
+    struct application_data *impl = impl_from_IApplicationData( iface );
+
     TRACE( "iface %p, value %p.\n", iface, value );
     if (!value) return E_POINTER;
     *value = NULL;
+    if (impl->package_family) return E_NOTIMPL;
     InitOnceExecuteOnce( &local_settings_once, init_local_settings, NULL, NULL );
     if (FAILED(local_settings_hr)) return local_settings_hr;
     IApplicationDataContainer_AddRef( *value = &local_settings.IApplicationDataContainer_iface );
@@ -359,32 +907,45 @@ static HRESULT WINAPI application_data_get_LocalSettings( IApplicationData *ifac
 
 static HRESULT WINAPI application_data_get_RoamingSettings( IApplicationData *iface, IApplicationDataContainer **value )
 {
+    if (value) *value = NULL;
     FIXME( "iface %p, value %p stub!\n", iface, value );
+    if (!value) return E_POINTER;
     return E_NOTIMPL;
 }
 
 static HRESULT WINAPI application_data_get_LocalFolder( IApplicationData *iface, IStorageFolder **value )
 {
-    FIXME( "iface %p, value %p stub!\n", iface, value );
-    return E_NOTIMPL;
+    struct application_data *impl = impl_from_IApplicationData( iface );
+
+    TRACE( "iface %p, value %p.\n", iface, value );
+    if (value) *value = NULL;
+    if (!value) return E_POINTER;
+    if (!impl->package_family) return E_NOTIMPL;
+    return storage_folder_create( impl->package_family, value );
 }
 
 static HRESULT WINAPI application_data_get_RoamingFolder( IApplicationData *iface, IStorageFolder **value )
 {
+    if (value) *value = NULL;
     FIXME( "iface %p, value %p stub!\n", iface, value );
+    if (!value) return E_POINTER;
     return E_NOTIMPL;
 }
 
 static HRESULT WINAPI application_data_get_TemporaryFolder( IApplicationData *iface, IStorageFolder **value )
 {
+    if (value) *value = NULL;
     FIXME( "iface %p, value %p stub!\n", iface, value );
+    if (!value) return E_POINTER;
     return E_NOTIMPL;
 }
 
 static HRESULT WINAPI application_data_add_DataChanged( IApplicationData *iface, ITypedEventHandler_ApplicationData_IInspectable *handler,
                                                         EventRegistrationToken *token )
 {
+    if (token) token->value = 0;
     FIXME( "iface %p, handler %p, token %p stub!\n", iface, handler, token );
+    if (!token) return E_POINTER;
     return E_NOTIMPL;
 }
 
@@ -402,7 +963,9 @@ static HRESULT WINAPI application_data_SignalDataChanged( IApplicationData *ifac
 
 static HRESULT WINAPI application_data_get_RoamingStorageQuota( IApplicationData *iface, UINT64 *value )
 {
+    if (value) *value = 0;
     FIXME( "iface %p, value %p stub!\n", iface, value );
+    if (!value) return E_POINTER;
     return E_NOTIMPL;
 }
 
@@ -433,22 +996,224 @@ static const struct IApplicationDataVtbl application_data_vtbl =
 
 DEFINE_IINSPECTABLE( application_data_statics, IApplicationDataStatics, struct application_data_statics, IActivationFactory_iface )
 
-static HRESULT WINAPI application_data_statics_get_Current( IApplicationDataStatics *iface, IApplicationData **value )
+static inline struct application_data_manager_statics *impl_from_manager_factory( IActivationFactory *iface )
+{
+    return CONTAINING_RECORD( iface, struct application_data_manager_statics, IActivationFactory_iface );
+}
+
+static inline struct application_data_manager_statics *impl_from_IApplicationDataManagerStatics( IApplicationDataManagerStatics *iface )
+{
+    return CONTAINING_RECORD( iface, struct application_data_manager_statics, IApplicationDataManagerStatics_iface );
+}
+
+static ULONG WINAPI manager_factory_AddRef( IActivationFactory *iface );
+
+static HRESULT WINAPI manager_factory_QueryInterface( IActivationFactory *iface, REFIID iid, void **out )
+{
+    struct application_data_manager_statics *impl = impl_from_manager_factory( iface );
+
+    if (!out) return E_POINTER;
+    *out = NULL;
+    if (IsEqualGUID( iid, &IID_IUnknown ) || IsEqualGUID( iid, &IID_IInspectable ) ||
+        IsEqualGUID( iid, &IID_IAgileObject ) || IsEqualGUID( iid, &IID_IActivationFactory ))
+        *out = &impl->IActivationFactory_iface;
+    else if (IsEqualGUID( iid, &IID_IApplicationDataManagerStatics ))
+        *out = &impl->IApplicationDataManagerStatics_iface;
+    else
+        return E_NOINTERFACE;
+
+    manager_factory_AddRef( iface );
+    return S_OK;
+}
+
+static ULONG WINAPI manager_factory_AddRef( IActivationFactory *iface )
+{
+    return InterlockedIncrement( &impl_from_manager_factory( iface )->ref );
+}
+
+static ULONG WINAPI manager_factory_Release( IActivationFactory *iface )
+{
+    return InterlockedDecrement( &impl_from_manager_factory( iface )->ref );
+}
+
+static HRESULT WINAPI manager_factory_GetIids( IActivationFactory *iface, ULONG *iid_count, IID **iids )
+{
+    if (iid_count) *iid_count = 0;
+    if (iids) *iids = NULL;
+    if (!iid_count || !iids) return E_POINTER;
+    if (!(*iids = CoTaskMemAlloc( sizeof(**iids) ))) return E_OUTOFMEMORY;
+
+    (*iids)[0] = IID_IApplicationDataManagerStatics;
+    *iid_count = 1;
+    return S_OK;
+}
+
+static HRESULT WINAPI manager_factory_GetRuntimeClassName( IActivationFactory *iface, HSTRING *name )
+{
+    if (name) *name = NULL;
+    if (!name) return E_POINTER;
+    return WindowsCreateString( RuntimeClass_Windows_Management_Core_ApplicationDataManager,
+            wcslen( RuntimeClass_Windows_Management_Core_ApplicationDataManager ), name );
+}
+
+static HRESULT WINAPI manager_factory_GetTrustLevel( IActivationFactory *iface, TrustLevel *trust_level )
+{
+    if (!trust_level) return E_POINTER;
+    *trust_level = BaseTrust;
+    return S_OK;
+}
+
+static HRESULT WINAPI manager_factory_ActivateInstance( IActivationFactory *iface, IInspectable **instance )
+{
+    if (instance) *instance = NULL;
+    if (!instance) return E_POINTER;
+    return E_NOTIMPL;
+}
+
+static const IActivationFactoryVtbl manager_factory_vtbl =
+{
+    manager_factory_QueryInterface,
+    manager_factory_AddRef,
+    manager_factory_Release,
+    manager_factory_GetIids,
+    manager_factory_GetRuntimeClassName,
+    manager_factory_GetTrustLevel,
+    manager_factory_ActivateInstance,
+};
+
+static HRESULT WINAPI application_data_manager_QueryInterface( IApplicationDataManagerStatics *iface, REFIID iid, void **out )
+{
+    struct application_data_manager_statics *impl = impl_from_IApplicationDataManagerStatics( iface );
+    return IActivationFactory_QueryInterface( &impl->IActivationFactory_iface, iid, out );
+}
+
+static ULONG WINAPI application_data_manager_AddRef( IApplicationDataManagerStatics *iface )
+{
+    struct application_data_manager_statics *impl = impl_from_IApplicationDataManagerStatics( iface );
+    return IActivationFactory_AddRef( &impl->IActivationFactory_iface );
+}
+
+static ULONG WINAPI application_data_manager_Release( IApplicationDataManagerStatics *iface )
+{
+    struct application_data_manager_statics *impl = impl_from_IApplicationDataManagerStatics( iface );
+    return IActivationFactory_Release( &impl->IActivationFactory_iface );
+}
+
+static HRESULT WINAPI application_data_manager_GetIids( IApplicationDataManagerStatics *iface, ULONG *iid_count, IID **iids )
+{
+    struct application_data_manager_statics *impl = impl_from_IApplicationDataManagerStatics( iface );
+    return IActivationFactory_GetIids( &impl->IActivationFactory_iface, iid_count, iids );
+}
+
+static HRESULT WINAPI application_data_manager_GetTrustLevel( IApplicationDataManagerStatics *iface, TrustLevel *trust_level )
+{
+    struct application_data_manager_statics *impl = impl_from_IApplicationDataManagerStatics( iface );
+    return IActivationFactory_GetTrustLevel( &impl->IActivationFactory_iface, trust_level );
+}
+
+static BOOL valid_package_family( HSTRING package_family )
+{
+    const WCHAR *str;
+    UINT32 length, separator = 0;
+    UINT32 i, name_length;
+
+    if (!package_family) return FALSE;
+    length = WindowsGetStringLen( package_family );
+    if (length < 17 || length > 64) return FALSE;
+    str = WindowsGetStringRawBuffer( package_family, NULL );
+
+    for (i = 0; i < length; ++i)
+    {
+        if (str[i] != L'_') continue;
+        if (separator) return FALSE;
+        separator = i + 1;
+    }
+    if (!separator || separator == length) return FALSE;
+
+    name_length = separator - 1;
+    if (name_length < 3 || name_length > 50 || length - separator != 13) return FALSE;
+
+    for (i = 0; i < name_length; ++i)
+    {
+        WCHAR c = str[i];
+        BOOL letter = (c >= L'A' && c <= L'Z') || (c >= L'a' && c <= L'z');
+        BOOL digit = c >= L'0' && c <= L'9';
+
+        if (!letter && !digit && c != L'.' && c != L'-') return FALSE;
+        if (c == L'.' && (!i || i + 1 == name_length || str[i - 1] == L'.'))
+            return FALSE;
+    }
+
+    for (i = separator; i < length; ++i)
+    {
+        WCHAR c = str[i];
+        BOOL letter = c >= L'a' && c <= L'z' && c != L'i' && c != L'l' && c != L'o' && c != L'u';
+
+        if (!letter && !(c >= L'0' && c <= L'9')) return FALSE;
+    }
+
+    return TRUE;
+}
+
+static HRESULT application_data_create( HSTRING package_family, IApplicationData **value )
 {
     struct application_data *impl;
+    HRESULT hr;
 
-    TRACE( "iface %p, value %p\n", iface, value );
-
-    if (!value) return E_INVALIDARG;
+    if (value) *value = NULL;
+    if (!value) return E_POINTER;
     if (!(impl = calloc( 1, sizeof(*impl) ))) return E_OUTOFMEMORY;
 
     impl->IApplicationData_iface.lpVtbl = &application_data_vtbl;
     impl->ref = 1;
+    if (package_family && FAILED(hr = WindowsDuplicateString( package_family, &impl->package_family )))
+    {
+        free( impl );
+        return hr;
+    }
 
     *value = &impl->IApplicationData_iface;
     TRACE( "created IApplicationData %p.\n", *value );
     return S_OK;
 }
+
+static HRESULT WINAPI application_data_statics_get_Current( IApplicationDataStatics *iface, IApplicationData **value )
+{
+    TRACE( "iface %p, value %p\n", iface, value );
+    if (!value) return E_INVALIDARG;
+    return application_data_create( NULL, value );
+}
+
+static HRESULT WINAPI application_data_manager_GetRuntimeClassName( IApplicationDataManagerStatics *iface, HSTRING *name )
+{
+    if (name) *name = NULL;
+    if (!name) return E_POINTER;
+    return WindowsCreateString( RuntimeClass_Windows_Management_Core_ApplicationDataManager,
+            wcslen( RuntimeClass_Windows_Management_Core_ApplicationDataManager ), name );
+}
+
+static HRESULT WINAPI application_data_manager_CreateForPackageFamily( IApplicationDataManagerStatics *iface,
+        HSTRING package_family, IApplicationData **value )
+{
+    TRACE( "iface %p, package family %s, value %p.\n", iface,
+            debugstr_hstring( package_family ), value );
+
+    if (value) *value = NULL;
+    if (!value) return E_POINTER;
+    if (!valid_package_family( package_family )) return E_INVALIDARG;
+    return application_data_create( package_family, value );
+}
+
+static const struct IApplicationDataManagerStaticsVtbl application_data_manager_vtbl =
+{
+    application_data_manager_QueryInterface,
+    application_data_manager_AddRef,
+    application_data_manager_Release,
+    application_data_manager_GetIids,
+    application_data_manager_GetRuntimeClassName,
+    application_data_manager_GetTrustLevel,
+    application_data_manager_CreateForPackageFamily,
+};
 
 static const struct IApplicationDataStaticsVtbl application_data_statics_vtbl =
 {
@@ -470,4 +1235,12 @@ static struct application_data_statics application_data_statics =
     1,
 };
 
+static struct application_data_manager_statics application_data_manager_statics =
+{
+    {&manager_factory_vtbl},
+    {&application_data_manager_vtbl},
+    1,
+};
+
 IActivationFactory *application_data_factory = &application_data_statics.IActivationFactory_iface;
+IActivationFactory *application_data_manager_factory = &application_data_manager_statics.IActivationFactory_iface;

--- a/dlls/windows.storage.applicationdata/applicationdata.c
+++ b/dlls/windows.storage.applicationdata/applicationdata.c
@@ -26,6 +26,8 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(data);
 
+LONG WINAPI GetCurrentPackageFamilyName( UINT32 *length, WCHAR *name );
+
 struct application_data_statics
 {
     IActivationFactory IActivationFactory_iface;
@@ -1177,11 +1179,42 @@ static HRESULT application_data_create( HSTRING package_family, IApplicationData
     return S_OK;
 }
 
+static HRESULT get_current_package_family( HSTRING *package_family )
+{
+    WCHAR *buffer;
+    UINT32 length = 0;
+    LONG status;
+    HRESULT hr;
+
+    *package_family = NULL;
+    status = GetCurrentPackageFamilyName( &length, NULL );
+    if (status == APPMODEL_ERROR_NO_PACKAGE) return S_FALSE;
+    if (status != ERROR_INSUFFICIENT_BUFFER) return HRESULT_FROM_WIN32( status );
+    if (!length || length > 256) return E_UNEXPECTED;
+    if (!(buffer = malloc( length * sizeof(*buffer) ))) return E_OUTOFMEMORY;
+    status = GetCurrentPackageFamilyName( &length, buffer );
+    if (status)
+        hr = HRESULT_FROM_WIN32( status );
+    else if (!length)
+        hr = E_UNEXPECTED;
+    else
+        hr = WindowsCreateString( buffer, length - 1, package_family );
+    free( buffer );
+    return hr;
+}
+
 static HRESULT WINAPI application_data_statics_get_Current( IApplicationDataStatics *iface, IApplicationData **value )
 {
+    HSTRING package_family = NULL;
+    HRESULT hr;
+
     TRACE( "iface %p, value %p\n", iface, value );
     if (!value) return E_INVALIDARG;
-    return application_data_create( NULL, value );
+    hr = get_current_package_family( &package_family );
+    if (FAILED(hr)) return hr;
+    hr = application_data_create( package_family, value );
+    WindowsDeleteString( package_family );
+    return hr;
 }
 
 static HRESULT WINAPI application_data_manager_GetRuntimeClassName( IApplicationDataManagerStatics *iface, HSTRING *name )

--- a/dlls/windows.storage.applicationdata/classes.idl
+++ b/dlls/windows.storage.applicationdata/classes.idl
@@ -22,7 +22,11 @@
 #pragma winrt ns_prefix
 
 import "windows.storage.idl";
+import "windows.management.core.idl";
 
 namespace Windows.Storage {
     runtimeclass ApplicationData;
+}
+namespace Windows.Management.Core {
+    runtimeclass ApplicationDataManager;
 }

--- a/dlls/windows.storage.applicationdata/main.c
+++ b/dlls/windows.storage.applicationdata/main.c
@@ -19,6 +19,7 @@
 
 #include "initguid.h"
 #include "private.h"
+#include "knownfolders.h"
 
 #include "wine/debug.h"
 
@@ -30,17 +31,28 @@ HRESULT WINAPI DllGetClassObject( REFCLSID clsid, REFIID riid, void **out )
     return CLASS_E_CLASSNOTAVAILABLE;
 }
 
+static BOOL hstring_equals( HSTRING string, const WCHAR *value )
+{
+    UINT32 length = WindowsGetStringLen( string );
+    SIZE_T value_length = wcslen( value );
+
+    return length == value_length && !memcmp( WindowsGetStringRawBuffer( string, NULL ), value,
+            length * sizeof(*value) );
+}
+
 HRESULT WINAPI DllGetActivationFactory( HSTRING classid, IActivationFactory **factory )
 {
-    const WCHAR *buffer = WindowsGetStringRawBuffer( classid, NULL );
-
     TRACE( "class %s, factory %p.\n", debugstr_hstring( classid ), factory );
 
+    if (!factory) return E_POINTER;
     *factory = NULL;
+    if (!classid) return CLASS_E_CLASSNOTAVAILABLE;
 
-    if (!wcscmp( buffer, RuntimeClass_Windows_Storage_ApplicationData ))
-        IActivationFactory_QueryInterface( application_data_factory, &IID_IActivationFactory, (void **)factory );
+    if (hstring_equals( classid, RuntimeClass_Windows_Storage_ApplicationData ))
+        return IActivationFactory_QueryInterface( application_data_factory, &IID_IActivationFactory, (void **)factory );
+    if (hstring_equals( classid, RuntimeClass_Windows_Management_Core_ApplicationDataManager ))
+        return IActivationFactory_QueryInterface( application_data_manager_factory, &IID_IActivationFactory,
+                (void **)factory );
 
-    if (*factory) return S_OK;
     return CLASS_E_CLASSNOTAVAILABLE;
 }

--- a/dlls/windows.storage.applicationdata/private.h
+++ b/dlls/windows.storage.applicationdata/private.h
@@ -35,8 +35,11 @@
 #include "windows.foundation.h"
 #define WIDL_using_Windows_Storage
 #include "windows.storage.h"
+#define WIDL_using_Windows_Management_Core
+#include "windows.management.core.h"
 
 extern IActivationFactory *application_data_factory;
+extern IActivationFactory *application_data_manager_factory;
 
 #define DEFINE_IINSPECTABLE_( pfx, iface_type, impl_type, impl_from, iface_mem, expr )             \
     static inline impl_type *impl_from( iface_type *iface )                                        \

--- a/dlls/windows.storage.applicationdata/tests/Makefile.in
+++ b/dlls/windows.storage.applicationdata/tests/Makefile.in
@@ -1,5 +1,5 @@
 TESTDLL = windows.storage.applicationdata.dll
-IMPORTS = combase
+IMPORTS = advapi32 combase
 
 SOURCES = \
 	data.c

--- a/dlls/windows.storage.applicationdata/tests/data.c
+++ b/dlls/windows.storage.applicationdata/tests/data.c
@@ -21,6 +21,7 @@
 
 #include "windef.h"
 #include "winbase.h"
+#include "winreg.h"
 #include "winstring.h"
 
 #include "roapi.h"
@@ -195,6 +196,147 @@ static HRESULT get_package_paths( const WCHAR *family, WCHAR **package_path, WCH
     return S_OK;
 }
 
+static void run_current_package_child( const char *output )
+{
+    static const WCHAR class_nameW[] = L"Windows.Storage.ApplicationData";
+    IApplicationDataStatics *statics = NULL;
+    IApplicationData *data = NULL;
+    IStorageFolder *folder = NULL;
+    IStorageItem *item = NULL;
+    IActivationFactory *factory = NULL;
+    HSTRING class_name = NULL, path = NULL;
+    WCHAR outputW[MAX_PATH] = {0};
+    DWORD written;
+    HANDLE file;
+    HRESULT hr;
+
+    if (!MultiByteToWideChar( CP_ACP, 0, output, -1, outputW, ARRAY_SIZE(outputW) )) return;
+    hr = WindowsCreateString( class_nameW, ARRAY_SIZE(class_nameW) - 1, &class_name );
+    if (FAILED(hr)) goto done;
+    hr = RoGetActivationFactory( class_name, &IID_IActivationFactory, (void **)&factory );
+    if (FAILED(hr)) goto done;
+    hr = IActivationFactory_QueryInterface( factory, &IID_IApplicationDataStatics, (void **)&statics );
+    if (FAILED(hr)) goto done;
+    hr = IApplicationDataStatics_get_Current( statics, &data );
+    if (FAILED(hr)) goto done;
+    hr = IApplicationData_get_LocalFolder( data, &folder );
+    if (FAILED(hr)) goto done;
+    hr = IStorageFolder_QueryInterface( folder, &IID_IStorageItem, (void **)&item );
+    if (FAILED(hr)) goto done;
+    hr = IStorageItem_get_Path( item, &path );
+    if (FAILED(hr) || !WindowsGetStringLen( path )) goto done;
+
+    file = CreateFileW( outputW, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, 0, NULL );
+    if (file != INVALID_HANDLE_VALUE)
+    {
+        WriteFile( file, WindowsGetStringRawBuffer( path, NULL ),
+                WindowsGetStringLen( path ) * sizeof(WCHAR), &written, NULL );
+        CloseHandle( file );
+    }
+
+done:
+    WindowsDeleteString( path );
+    if (item) IStorageItem_Release( item );
+    if (folder) IStorageFolder_Release( folder );
+    if (data) IApplicationData_Release( data );
+    if (statics) IApplicationDataStatics_Release( statics );
+    if (factory) IActivationFactory_Release( factory );
+    WindowsDeleteString( class_name );
+}
+
+static void test_current_package_local_folder(void)
+{
+    static const WCHAR key_name[] = L"Software\\Wine\\Appx\\StagedPackages";
+    WCHAR family[64], temp[MAX_PATH], root[MAX_PATH] = {0}, source[MAX_PATH], target[MAX_PATH] = {0};
+    WCHAR output[MAX_PATH] = {0}, command[3 * MAX_PATH], *package_path = NULL, *state_path = NULL;
+    STARTUPINFOW startup = {.cb = sizeof(startup)};
+    PROCESS_INFORMATION process;
+    WCHAR *returned_path = NULL;
+    HANDLE file = INVALID_HANDLE_VALUE;
+    HKEY key = NULL;
+    DWORD size, read, wait;
+    BOOL ret;
+    HRESULT hr;
+
+    if (strcmp( winetest_platform, "wine" ))
+    {
+        win_skip( "Wine staged-package bridge is unavailable on Windows.\n" );
+        return;
+    }
+    if (swprintf( family, ARRAY_SIZE(family), L"Wine.ApplicationData.Current.%lu_8wekyb3d8bbwe",
+            GetCurrentProcessId() ) < 0)
+        return;
+    if (FAILED(hr = get_package_paths( family, &package_path, &state_path ))) return;
+    if (!GetTempPathW( ARRAY_SIZE(temp), temp ) || !GetTempFileNameW( temp, L"wad", 0, root )) goto done;
+    DeleteFileW( root );
+    if (!CreateDirectoryW( root, NULL )) goto done;
+    GetModuleFileNameW( NULL, source, ARRAY_SIZE(source) );
+    swprintf( target, ARRAY_SIZE(target), L"%s\\current.exe", root );
+    if (!CopyFileW( source, target, FALSE )) goto done;
+    if (!GetTempFileNameW( temp, L"wad", 0, output )) goto done;
+    DeleteFileW( output );
+
+    if (RegCreateKeyExW( HKEY_LOCAL_MACHINE, key_name, 0, NULL, 0,
+            KEY_SET_VALUE | KEY_WOW64_64KEY, NULL, &key, NULL ))
+    {
+        win_skip( "Cannot stage the current-package child.\n" );
+        goto done;
+    }
+    if (RegSetValueExW( key, family, 0, REG_SZ, (const BYTE *)root,
+            (wcslen( root ) + 1) * sizeof(WCHAR) ))
+        goto done;
+
+    swprintf( command, ARRAY_SIZE(command), L"\"%s\" data current-package-child \"%s\"", target, output );
+    ret = CreateProcessW( target, command, NULL, NULL, FALSE, 0, NULL, root, &startup, &process );
+    ok( ret, "CreateProcessW failed, error %lu.\n", GetLastError() );
+    if (!ret) goto done;
+    wait = WaitForSingleObject( process.hProcess, 10000 );
+    ok( wait == WAIT_OBJECT_0, "Current-package child wait returned %#lx.\n", wait );
+    if (wait != WAIT_OBJECT_0)
+    {
+        TerminateProcess( process.hProcess, 1 );
+        WaitForSingleObject( process.hProcess, 1000 );
+    }
+    CloseHandle( process.hThread );
+    CloseHandle( process.hProcess );
+    if (wait != WAIT_OBJECT_0) goto done;
+
+    file = CreateFileW( output, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, 0, NULL );
+    ok( file != INVALID_HANDLE_VALUE, "Opening current-package output failed, error %lu.\n", GetLastError() );
+    if (file == INVALID_HANDLE_VALUE) goto done;
+    size = GetFileSize( file, NULL );
+    ok( size && size != INVALID_FILE_SIZE && size <= 32768 * sizeof(WCHAR) && !(size % sizeof(WCHAR)),
+            "Invalid current-package output size %lu.\n", size );
+    if (!size || size == INVALID_FILE_SIZE || size > 32768 * sizeof(WCHAR) || size % sizeof(WCHAR)) goto done;
+    returned_path = malloc( size + sizeof(*returned_path) );
+    if (!returned_path) goto done;
+    ret = ReadFile( file, returned_path, size, &read, NULL );
+    ok( ret && read == size, "Reading current-package output returned %d and %lu/%lu bytes.\n",
+            ret, read, size );
+    if (ret && read == size)
+    {
+        returned_path[size / sizeof(*returned_path)] = 0;
+        ok( !wcscmp( returned_path, state_path ), "Current LocalFolder returned %s, expected %s.\n",
+                debugstr_w(returned_path), debugstr_w(state_path) );
+    }
+
+done:
+    if (file != INVALID_HANDLE_VALUE) CloseHandle( file );
+    if (key)
+    {
+        RegDeleteValueW( key, family );
+        RegCloseKey( key );
+    }
+    if (output[0]) DeleteFileW( output );
+    if (target[0]) DeleteFileW( target );
+    if (root[0]) RemoveDirectoryW( root );
+    if (state_path) RemoveDirectoryW( state_path );
+    if (package_path) RemoveDirectoryW( package_path );
+    free( returned_path );
+    free( state_path );
+    free( package_path );
+}
+
 static HRESULT test_package_local_folder( IApplicationData *data, const WCHAR *family, IStorageFolder **survivor )
 {
     IStorageFolder *folder = NULL, *other = NULL;
@@ -363,9 +505,9 @@ static HRESULT test_package_local_folder( IApplicationData *data, const WCHAR *f
     hr = IStorageItem_get_DateCreated( item, NULL );
     ok( hr == E_POINTER, "DateCreated(NULL) returned %#lx.\n", hr );
 
-    other = (void *)0xdeadbeef;
+    other = NULL;
     hr = IApplicationData_get_LocalFolder( data, &other );
-    ok( hr == S_OK && other && other != folder, "second LocalFolder returned %#lx and %p (first %p).\n", hr, other, folder );
+    ok( hr == S_OK && other, "second LocalFolder returned %#lx and %p (first %p).\n", hr, other, folder );
     if (other)
     {
         hr = IStorageFolder_QueryInterface( other, &IID_IStorageItem, (void **)&other_item );
@@ -822,12 +964,23 @@ done:
 
 START_TEST(data)
 {
+    char **argv;
+    int argc;
     HRESULT hr;
 
+    argc = winetest_get_mainargs( &argv );
     hr = RoInitialize( RO_INIT_MULTITHREADED );
     ok( hr == S_OK, "RoInitialize failed, hr %#lx\n", hr );
 
+    if (argc == 4 && !strcmp( argv[2], "current-package-child" ))
+    {
+        run_current_package_child( argv[3] );
+        RoUninitialize();
+        return;
+    }
+
     test_ApplicationDataStatics();
+    test_current_package_local_folder();
     test_ApplicationDataManager();
 
     RoUninitialize();

--- a/dlls/windows.storage.applicationdata/tests/data.c
+++ b/dlls/windows.storage.applicationdata/tests/data.c
@@ -655,6 +655,8 @@ static void test_ApplicationDataManager(void)
         L"../foo_8wekyb3d8bbwe", L"Microsoft.OutlookForWindows_8wekyb3d8bbwE",
         L"Microsoft.OutlookForWindows_iiiiiiiiiiiii", L"Microsoft.OutlookForWindows_lllllllllllll",
         L"Microsoft.OutlookForWindows_ooooooooooooo", L"Microsoft.OutlookForWindows_uuuuuuuuuuuuu",
+        L"con_8wekyb3d8bbwe", L"CON.foo_8wekyb3d8bbwe", L"xn--foo_8wekyb3d8bbwe",
+        L"foo.xn--bar_8wekyb3d8bbwe",
         L"foo..bar_8wekyb3d8bbwe", L".foo_8wekyb3d8bbwe", L"foo._8wekyb3d8bbwe",
         L"foo\tbar_8wekyb3d8bbwe", L"foo\nbar_8wekyb3d8bbwe", L"foo" L"\x00e9" L"bar_8wekyb3d8bbwe",
         L"Microsoft.OutlookForWindows_8wekyb3d8bb_w e",

--- a/dlls/windows.storage.applicationdata/tests/data.c
+++ b/dlls/windows.storage.applicationdata/tests/data.c
@@ -30,6 +30,8 @@
 #include "windows.foundation.h"
 #define WIDL_using_Windows_Storage
 #include "windows.storage.h"
+#define WIDL_using_Windows_Management_Core
+#include "windows.management.core.h"
 
 #include "wine/test.h"
 
@@ -37,54 +39,785 @@
 static void check_interface_( unsigned int line, void *obj, const IID *iid )
 {
     IUnknown *iface = obj;
-    IUnknown *unk;
+    IUnknown *unk = NULL;
     HRESULT hr;
 
     hr = IUnknown_QueryInterface( iface, iid, (void **)&unk );
     ok_(__FILE__, line)( hr == S_OK, "got hr %#lx.\n", hr );
-    IUnknown_Release( unk );
+    if (unk) IUnknown_Release( unk );
 }
 
 static void test_ApplicationDataStatics(void)
 {
-    static const WCHAR *application_data_statics_name = L"Windows.Storage.ApplicationData";
-    IApplicationDataStatics *application_data_statics;
-    IApplicationData *application_data = NULL;
-    IActivationFactory *factory;
-    HSTRING str;
+    static const WCHAR name[] = L"Windows.Storage.ApplicationData";
+    IApplicationDataStatics *statics = NULL;
+    IApplicationData *data = NULL;
+    IApplicationDataContainer *settings = NULL, *child = NULL;
+    IMapView_HSTRING_ApplicationDataContainer *containers = NULL;
+    IStorageFolder *folder = NULL;
+    IActivationFactory *factory = NULL;
+    HSTRING class_name = NULL;
     HRESULT hr;
-    LONG ref;
 
-    hr = WindowsCreateString( application_data_statics_name, wcslen( application_data_statics_name ), &str );
+    hr = WindowsCreateString( name, ARRAY_SIZE(name) - 1, &class_name );
     ok( hr == S_OK, "got hr %#lx.\n", hr );
-
-    hr = RoGetActivationFactory( str, &IID_IActivationFactory, (void **)&factory );
-    WindowsDeleteString( str );
+    if (FAILED(hr)) return;
+    hr = RoGetActivationFactory( class_name, &IID_IActivationFactory, (void **)&factory );
+    WindowsDeleteString( class_name );
     ok( hr == S_OK || broken( hr == REGDB_E_CLASSNOTREG ), "got hr %#lx.\n", hr );
     if (hr == REGDB_E_CLASSNOTREG)
     {
-        win_skip( "%s runtimeclass not registered, skipping tests.\n", wine_dbgstr_w( application_data_statics_name ) );
+        win_skip( "%s runtimeclass not registered, skipping tests.\n", wine_dbgstr_w( name ) );
         return;
     }
+    if (FAILED(hr) || !factory) return;
 
     check_interface( factory, &IID_IUnknown );
     check_interface( factory, &IID_IInspectable );
     check_interface( factory, &IID_IAgileObject );
 
-    hr = IActivationFactory_QueryInterface( factory, &IID_IApplicationDataStatics, (void **)&application_data_statics );
-    ok( hr == S_OK, "got hr %#lx.\n", hr );
-
-    hr = IApplicationDataStatics_get_Current( application_data_statics, NULL );
+    hr = IActivationFactory_QueryInterface( factory, &IID_IApplicationDataStatics, (void **)&statics );
+    ok( hr == S_OK && statics != NULL, "got hr %#lx and statics %p.\n", hr, statics );
+    if (FAILED(hr) || !statics)
+    {
+        IActivationFactory_Release( factory );
+        return;
+    }
+    hr = IApplicationDataStatics_get_Current( statics, NULL );
     ok( hr == E_INVALIDARG, "got hr %#lx.\n", hr );
-    hr = IApplicationDataStatics_get_Current( application_data_statics, &application_data );
-    todo_wine ok( hr == 0x80073d54, "got hr %#lx.\n", hr );
-    todo_wine ok( !application_data, "got application_data %p.\n", application_data );
-    if (application_data) IApplicationData_Release( application_data );
+    hr = IApplicationDataStatics_get_Current( statics, &data );
+    ok( hr == S_OK && data != NULL, "got hr %#lx and data %p.\n", hr, data );
+    if (data)
+    {
+        hr = IApplicationData_get_LocalSettings( data, &settings );
+        ok( hr == S_OK && settings != NULL, "LocalSettings returned %#lx and %p.\n", hr, settings );
+        if (settings)
+        {
+            containers = (void *)0xdeadbeef;
+            hr = IApplicationDataContainer_get_Containers( settings, &containers );
+            ok( hr == E_NOTIMPL && !containers, "Containers returned %#lx and %p.\n", hr, containers );
+            if (containers) IMapView_HSTRING_ApplicationDataContainer_Release( containers );
+            child = (void *)0xdeadbeef;
+            hr = IApplicationDataContainer_CreateContainer( settings, NULL,
+                    ApplicationDataCreateDisposition_Always, &child );
+            ok( hr == E_NOTIMPL && !child, "CreateContainer returned %#lx and %p.\n", hr, child );
+            if (child) IApplicationDataContainer_Release( child );
+            IApplicationDataContainer_Release( settings );
+        }
+        folder = (void *)0xdeadbeef;
+        hr = IApplicationData_get_LocalFolder( data, &folder );
+        ok( hr == E_NOTIMPL && !folder, "Current LocalFolder returned %#lx and %p.\n", hr, folder );
+        IApplicationData_Release( data );
+    }
+    IApplicationDataStatics_Release( statics );
+    IActivationFactory_Release( factory );
+}
 
-    ref = IApplicationDataStatics_Release( application_data_statics );
-    ok( ref == 2, "got ref %ld.\n", ref );
-    ref = IActivationFactory_Release( factory );
-    ok( ref == 1, "got ref %ld.\n", ref );
+static BOOL iid_in_list( const IID *iids, ULONG count, REFIID iid )
+{
+    ULONG i;
+    for (i = 0; i < count; ++i) if (IsEqualGUID( &iids[i], iid )) return TRUE;
+    return FALSE;
+}
+
+static HRESULT create_hstring( const WCHAR *str, HSTRING *value )
+{
+    return WindowsCreateString( str, wcslen( str ), value );
+}
+
+static void test_embedded_null_activation( const WCHAR *name )
+{
+    IActivationFactory *factory = (void *)(ULONG_PTR)0xdeadbeef;
+    UINT32 length = wcslen( name );
+    WCHAR *invalid_name;
+    HSTRING class_name;
+    HRESULT hr;
+
+    invalid_name = malloc( (length + 5) * sizeof(*invalid_name) );
+    ok( !!invalid_name, "failed to allocate embedded-NUL class name.\n" );
+    if (!invalid_name) return;
+    memcpy( invalid_name, name, length * sizeof(*invalid_name) );
+    invalid_name[length] = 0;
+    memcpy( invalid_name + length + 1, L"junk", 4 * sizeof(*invalid_name) );
+    hr = WindowsCreateString( invalid_name, length + 5, &class_name );
+    free( invalid_name );
+    ok( hr == S_OK, "embedded-NUL class creation returned %#lx.\n", hr );
+    if (FAILED(hr)) return;
+
+    hr = RoGetActivationFactory( class_name, &IID_IActivationFactory, (void **)&factory );
+    ok( hr == CLASS_E_CLASSNOTAVAILABLE && !factory,
+            "%s embedded-NUL activation returned %#lx, %p.\n", wine_dbgstr_w( name ), hr, factory );
+    WindowsDeleteString( class_name );
+}
+
+static HRESULT get_package_paths( const WCHAR *family, WCHAR **package_path, WCHAR **state_path )
+{
+    WCHAR *local_appdata = NULL;
+    SIZE_T package_length, state_length;
+    DWORD local_length;
+    HRESULT hr;
+
+    *package_path = NULL;
+    *state_path = NULL;
+    if (!(local_appdata = malloc( 32768 * sizeof(*local_appdata) ))) return E_OUTOFMEMORY;
+    local_length = GetEnvironmentVariableW( L"LOCALAPPDATA", local_appdata, 32768 );
+    if (!local_length || local_length >= 32768)
+    {
+        hr = local_length >= 32768 ? HRESULT_FROM_WIN32( ERROR_INSUFFICIENT_BUFFER ) :
+                HRESULT_FROM_WIN32( GetLastError() );
+        free( local_appdata );
+        return hr;
+    }
+
+    package_length = wcslen(local_appdata) + wcslen(L"\\Packages\\") + wcslen(family) + 1;
+    state_length = package_length + wcslen(L"\\LocalState");
+    if (!(*package_path = malloc( package_length * sizeof(**package_path) )) ||
+        !(*state_path = malloc( state_length * sizeof(**state_path) )))
+    {
+        free( local_appdata );
+        free( *package_path );
+        free( *state_path );
+        *package_path = NULL;
+        *state_path = NULL;
+        return E_OUTOFMEMORY;
+    }
+    if (swprintf( *package_path, package_length, L"%s\\Packages\\%s", local_appdata, family ) < 0 ||
+        swprintf( *state_path, state_length, L"%s\\LocalState", *package_path ) < 0)
+    {
+        free( local_appdata );
+        free( *package_path );
+        free( *state_path );
+        *package_path = NULL;
+        *state_path = NULL;
+        return E_FAIL;
+    }
+    free( local_appdata );
+    return S_OK;
+}
+
+static HRESULT test_package_local_folder( IApplicationData *data, const WCHAR *family, IStorageFolder **survivor )
+{
+    IStorageFolder *folder = NULL, *other = NULL;
+    IStorageItem *item = NULL, *other_item = NULL;
+    IUnknown *folder_unknown = NULL, *item_unknown = NULL;
+    IAsyncOperation_StorageFile *file_operation = NULL;
+    IAsyncOperation_IVectorView_IStorageItem *items_operation = NULL;
+    IAsyncAction *action = NULL;
+    IAsyncOperation_BasicProperties *properties_operation = NULL;
+    IID *iids = NULL;
+    HSTRING name = NULL, path = NULL, other_path = NULL, runtime_name = NULL;
+    const WCHAR *path_buffer, *other_path_buffer;
+    static const WCHAR expected_name[] = L"LocalState";
+    static const WCHAR expected_class[] = L"Windows.Storage.StorageFolder";
+    WCHAR expected_suffix[128];
+    WCHAR *expected_path = NULL, *expected_package = NULL;
+    DateTime date;
+    FileAttributes attributes;
+    TrustLevel trust_level;
+    boolean is_type;
+    ULONG count;
+    UINT32 path_length;
+    SIZE_T suffix_length;
+    HRESULT hr, result = S_OK;
+
+    *survivor = NULL;
+    hr = get_package_paths( family, &expected_package, &expected_path );
+    ok( hr == S_OK, "get_package_paths returned %#lx.\n", hr );
+    if (FAILED(hr)) return hr;
+    if (swprintf( expected_suffix, ARRAY_SIZE(expected_suffix), L"\\Packages\\%s\\LocalState", family ) < 0)
+    {
+        free( expected_package );
+        free( expected_path );
+        return E_FAIL;
+    }
+
+    folder = (void *)0xdeadbeef;
+    hr = IApplicationData_get_LocalFolder( data, &folder );
+    ok( hr == S_OK && folder && folder != (void *)0xdeadbeef,
+            "LocalFolder returned %#lx and %p.\n", hr, folder );
+    if (FAILED(hr) || !folder || folder == (void *)0xdeadbeef)
+    {
+        result = hr;
+        goto done;
+    }
+
+    check_interface( folder, &IID_IUnknown );
+    check_interface( folder, &IID_IInspectable );
+    check_interface( folder, &IID_IAgileObject );
+    hr = IStorageFolder_QueryInterface( folder, &IID_IStorageItem, (void **)&item );
+    ok( hr == S_OK && item, "folder IStorageItem QI returned %#lx and %p.\n", hr, item );
+    if (FAILED(hr) || !item)
+    {
+        result = hr;
+        goto done;
+    }
+    check_interface( item, &IID_IUnknown );
+    check_interface( item, &IID_IInspectable );
+    check_interface( item, &IID_IAgileObject );
+
+    hr = IStorageFolder_QueryInterface( folder, &IID_IUnknown, (void **)&folder_unknown );
+    ok( hr == S_OK && folder_unknown, "folder IUnknown QI returned %#lx and %p.\n", hr, folder_unknown );
+    hr = IStorageItem_QueryInterface( item, &IID_IUnknown, (void **)&item_unknown );
+    ok( hr == S_OK && item_unknown, "item IUnknown QI returned %#lx and %p.\n", hr, item_unknown );
+    ok( folder_unknown && item_unknown && folder_unknown == item_unknown, "folder and item identities differ.\n" );
+    if (folder_unknown) IUnknown_Release( folder_unknown );
+    if (item_unknown) IUnknown_Release( item_unknown );
+
+    count = 99;
+    iids = (void *)0xdeadbeef;
+    hr = IStorageFolder_GetIids( folder, NULL, &iids );
+    ok( hr == E_POINTER && !iids, "folder GetIids(NULL,count) returned %#lx and %p.\n", hr, iids );
+    count = 99;
+    hr = IStorageFolder_GetIids( folder, &count, NULL );
+    ok( hr == E_POINTER && !count, "folder GetIids(NULL,iids) returned %#lx and %lu.\n", hr, count );
+    count = 99;
+    iids = (void *)0xdeadbeef;
+    hr = IStorageFolder_GetIids( folder, &count, &iids );
+    ok( hr == S_OK && count == 2 && iids && iid_in_list( iids, count, &IID_IStorageFolder ) &&
+            iid_in_list( iids, count, &IID_IStorageItem ), "folder GetIids returned %#lx, %lu, %p.\n", hr, count, iids );
+    if (iids != (void *)0xdeadbeef) CoTaskMemFree( iids );
+    iids = NULL;
+    count = 99;
+    hr = IStorageItem_GetIids( item, &count, &iids );
+    ok( hr == S_OK && count == 2 && iids && iid_in_list( iids, count, &IID_IStorageFolder ) &&
+            iid_in_list( iids, count, &IID_IStorageItem ), "item GetIids returned %#lx, %lu, %p.\n", hr, count, iids );
+    if (iids) CoTaskMemFree( iids );
+    iids = NULL;
+
+    runtime_name = (void *)0xdeadbeef;
+    hr = IStorageFolder_GetRuntimeClassName( folder, &runtime_name );
+    ok( hr == S_OK && runtime_name && !wcscmp( WindowsGetStringRawBuffer( runtime_name, NULL ), expected_class ),
+            "folder runtime class returned %#lx and %s.\n", hr, debugstr_hstring( runtime_name ) );
+    if (runtime_name) WindowsDeleteString( runtime_name );
+    runtime_name = NULL;
+    hr = IStorageItem_GetRuntimeClassName( item, &runtime_name );
+    ok( hr == S_OK && runtime_name && !wcscmp( WindowsGetStringRawBuffer( runtime_name, NULL ), expected_class ),
+            "item runtime class returned %#lx and %s.\n", hr, debugstr_hstring( runtime_name ) );
+    if (runtime_name) WindowsDeleteString( runtime_name );
+    runtime_name = NULL;
+    hr = IStorageFolder_GetTrustLevel( folder, &trust_level );
+    ok( hr == S_OK && trust_level == BaseTrust, "folder trust level returned %#lx and %u.\n", hr, trust_level );
+    hr = IStorageItem_GetTrustLevel( item, &trust_level );
+    ok( hr == S_OK && trust_level == BaseTrust, "item trust level returned %#lx and %u.\n", hr, trust_level );
+
+    name = (void *)0xdeadbeef;
+    hr = IStorageItem_get_Name( item, &name );
+    ok( hr == S_OK && name && !wcscmp( WindowsGetStringRawBuffer( name, NULL ), expected_name ),
+            "Name returned %#lx and %s.\n", hr, debugstr_hstring( name ) );
+    if (name) WindowsDeleteString( name );
+    name = NULL;
+    hr = IStorageItem_get_Name( item, NULL );
+    ok( hr == E_POINTER, "Name(NULL) returned %#lx.\n", hr );
+
+    path = (void *)0xdeadbeef;
+    hr = IStorageItem_get_Path( item, &path );
+    ok( hr == S_OK && path, "Path returned %#lx and %p.\n", hr, path );
+    if (path)
+    {
+        path_buffer = WindowsGetStringRawBuffer( path, &path_length );
+        suffix_length = wcslen( expected_suffix );
+        ok( !wcscmp( path_buffer, expected_path ), "Path %s differs from expected %s.\n",
+                debugstr_w(path_buffer), debugstr_w(expected_path) );
+        ok( path_length >= suffix_length && !wcscmp( path_buffer + path_length - suffix_length, expected_suffix ),
+                "Path %s lacks expected suffix.\n", debugstr_w(path_buffer) );
+        attributes = GetFileAttributesW( path_buffer );
+        ok( attributes != INVALID_FILE_ATTRIBUTES && (attributes & FILE_ATTRIBUTE_DIRECTORY),
+                "Path %s is not an existing directory, attributes %#x.\n", debugstr_w(path_buffer), attributes );
+        WindowsDeleteString( path );
+    }
+    path = NULL;
+    hr = IStorageItem_get_Path( item, NULL );
+    ok( hr == E_POINTER, "Path(NULL) returned %#lx.\n", hr );
+
+    attributes = (FileAttributes)0xdeadbeef;
+    hr = IStorageItem_get_Attributes( item, &attributes );
+    ok( hr == S_OK && attributes == FileAttributes_Directory, "Attributes returned %#lx and %#x.\n", hr, attributes );
+    hr = IStorageItem_get_Attributes( item, NULL );
+    ok( hr == E_POINTER, "Attributes(NULL) returned %#lx.\n", hr );
+    is_type = 2;
+    hr = IStorageItem_IsOfType( item, StorageItemTypes_Folder, &is_type );
+    ok( hr == S_OK && is_type, "IsOfType(Folder) returned %#lx and %d.\n", hr, is_type );
+    is_type = 2;
+    hr = IStorageItem_IsOfType( item, StorageItemTypes_File, &is_type );
+    ok( hr == S_OK && !is_type, "IsOfType(File) returned %#lx and %d.\n", hr, is_type );
+    hr = IStorageItem_IsOfType( item, StorageItemTypes_Folder, NULL );
+    ok( hr == E_POINTER, "IsOfType(NULL) returned %#lx.\n", hr );
+
+    file_operation = (void *)0xdeadbeef;
+    hr = IStorageFolder_CreateFileAsyncOverloadDefaultOptions( folder, NULL, &file_operation );
+    ok( hr == E_NOTIMPL && !file_operation, "CreateFileAsync returned %#lx and %p.\n", hr, file_operation );
+    hr = IStorageFolder_CreateFileAsyncOverloadDefaultOptions( folder, NULL, NULL );
+    ok( hr == E_POINTER, "CreateFileAsync(NULL) returned %#lx.\n", hr );
+    items_operation = (void *)0xdeadbeef;
+    hr = IStorageFolder_GetItemsAsyncOverloadDefaultStartAndCount( folder, &items_operation );
+    ok( hr == E_NOTIMPL && !items_operation, "GetItemsAsync returned %#lx and %p.\n", hr, items_operation );
+    action = (void *)0xdeadbeef;
+    hr = IStorageItem_RenameAsyncOverloadDefaultOptions( item, NULL, &action );
+    ok( hr == E_NOTIMPL && !action, "RenameAsync returned %#lx and %p.\n", hr, action );
+    properties_operation = (void *)0xdeadbeef;
+    hr = IStorageItem_GetBasicPropertiesAsync( item, &properties_operation );
+    ok( hr == E_NOTIMPL && !properties_operation, "GetBasicPropertiesAsync returned %#lx and %p.\n", hr, properties_operation );
+    date.UniversalTime = 0x1234;
+    hr = IStorageItem_get_DateCreated( item, &date );
+    ok( hr == E_NOTIMPL && !date.UniversalTime, "DateCreated returned %#lx and %I64x.\n", hr, date.UniversalTime );
+    hr = IStorageItem_get_DateCreated( item, NULL );
+    ok( hr == E_POINTER, "DateCreated(NULL) returned %#lx.\n", hr );
+
+    other = (void *)0xdeadbeef;
+    hr = IApplicationData_get_LocalFolder( data, &other );
+    ok( hr == S_OK && other && other != folder, "second LocalFolder returned %#lx and %p (first %p).\n", hr, other, folder );
+    if (other)
+    {
+        hr = IStorageFolder_QueryInterface( other, &IID_IStorageItem, (void **)&other_item );
+        ok( hr == S_OK && other_item, "second folder item QI returned %#lx and %p.\n", hr, other_item );
+        other_path = (void *)0xdeadbeef;
+        hr = other_item ? IStorageItem_get_Path( other_item, &other_path ) : E_FAIL;
+        other_path_buffer = other_path != (void *)0xdeadbeef && other_path ?
+                WindowsGetStringRawBuffer( other_path, NULL ) : NULL;
+        ok( hr == S_OK && other_path_buffer && !wcscmp( other_path_buffer, expected_path ),
+                "second folder Path returned %#lx and %s.\n", hr, debugstr_hstring( other_path ) );
+        if (other_path != (void *)0xdeadbeef && other_path) WindowsDeleteString( other_path );
+        other_path = NULL;
+        if (other_item) IStorageItem_Release( other_item );
+        other_item = NULL;
+    }
+
+    IStorageItem_Release( item );
+    item = NULL;
+    IStorageFolder_Release( folder );
+    folder = NULL;
+    *survivor = other;
+    other = NULL;
+
+ done:
+    if (iids && iids != (void *)0xdeadbeef) CoTaskMemFree( iids );
+    if (name) WindowsDeleteString( name );
+    if (path) WindowsDeleteString( path );
+    if (other_path) WindowsDeleteString( other_path );
+    if (runtime_name) WindowsDeleteString( runtime_name );
+    if (item) IStorageItem_Release( item );
+    if (other_item) IStorageItem_Release( other_item );
+    if (folder) IStorageFolder_Release( folder );
+    if (other) IStorageFolder_Release( other );
+    free( expected_package );
+    free( expected_path );
+    return result;
+}
+
+static void test_package_local_folder_reparse( IApplicationDataManagerStatics *manager )
+{
+    static const DWORD symlink_flags = SYMBOLIC_LINK_FLAG_DIRECTORY |
+            SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE;
+    WCHAR family_name[64], *package_path = NULL, *state_path = NULL, *outside_path = NULL;
+    WCHAR *outside_state = NULL;
+    IApplicationData *data = NULL;
+    IStorageFolder *folder = NULL;
+    HSTRING family = NULL;
+    SIZE_T length;
+    DWORD error;
+    HRESULT hr;
+    BOOL ret;
+    unsigned int scenario;
+
+    for (scenario = 0; scenario < 2; ++scenario)
+    {
+        if (swprintf( family_name, ARRAY_SIZE(family_name), L"Wine.AppData.Reparse.%u.%lu_8wekyb3d8bbwe",
+                scenario, GetCurrentProcessId() ) < 0)
+        {
+            ok( FALSE, "failed to construct reparse test package family.\n" );
+            return;
+        }
+        hr = get_package_paths( family_name, &package_path, &state_path );
+        ok( hr == S_OK, "get_package_paths returned %#lx.\n", hr );
+        if (FAILED(hr)) return;
+
+        length = wcslen(package_path) + wcslen(L".outside") + 1;
+        outside_path = malloc( length * sizeof(*outside_path) );
+        outside_state = malloc( (length + wcslen(L"\\LocalState")) * sizeof(*outside_state) );
+        if (!outside_path || !outside_state)
+        {
+            ok( FALSE, "failed to allocate reparse test paths.\n" );
+            goto cleanup;
+        }
+        swprintf( outside_path, length, L"%s.outside", package_path );
+        swprintf( outside_state, length + wcslen(L"\\LocalState"), L"%s\\LocalState", outside_path );
+
+        ret = CreateDirectoryW( outside_path, NULL );
+        ok( ret, "failed to create outside directory %s, error %lu.\n",
+                debugstr_w(outside_path), GetLastError() );
+        if (!ret) goto cleanup;
+        if (scenario)
+        {
+            ret = CreateDirectoryW( package_path, NULL );
+            ok( ret, "failed to create package directory %s, error %lu.\n",
+                    debugstr_w(package_path), GetLastError() );
+            if (!ret) goto cleanup;
+        }
+
+        ret = CreateSymbolicLinkW( scenario ? state_path : package_path, outside_path, symlink_flags );
+        error = ret ? ERROR_SUCCESS : GetLastError();
+        if (!ret && (error == ERROR_PRIVILEGE_NOT_HELD || error == ERROR_INVALID_PARAMETER))
+        {
+            win_skip( "directory symbolic links unavailable, error %lu.\n", error );
+            goto cleanup;
+        }
+        ok( ret, "failed to create directory symbolic link, error %lu.\n", error );
+        if (!ret) goto cleanup;
+
+        hr = create_hstring( family_name, &family );
+        ok( hr == S_OK, "got hr %#lx.\n", hr );
+        if (FAILED(hr)) goto cleanup;
+        hr = IApplicationDataManagerStatics_CreateForPackageFamily( manager, family, &data );
+        ok( hr == S_OK && data, "CreateForPackageFamily returned %#lx and %p.\n", hr, data );
+        if (FAILED(hr) || !data) goto cleanup;
+
+        folder = (void *)0xdeadbeef;
+        hr = IApplicationData_get_LocalFolder( data, &folder );
+        ok( FAILED(hr) && !folder, "reparse scenario %u returned %#lx and %p.\n", scenario, hr, folder );
+        if (folder && folder != (void *)0xdeadbeef) IStorageFolder_Release( folder );
+        folder = NULL;
+        if (!scenario)
+            ok( GetFileAttributesW( outside_state ) == INVALID_FILE_ATTRIBUTES,
+                    "package reparse created outside LocalState %s.\n", debugstr_w(outside_state) );
+
+cleanup:
+        if (folder && folder != (void *)0xdeadbeef) IStorageFolder_Release( folder );
+        if (data) IApplicationData_Release( data );
+        if (family) WindowsDeleteString( family );
+        if (outside_state) RemoveDirectoryW( outside_state );
+        if (scenario && state_path) RemoveDirectoryW( state_path );
+        if (!scenario && package_path) RemoveDirectoryW( package_path );
+        if (outside_path) RemoveDirectoryW( outside_path );
+        if (scenario && package_path) RemoveDirectoryW( package_path );
+        free( outside_state );
+        free( outside_path );
+        free( state_path );
+        free( package_path );
+        outside_state = outside_path = state_path = package_path = NULL;
+        family = NULL;
+        data = NULL;
+    }
+}
+
+static void test_ApplicationDataManager(void)
+{
+    static const WCHAR manager_name[] = L"Windows.Management.Core.ApplicationDataManager";
+    static const WCHAR application_name[] = L"Windows.Storage.ApplicationData";
+    static const WCHAR *invalid_families[] =
+    {
+        L"", L"_8wekyb3d8bbwe", L"Microsoft.OutlookForWindows_",
+        L"Ab_8wekyb3d8bbwe", L"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_8wekyb3d8bbwe",
+        L"Microsoft.OutlookForWindows8wekyb3d8bbwe",
+        L"Microsoft_OutlookForWindows_8wekyb3d8bbwe", L"Microsoft/Outlook_8wekyb3d8bbwe",
+        L"Microsoft\\Outlook_8wekyb3d8bbwe", L"Microsoft:Outlook_8wekyb3d8bbwe",
+        L"../foo_8wekyb3d8bbwe", L"Microsoft.OutlookForWindows_8wekyb3d8bbwE",
+        L"Microsoft.OutlookForWindows_iiiiiiiiiiiii", L"Microsoft.OutlookForWindows_lllllllllllll",
+        L"Microsoft.OutlookForWindows_ooooooooooooo", L"Microsoft.OutlookForWindows_uuuuuuuuuuuuu",
+        L"foo..bar_8wekyb3d8bbwe", L".foo_8wekyb3d8bbwe", L"foo._8wekyb3d8bbwe",
+        L"foo\tbar_8wekyb3d8bbwe", L"foo\nbar_8wekyb3d8bbwe", L"foo" L"\x00e9" L"bar_8wekyb3d8bbwe",
+        L"Microsoft.OutlookForWindows_8wekyb3d8bb_w e",
+    };
+    IApplicationDataManagerStatics *manager = NULL, *unexpected_manager_statics = NULL;
+    IApplicationDataManager *unexpected_manager = NULL;
+    IApplicationDataStatics *statics = NULL, *unexpected_statics = NULL;
+    IActivationFactory *manager_factory = NULL, *application_factory = NULL;
+    IUnknown *manager_unknown = NULL, *application_unknown = NULL;
+    IApplicationData *data = NULL, *other = NULL;
+    IApplicationDataContainer *settings = NULL;
+    IStorageFolder *survivor = NULL;
+    IStorageItem *survivor_item = NULL;
+    HSTRING survivor_path = NULL;
+    WCHAR *package_path = NULL, *state_path = NULL;
+    WCHAR valid_family[64];
+    BOOL package_existed = TRUE, state_existed = TRUE;
+    DWORD attributes;
+    IID *iids = NULL;
+    HSTRING class_name = NULL, family = NULL, value = NULL;
+    ULONG count;
+    HRESULT hr;
+    unsigned int i;
+
+    test_embedded_null_activation( application_name );
+    test_embedded_null_activation( manager_name );
+
+    if (swprintf( valid_family, ARRAY_SIZE(valid_family), L"Wine.ApplicationData.Test.%lu_8wekyb3d8bbwe",
+            GetCurrentProcessId() ) < 0)
+    {
+        ok( FALSE, "failed to construct a unique package family name.\n" );
+        return;
+    }
+
+    hr = create_hstring( manager_name, &class_name );
+    ok( hr == S_OK, "got hr %#lx.\n", hr );
+    if (FAILED(hr)) return;
+    hr = RoGetActivationFactory( class_name, &IID_IActivationFactory, (void **)&manager_factory );
+    ok( hr == S_OK || broken( hr == REGDB_E_CLASSNOTREG ), "manager activation returned %#lx.\n", hr );
+    WindowsDeleteString( class_name );
+    if (hr == REGDB_E_CLASSNOTREG)
+    {
+        win_skip( "%s runtimeclass not registered, skipping tests.\n", wine_dbgstr_w( manager_name ) );
+        return;
+    }
+    if (FAILED(hr) || !manager_factory) return;
+
+    hr = create_hstring( application_name, &class_name );
+    ok( hr == S_OK, "got hr %#lx.\n", hr );
+    if (FAILED(hr))
+    {
+        IActivationFactory_Release( manager_factory );
+        return;
+    }
+    hr = RoGetActivationFactory( class_name, &IID_IActivationFactory, (void **)&application_factory );
+    ok( hr == S_OK, "application activation returned %#lx.\n", hr );
+    WindowsDeleteString( class_name );
+    if (FAILED(hr) || !application_factory)
+    {
+        IActivationFactory_Release( manager_factory );
+        return;
+    }
+
+    value = NULL;
+    hr = IActivationFactory_GetRuntimeClassName( manager_factory, &value );
+    ok( hr == S_OK && value && !wcscmp( WindowsGetStringRawBuffer( value, NULL ), manager_name ),
+            "manager factory runtime name returned %#lx and %s.\n", hr, debugstr_hstring( value ) );
+    if (value) WindowsDeleteString( value );
+    value = NULL;
+    count = 99;
+    iids = (void *)0xdeadbeef;
+    hr = IActivationFactory_GetIids( manager_factory, &count, &iids );
+    ok( hr == S_OK && count == 1 && iids && iids != (void *)0xdeadbeef &&
+            IsEqualGUID( &iids[0], &IID_IApplicationDataManagerStatics ),
+            "manager factory GetIids returned %#lx, %lu, %p.\n", hr, count, iids );
+    if (iids != (void *)0xdeadbeef) CoTaskMemFree( iids );
+    iids = NULL;
+    unexpected_statics = (void *)0xdeadbeef;
+    hr = IActivationFactory_QueryInterface( manager_factory, &IID_IApplicationDataStatics,
+            (void **)&unexpected_statics );
+    ok( hr == E_NOINTERFACE && unexpected_statics == NULL,
+            "manager factory application statics QI returned %#lx and %p.\n", hr, unexpected_statics );
+    unexpected_manager = (void *)0xdeadbeef;
+    hr = IActivationFactory_QueryInterface( manager_factory, &IID_IApplicationDataManager,
+            (void **)&unexpected_manager );
+    ok( hr == E_NOINTERFACE && unexpected_manager == NULL,
+            "manager factory default interface QI returned %#lx and %p.\n", hr, unexpected_manager );
+
+    value = NULL;
+    hr = IActivationFactory_GetRuntimeClassName( application_factory, &value );
+    ok( hr == S_OK && value && !wcscmp( WindowsGetStringRawBuffer( value, NULL ), application_name ),
+            "application factory runtime name returned %#lx and %s.\n", hr, debugstr_hstring( value ) );
+    if (value) WindowsDeleteString( value );
+    value = NULL;
+    count = 99;
+    iids = (void *)0xdeadbeef;
+    hr = IActivationFactory_GetIids( application_factory, &count, &iids );
+    ok( hr == S_OK && count == 1 && iids && iids != (void *)0xdeadbeef &&
+            IsEqualGUID( &iids[0], &IID_IApplicationDataStatics ),
+            "application factory GetIids returned %#lx, %lu, %p.\n", hr, count, iids );
+    if (iids != (void *)0xdeadbeef) CoTaskMemFree( iids );
+    iids = NULL;
+    unexpected_manager_statics = (void *)0xdeadbeef;
+    hr = IActivationFactory_QueryInterface( application_factory, &IID_IApplicationDataManagerStatics,
+            (void **)&unexpected_manager_statics );
+    ok( hr == E_NOINTERFACE && unexpected_manager_statics == NULL,
+            "application factory manager statics QI returned %#lx and %p.\n", hr, unexpected_manager_statics );
+
+    hr = IActivationFactory_QueryInterface( manager_factory, &IID_IApplicationDataManagerStatics, (void **)&manager );
+    ok( hr == S_OK && manager != NULL, "manager QI returned %#lx and %p.\n", hr, manager );
+    if (FAILED(hr) || !manager)
+    {
+        IActivationFactory_Release( application_factory );
+        IActivationFactory_Release( manager_factory );
+        return;
+    }
+    hr = IActivationFactory_QueryInterface( application_factory, &IID_IApplicationDataStatics, (void **)&statics );
+    ok( hr == S_OK && statics != NULL, "statics QI returned %#lx and %p.\n", hr, statics );
+    if (FAILED(hr) || !statics)
+    {
+        IApplicationDataManagerStatics_Release( manager );
+        IActivationFactory_Release( application_factory );
+        IActivationFactory_Release( manager_factory );
+        return;
+    }
+    check_interface( manager, &IID_IUnknown );
+    check_interface( manager, &IID_IInspectable );
+    check_interface( manager, &IID_IAgileObject );
+    value = NULL;
+    hr = IApplicationDataManagerStatics_GetRuntimeClassName( manager, &value );
+    ok( hr == S_OK && value && !wcscmp( WindowsGetStringRawBuffer( value, NULL ), manager_name ),
+            "manager runtime name returned %#lx and %s.\n", hr, debugstr_hstring( value ) );
+    if (value) WindowsDeleteString( value );
+
+    hr = IApplicationDataManagerStatics_QueryInterface( manager, &IID_IUnknown, (void **)&manager_unknown );
+    ok( hr == S_OK && manager_unknown != NULL, "manager IUnknown QI returned %#lx and %p.\n", hr, manager_unknown );
+    hr = IActivationFactory_QueryInterface( application_factory, &IID_IUnknown, (void **)&application_unknown );
+    ok( hr == S_OK && application_unknown != NULL, "factory IUnknown QI returned %#lx and %p.\n", hr, application_unknown );
+    ok( manager_unknown && application_unknown && manager_unknown != application_unknown,
+            "manager and application factories unexpectedly share identity.\n" );
+    if (manager_unknown) IUnknown_Release( manager_unknown );
+    if (application_unknown) IUnknown_Release( application_unknown );
+
+    count = 99;
+    iids = (void *)0xdeadbeef;
+    hr = IApplicationDataManagerStatics_GetIids( manager, &count, &iids );
+    ok( hr == S_OK, "manager GetIids returned %#lx.\n", hr );
+    if (hr == S_OK && iids != (void *)0xdeadbeef && iids)
+    {
+        ok( count == 1 && iid_in_list( iids, count, &IID_IApplicationDataManagerStatics ),
+                "unexpected manager interface metadata.\n" );
+    }
+    else if (hr == S_OK)
+        ok( FALSE, "manager GetIids returned an invalid output.\n" );
+    if (iids != (void *)0xdeadbeef) CoTaskMemFree( iids );
+
+    data = (void *)0xdeadbeef;
+    hr = IApplicationDataManagerStatics_CreateForPackageFamily( manager, NULL, &data );
+    ok( hr == E_INVALIDARG && !data, "NULL family returned %#lx and data %p.\n", hr, data );
+    hr = IApplicationDataManagerStatics_CreateForPackageFamily( manager, NULL, NULL );
+    ok( hr == E_POINTER, "NULL output returned %#lx.\n", hr );
+
+    hr = create_hstring( valid_family, &family );
+    ok( hr == S_OK, "got hr %#lx.\n", hr );
+    if (FAILED(hr)) goto done;
+    hr = get_package_paths( valid_family, &package_path, &state_path );
+    ok( hr == S_OK, "get_package_paths returned %#lx.\n", hr );
+    if (FAILED(hr)) goto done;
+    attributes = GetFileAttributesW( package_path );
+    package_existed = attributes != INVALID_FILE_ATTRIBUTES && (attributes & FILE_ATTRIBUTE_DIRECTORY);
+    attributes = GetFileAttributesW( state_path );
+    state_existed = attributes != INVALID_FILE_ATTRIBUTES && (attributes & FILE_ATTRIBUTE_DIRECTORY);
+    data = NULL;
+    hr = IApplicationDataManagerStatics_CreateForPackageFamily( manager, family, &data );
+    ok( hr == S_OK && data != NULL, "valid family returned %#lx and data %p.\n", hr, data );
+    if (FAILED(hr) || !data) goto done;
+    check_interface( data, &IID_IAgileObject );
+    other = NULL;
+    hr = IApplicationDataManagerStatics_CreateForPackageFamily( manager, family, &other );
+    ok( hr == S_OK && other != NULL && other != data, "second object returned %#lx, %p (first %p).\n", hr, other, data );
+    if (FAILED(hr) || !other) goto done;
+    WindowsDeleteString( family );
+    family = NULL;
+
+    settings = (void *)0xdeadbeef;
+    hr = IApplicationData_get_LocalSettings( data, &settings );
+    ok( hr == E_NOTIMPL && !settings, "package LocalSettings returned %#lx and %p.\n", hr, settings );
+    {
+        UINT32 version = 0xdeadbeef;
+        IAsyncAction *operation = (void *)0xdeadbeef;
+        IApplicationDataContainer *roaming_settings = (void *)0xdeadbeef;
+        IStorageFolder *roaming_folder = (void *)0xdeadbeef, *temporary_folder = (void *)0xdeadbeef;
+        EventRegistrationToken token = {0xdeadbeef};
+        UINT64 quota = 0xdeadbeef;
+
+        hr = IApplicationData_get_Version( data, &version );
+        ok( hr == E_NOTIMPL && !version, "Version returned %#lx and %#x.\n", hr, version );
+        hr = IApplicationData_SetVersionAsync( data, 1, NULL, &operation );
+        ok( hr == E_NOTIMPL && !operation, "SetVersionAsync returned %#lx and %p.\n", hr, operation );
+        hr = IApplicationData_ClearAllAsync( data, &operation );
+        ok( hr == E_NOTIMPL && !operation, "ClearAllAsync returned %#lx and %p.\n", hr, operation );
+        hr = IApplicationData_ClearAsync( data, ApplicationDataLocality_Local, &operation );
+        ok( hr == E_NOTIMPL && !operation, "ClearAsync returned %#lx and %p.\n", hr, operation );
+        hr = IApplicationData_get_RoamingSettings( data, &roaming_settings );
+        ok( hr == E_NOTIMPL && !roaming_settings, "RoamingSettings returned %#lx and %p.\n", hr, roaming_settings );
+        hr = IApplicationData_get_RoamingFolder( data, &roaming_folder );
+        ok( hr == E_NOTIMPL && !roaming_folder, "RoamingFolder returned %#lx and %p.\n", hr, roaming_folder );
+        hr = IApplicationData_get_TemporaryFolder( data, &temporary_folder );
+        ok( hr == E_NOTIMPL && !temporary_folder, "TemporaryFolder returned %#lx and %p.\n", hr, temporary_folder );
+        hr = IApplicationData_add_DataChanged( data, NULL, &token );
+        ok( hr == E_NOTIMPL && !token.value, "DataChanged returned %#lx and %#I64x.\n", hr, token.value );
+        hr = IApplicationData_get_RoamingStorageQuota( data, &quota );
+        ok( hr == E_NOTIMPL && !quota, "RoamingStorageQuota returned %#lx and %#I64x.\n", hr, quota );
+    }
+    hr = test_package_local_folder( data, valid_family, &survivor );
+    ok( hr == S_OK && survivor, "package LocalFolder tests returned %#lx and %p.\n", hr, survivor );
+    IApplicationDataManagerStatics_Release( manager );
+    manager = NULL;
+    IActivationFactory_Release( manager_factory );
+    manager_factory = NULL;
+    settings = (void *)0xdeadbeef;
+    hr = IApplicationData_get_LocalSettings( other, &settings );
+    ok( hr == E_NOTIMPL && !settings, "surviving package LocalSettings returned %#lx and %p.\n", hr, settings );
+    IApplicationData_Release( other );
+    other = NULL;
+    IApplicationData_Release( data );
+    data = NULL;
+    IApplicationDataStatics_Release( statics );
+    statics = NULL;
+    IActivationFactory_Release( application_factory );
+    application_factory = NULL;
+
+    if (survivor)
+    {
+        survivor_item = NULL;
+        survivor_path = NULL;
+        hr = IStorageFolder_QueryInterface( survivor, &IID_IStorageItem, (void **)&survivor_item );
+        ok( hr == S_OK && survivor_item, "surviving folder item QI returned %#lx and %p.\n", hr, survivor_item );
+        if (survivor_item)
+        {
+            hr = IStorageItem_get_Path( survivor_item, &survivor_path );
+            ok( hr == S_OK && survivor_path && !wcscmp( WindowsGetStringRawBuffer( survivor_path, NULL ), state_path ),
+                    "surviving folder Path returned %#lx and %s.\n", hr, debugstr_hstring( survivor_path ) );
+            if (survivor_path) WindowsDeleteString( survivor_path );
+            survivor_path = NULL;
+            IStorageItem_Release( survivor_item );
+            survivor_item = NULL;
+        }
+        IStorageFolder_Release( survivor );
+        survivor = NULL;
+    }
+
+    hr = create_hstring( manager_name, &class_name );
+    ok( hr == S_OK, "got hr %#lx.\n", hr );
+    if (FAILED(hr)) goto done;
+    hr = RoGetActivationFactory( class_name, &IID_IActivationFactory, (void **)&manager_factory );
+    ok( hr == S_OK && manager_factory, "reacquiring manager factory returned %#lx and %p.\n", hr, manager_factory );
+    WindowsDeleteString( class_name );
+    class_name = NULL;
+    if (FAILED(hr) || !manager_factory) goto done;
+    hr = IActivationFactory_QueryInterface( manager_factory, &IID_IApplicationDataManagerStatics, (void **)&manager );
+    ok( hr == S_OK && manager != NULL, "reacquired manager QI returned %#lx and %p.\n", hr, manager );
+    if (FAILED(hr) || !manager) goto done;
+
+    test_package_local_folder_reparse( manager );
+
+    for (i = 0; i < ARRAY_SIZE(invalid_families); ++i)
+    {
+        value = NULL;
+        hr = create_hstring( invalid_families[i], &value );
+        ok( hr == S_OK, "got hr %#lx for invalid family %u.\n", hr, i );
+        if (FAILED(hr))
+        {
+            if (value) WindowsDeleteString( value );
+            continue;
+        }
+        data = (void *)0xdeadbeef;
+        hr = IApplicationDataManagerStatics_CreateForPackageFamily( manager, value, &data );
+        ok( hr == E_INVALIDARG && !data, "invalid family %u returned %#lx and %p.\n", i, hr, data );
+        if (data != (void *)0xdeadbeef && data) IApplicationData_Release( data );
+        WindowsDeleteString( value );
+    }
+    IApplicationDataManagerStatics_Release( manager );
+    manager = NULL;
+    IActivationFactory_Release( manager_factory );
+    if (state_path && !state_existed) RemoveDirectoryW( state_path );
+    if (package_path && !package_existed) RemoveDirectoryW( package_path );
+    free( state_path );
+    free( package_path );
+    return;
+
+done:
+    if (family) WindowsDeleteString( family );
+    if (other) IApplicationData_Release( other );
+    if (data && data != (void *)0xdeadbeef) IApplicationData_Release( data );
+    if (statics) IApplicationDataStatics_Release( statics );
+    if (manager) IApplicationDataManagerStatics_Release( manager );
+    if (application_factory) IActivationFactory_Release( application_factory );
+    if (manager_factory) IActivationFactory_Release( manager_factory );
+    if (survivor_item) IStorageItem_Release( survivor_item );
+    if (survivor) IStorageFolder_Release( survivor );
+    if (state_path && !state_existed) RemoveDirectoryW( state_path );
+    if (package_path && !package_existed) RemoveDirectoryW( package_path );
+    free( state_path );
+    free( package_path );
 }
 
 START_TEST(data)
@@ -95,6 +828,7 @@ START_TEST(data)
     ok( hr == S_OK, "RoInitialize failed, hr %#lx\n", hr );
 
     test_ApplicationDataStatics();
+    test_ApplicationDataManager();
 
     RoUninitialize();
 }

--- a/dlls/windows.storage.applicationdata/tests/data.c
+++ b/dlls/windows.storage.applicationdata/tests/data.c
@@ -44,7 +44,7 @@ static void check_interface_( unsigned int line, void *obj, const IID *iid )
     HRESULT hr;
 
     hr = IUnknown_QueryInterface( iface, iid, (void **)&unk );
-    ok_(__FILE__, line)( hr == S_OK, "got hr %#lx.\n", hr );
+    ok_(__FILE__, line)( hr == S_OK && unk, "got hr %#lx and interface %p.\n", hr, unk );
     if (unk) IUnknown_Release( unk );
 }
 
@@ -546,6 +546,67 @@ static HRESULT test_package_local_folder( IApplicationData *data, const WCHAR *f
     return result;
 }
 
+struct local_folder_thread_context
+{
+    IApplicationData *data;
+    HANDLE start;
+    IStorageFolder *folder;
+    HRESULT hr;
+};
+
+static DWORD WINAPI local_folder_thread( void *arg )
+{
+    struct local_folder_thread_context *context = arg;
+
+    if (WaitForSingleObject( context->start, 30000 ) != WAIT_OBJECT_0)
+    {
+        context->hr = HRESULT_FROM_WIN32( ERROR_TIMEOUT );
+        return 0;
+    }
+    context->hr = IApplicationData_get_LocalFolder( context->data, &context->folder );
+    return 0;
+}
+
+static void test_package_local_folder_concurrent( IApplicationData *data, IApplicationData *other )
+{
+    struct local_folder_thread_context contexts[4] = {0};
+    HANDLE threads[ARRAY_SIZE(contexts)] = {0}, start;
+    DWORD wait;
+    unsigned int count, i;
+
+    start = CreateEventW( NULL, TRUE, FALSE, NULL );
+    ok( !!start, "CreateEventW failed, error %lu.\n", GetLastError() );
+    if (!start) return;
+
+    for (count = 0; count < ARRAY_SIZE(contexts); ++count)
+    {
+        contexts[count].data = count & 1 ? other : data;
+        contexts[count].start = start;
+        contexts[count].hr = E_FAIL;
+        threads[count] = CreateThread( NULL, 0, local_folder_thread, &contexts[count], 0, NULL );
+        ok( !!threads[count], "CreateThread %u failed, error %lu.\n", count, GetLastError() );
+        if (!threads[count]) break;
+    }
+    SetEvent( start );
+    if (count)
+    {
+        wait = WaitForMultipleObjects( count, threads, TRUE, 35000 );
+        ok( wait == WAIT_OBJECT_0,
+                "Concurrent LocalFolder wait returned %#lx, error %lu.\n", wait, GetLastError() );
+        if (wait != WAIT_OBJECT_0)
+            WaitForMultipleObjects( count, threads, TRUE, INFINITE );
+    }
+    for (i = 0; i < count; ++i)
+    {
+        ok( contexts[i].hr == S_OK && contexts[i].folder,
+                "Concurrent LocalFolder %u returned %#lx and %p.\n",
+                i, contexts[i].hr, contexts[i].folder );
+        if (contexts[i].folder) IStorageFolder_Release( contexts[i].folder );
+        CloseHandle( threads[i] );
+    }
+    CloseHandle( start );
+}
+
 static void test_package_local_folder_reparse( IApplicationDataManagerStatics *manager )
 {
     static const DWORD symlink_flags = SYMBOLIC_LINK_FLAG_DIRECTORY |
@@ -871,6 +932,7 @@ static void test_ApplicationDataManager(void)
         hr = IApplicationData_get_RoamingStorageQuota( data, &quota );
         ok( hr == E_NOTIMPL && !quota, "RoamingStorageQuota returned %#lx and %#I64x.\n", hr, quota );
     }
+    test_package_local_folder_concurrent( data, other );
     hr = test_package_local_folder( data, valid_family, &survivor );
     ok( hr == S_OK && survivor, "package LocalFolder tests returned %#lx and %p.\n", hr, survivor );
     IApplicationDataManagerStatics_Release( manager );


### PR DESCRIPTION
## Stack

PR 2 of 8. Stacked on #25; merge only after #25.

## Summary

- Implement package-scoped `ApplicationData` and `LocalFolder` behavior.
- Add safe package-family validation and reparse-point containment.
- Implement the `EducationSettings` environment query used during startup.
- Add focused ApplicationData and AppCore regression coverage.

## Functional boundary

Includes package-local storage and environment probes.

Excludes user profile contracts from #25 and all DOM, manager, DirectComposition, and Wayland work from later PRs.

## Validation

- `git diff --check` passes.
- Reconstructed from the validated final integration tree with exact file content.
- The original combined-WoW64 validation passed ApplicationData and AppCore regressions on x86_64 and i386.

## Provenance

- Base branch: `feature/outlook-new-01-winrt-system`.
- Reconstructed from final integration HEAD `cf77f3b43ce5981bac562d692d25c74dc1ed6be1`.
- The original dirty integration worktree was not modified.

## Review notes

This PR deliberately returns honest unsupported results for unavailable package-local facilities instead of exposing process-global fallback state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Implement WinRT application-environment probes for package-local application data and education-environment detection.

New Features:
- Implement package-scoped ApplicationData instances with package-family creation and local-folder discovery.
- Expose the ApplicationDataManager runtime class for validated package-family probes.
- Add the EducationSettings environment query used by application startup.

Bug Fixes:
- Prevent activation of runtime classes from accepting embedded-NUL names and improve invalid output handling.
- Reject unsafe package-family identifiers and prevent package-local storage from traversing reparse points.

Enhancements:
- Return honest unsupported results for package-local facilities that are not implemented instead of using process-global fallback state.
- Improve WinRT activation-factory metadata, interface identity, and argument validation across the affected components.

Build:
- Add the required ntdll, shell32, and advapi32 dependencies and include the new EducationSettings source.

Documentation:
- Document packaged Office access to local application-data folders and education-environment state in the changelog.

Tests:
- Expand ApplicationData coverage for package-local folders, package-family validation, reparse-point containment, concurrency, interface metadata, and unsupported contracts.
- Add EducationSettings activation, metadata, lifetime, argument-validation, and environment-query regression tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for detecting education-environment status.
  * Added `ApplicationDataManager` support for accessing package-specific application data.
  * Expanded application data support with package local storage folders and containers.
  * Improved discovery of local application-data folders for packaged Office components.
* **Bug Fixes**
  * Improved activation validation, output handling, runtime class identification, and invalid-input reporting.
  * Added safeguards for invalid storage paths and unsupported operations.
* **Tests**
  * Expanded coverage for activation, storage behavior, cleanup, metadata, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->