### PR TITLE
mshtml: Implement MutationObserver delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Let modern Office identify the current user without exposing machine, account,
+  or application identifiers.
+- Let packaged Office components discover their local application-data folders
+  and education-environment state.
+- Let modern Office web views observe text and child-node changes reliably.
+
 ## 0.2.0-beta.1 — 2026-08-19
 
 - Let Office finish proofing-language updates without crashing Click-to-Run.

--- a/dlls/jscript/jscript.c
+++ b/dlls/jscript/jscript.c
@@ -1477,6 +1477,34 @@ static HRESULT WINAPI WineJScript_CreateObject(IWineJScript *iface, IWineJSDispa
     return hres;
 }
 
+static HRESULT WINAPI WineJScript_CreateArray(IWineJScript *iface, DWORD length, IWineJSDispatch **ret)
+{
+    JScript *This = impl_from_IWineJScript(iface);
+    jsdisp_t *array;
+    HRESULT hres;
+
+    if (!ret) return E_POINTER;
+    *ret = NULL;
+    hres = create_array(This->ctx, length, &array);
+    if (SUCCEEDED(hres)) *ret = &array->IWineJSDispatch_iface;
+    return hres;
+}
+
+static HRESULT WINAPI WineJScript_IsCallable(IWineJScript *iface, IDispatch *dispatch, BOOL *ret)
+{
+    jsdisp_t *jsdisp;
+
+    if (!ret) return E_POINTER;
+    *ret = FALSE;
+    if (!dispatch) return E_INVALIDARG;
+    if ((jsdisp = iface_to_jsdisp(dispatch)))
+    {
+        *ret = is_class(jsdisp, JSCLASS_FUNCTION);
+        jsdisp_release(jsdisp);
+    }
+    return S_OK;
+}
+
 static HRESULT WINAPI WineJScript_CreateArrayBuffer(IWineJScript *iface, DWORD size, IWineJSDispatch **arraybuf, void **data)
 {
     JScript *This = impl_from_IWineJScript(iface);
@@ -1498,6 +1526,8 @@ static const IWineJScriptVtbl WineJScriptVtbl = {
     WineJScript_CreateObject,
     WineJScript_CreateArrayBuffer,
     WineJScript_FillGlobals,
+    WineJScript_CreateArray,
+    WineJScript_IsCallable,
 };
 
 HRESULT create_jscript_object(BOOL is_encode, REFIID riid, void **ppv)

--- a/dlls/jscript/jsdisp.idl
+++ b/dlls/jscript/jsdisp.idl
@@ -97,4 +97,6 @@ interface IWineJScript : IUnknown
     HRESULT CreateObject(IWineJSDispatch **ret);
     HRESULT CreateArrayBuffer(DWORD size, IWineJSDispatch **ret, void **data);
     HRESULT FillGlobals(IWineJSDispatchHost *script_global);
+    HRESULT CreateArray(DWORD length, IWineJSDispatch **ret);
+    HRESULT IsCallable(IDispatch *dispatch, BOOL *ret);
 }

--- a/dlls/mshtml/htmlnode.c
+++ b/dlls/mshtml/htmlnode.c
@@ -87,7 +87,7 @@ static HRESULT WINAPI HTMLDOMChildrenCollection_item(IHTMLDOMChildrenCollection 
 
     nsIDOMNodeList_GetLength(This->nslist, &length);
     if(index < 0 || index >= length)
-        return E_INVALIDARG;
+        return S_OK;
 
     return HTMLDOMChildrenCollection_collection_item(&This->dispex, index, ppItem);
 }

--- a/dlls/mshtml/mutation.c
+++ b/dlls/mshtml/mutation.c
@@ -1327,7 +1327,7 @@ static nsresult NSAPI mutation_node_list_Item(nsIDOMNodeList *iface, UINT32 inde
         return NS_ERROR_FAILURE;
     *ret = NULL;
     if(index >= This->count)
-        return NS_ERROR_FAILURE;
+        return NS_OK;
 
     nsIDOMNode_AddRef(This->nodes[index]);
     *ret = This->nodes[index];
@@ -1447,7 +1447,8 @@ static void mutation_observer_restore_records(struct mutation_observer *This, st
     }
 }
 
-static HRESULT mutation_observer_create_array(struct mutation_observer *This, IWineJSDispatch **ret)
+static HRESULT mutation_observer_create_array(struct mutation_observer *This, DWORD length,
+        IWineJSDispatch **ret)
 {
     HTMLInnerWindow *window;
     HRESULT hres;
@@ -1460,7 +1461,7 @@ static HRESULT mutation_observer_create_array(struct mutation_observer *This, IW
         return E_UNEXPECTED;
     }
 
-    hres = IWineJScript_CreateArray(window->jscript, 0, ret);
+    hres = IWineJScript_CreateArray(window->jscript, length, ret);
     IHTMLWindow2_Release(&window->base.IHTMLWindow2_iface);
     return hres;
 }
@@ -1611,7 +1612,7 @@ static HRESULT mutation_observer_create_records(struct mutation_observer *This, 
     HRESULT hres;
 
     *ret = NULL;
-    hres = mutation_observer_create_array(This, &array);
+    hres = mutation_observer_create_array(This, list_count(&This->records), &array);
     if(FAILED(hres))
         return hres;
 
@@ -1857,7 +1858,8 @@ static nsresult mutation_observer_deliver(HTMLDocumentNode *doc, nsISupports *ar
     hres = mutation_observer_create_records(This, &records);
     if(FAILED(hres)) {
         WARN("Could not create MutationObserver records array: %08lx\n", hres);
-        mutation_observer_schedule(This);
+        if(hres == E_UNEXPECTED)
+            mutation_observer_clear_records(This);
         return NS_OK;
     }
 
@@ -2544,8 +2546,6 @@ static void mutation_observer_traverse(DispatchEx *dispex, nsCycleCollectionTrav
 
     if(This->callback)
         note_cc_edge((nsISupports*)This->callback, "callback", cb);
-    if(This->delivery_pending)
-        note_cc_edge((nsISupports*)&This->nsIMutationObserver_iface, "scheduled_runner", cb);
     LIST_FOR_EACH_ENTRY(target, &This->targets, struct mutation_observer_target, entry) {
         note_cc_edge((nsISupports*)&target->node->IHTMLDOMNode_iface, "target", cb);
         note_cc_edge((nsISupports*)target->native_node, "native_target", cb);

--- a/dlls/mshtml/mutation.c
+++ b/dlls/mshtml/mutation.c
@@ -1167,8 +1167,8 @@ struct mutation_observer_record {
 };
 
 struct mutation_observer_runner {
-    nsISupports nsISupports_iface;
-    LONG ref;
+    task_t task;
+    struct mutation_observer *observer;
     ULONG generation;
 };
 
@@ -1202,11 +1202,6 @@ static inline struct mutation_observer *impl_from_nsIMutationObserver(nsIMutatio
     return CONTAINING_RECORD(iface, struct mutation_observer, nsIMutationObserver_iface);
 }
 
-static inline struct mutation_observer_runner *impl_from_mutation_runner(nsISupports *iface)
-{
-    return CONTAINING_RECORD(iface, struct mutation_observer_runner, nsISupports_iface);
-}
-
 static inline struct mutation_node_list *impl_from_mutation_node_list(nsIDOMNodeList *iface)
 {
     return CONTAINING_RECORD(iface, struct mutation_node_list, nsIDOMNodeList_iface);
@@ -1217,40 +1212,6 @@ static void mutation_observer_disconnect_internal(struct mutation_observer *This
 static HRESULT mutation_observer_create_records(struct mutation_observer *This, IDispatch **ret);
 static HRESULT mutation_observer_get_native_node(HTMLDOMNode *node, nsINode **ret);
 static void mutation_observer_schedule(struct mutation_observer *This);
-
-static nsresult NSAPI mutation_runner_QueryInterface(nsISupports *iface, nsIIDRef riid, void **result)
-{
-    if(!IsEqualGUID(riid, &IID_nsISupports)) {
-        *result = NULL;
-        return NS_NOINTERFACE;
-    }
-
-    *result = iface;
-    nsISupports_AddRef(iface);
-    return NS_OK;
-}
-
-static nsrefcnt NSAPI mutation_runner_AddRef(nsISupports *iface)
-{
-    struct mutation_observer_runner *This = impl_from_mutation_runner(iface);
-    return InterlockedIncrement(&This->ref);
-}
-
-static nsrefcnt NSAPI mutation_runner_Release(nsISupports *iface)
-{
-    struct mutation_observer_runner *This = impl_from_mutation_runner(iface);
-    LONG ref = InterlockedDecrement(&This->ref);
-
-    if(!ref)
-        free(This);
-    return ref;
-}
-
-static const nsISupportsVtbl mutation_runner_vtbl = {
-    mutation_runner_QueryInterface,
-    mutation_runner_AddRef,
-    mutation_runner_Release
-};
 
 static nsresult NSAPI mutation_node_list_QueryInterface(nsIDOMNodeList *iface, nsIIDRef riid, void **result)
 {
@@ -1837,30 +1798,30 @@ static HRESULT mutation_observer_add_transient(struct mutation_observer *This,
     return S_OK;
 }
 
-static nsresult mutation_observer_deliver(HTMLDocumentNode *doc, nsISupports *arg1, nsISupports *arg2)
+static void mutation_observer_deliver(task_t *task)
 {
-    struct mutation_observer *This = impl_from_nsIMutationObserver((nsIMutationObserver *)arg1);
-    struct mutation_observer_runner *runner = arg2 ? impl_from_mutation_runner(arg2) : NULL;
+    struct mutation_observer_runner *runner = CONTAINING_RECORD(task, struct mutation_observer_runner, task);
+    struct mutation_observer *This = runner->observer;
     DISPID named_arg = DISPID_THIS;
     VARIANT args[3], result;
     DISPPARAMS params = {args, &named_arg, ARRAY_SIZE(args), 1};
     IDispatch *records, *callback;
     HRESULT hres;
 
-    if(!runner || !This->delivery_pending || runner->generation != This->delivery_generation)
-        return NS_OK;
+    if(!This->delivery_pending || runner->generation != This->delivery_generation)
+        return;
 
     This->delivery_pending = FALSE;
     mutation_observer_clear_transients(This);
     if(list_empty(&This->records) || !This->callback)
-        return NS_OK;
+        return;
 
     hres = mutation_observer_create_records(This, &records);
     if(FAILED(hres)) {
         WARN("Could not create MutationObserver records array: %08lx\n", hres);
         if(hres == E_UNEXPECTED)
             mutation_observer_clear_records(This);
-        return NS_OK;
+        return;
     }
 
     callback = This->callback;
@@ -1878,36 +1839,52 @@ static nsresult mutation_observer_deliver(HTMLDocumentNode *doc, nsISupports *ar
     IDispatch_Release(records);
     if(FAILED(hres))
         WARN("MutationObserver callback failed: %08lx\n", hres);
-    return NS_OK;
+}
+
+static void mutation_observer_runner_destroy(task_t *task)
+{
+    struct mutation_observer_runner *runner = CONTAINING_RECORD(task, struct mutation_observer_runner, task);
+    struct mutation_observer *This = runner->observer;
+
+    if(This->delivery_pending && runner->generation == This->delivery_generation) {
+        This->delivery_pending = FALSE;
+        ++This->delivery_generation;
+    }
+    IWineMSHTMLMutationObserver_Release(&This->IWineMSHTMLMutationObserver_iface);
 }
 
 static void mutation_observer_schedule(struct mutation_observer *This)
 {
-    struct mutation_observer_target *target;
     struct mutation_observer_runner *runner;
+    HTMLInnerWindow *window;
+    HRESULT hres;
 
     if(This->delivery_pending || (list_empty(&This->records)
             && !mutation_observer_has_transients(This)) || list_empty(&This->targets))
         return;
 
-    target = LIST_ENTRY(list_head(&This->targets), struct mutation_observer_target, entry);
     runner = calloc(1, sizeof(*runner));
     if(!runner)
         return;
 
-    runner->nsISupports_iface.lpVtbl = &mutation_runner_vtbl;
-    runner->ref = 1;
+    window = get_script_global(&This->dispex);
+    if(!window) {
+        free(runner);
+        return;
+    }
+
+    runner->observer = This;
+    IWineMSHTMLMutationObserver_AddRef(&This->IWineMSHTMLMutationObserver_iface);
     runner->generation = ++This->delivery_generation;
     This->delivery_pending = TRUE;
 
-    if(!add_script_runner(target->node->doc, mutation_observer_deliver,
-            (nsISupports *)&This->nsIMutationObserver_iface, &runner->nsISupports_iface)) {
+    hres = push_task(&runner->task, mutation_observer_deliver,
+            mutation_observer_runner_destroy, window->task_magic);
+    IHTMLWindow2_Release(&window->base.IHTMLWindow2_iface);
+    if(FAILED(hres)) {
         This->delivery_pending = FALSE;
         ++This->delivery_generation;
-        nsISupports_Release(&runner->nsISupports_iface);
-        return;
     }
-    nsISupports_Release(&runner->nsISupports_iface);
 }
 
 struct mutation_node_array {

--- a/dlls/mshtml/mutation.c
+++ b/dlls/mshtml/mutation.c
@@ -700,13 +700,17 @@ static const nsIRunnableVtbl nsRunnableVtbl = {
     nsRunnable_Run
 };
 
-static void add_script_runner(HTMLDocumentNode *This, runnable_proc_t proc, nsISupports *arg1, nsISupports *arg2)
+static BOOL add_script_runner(HTMLDocumentNode *This, runnable_proc_t proc, nsISupports *arg1, nsISupports *arg2)
 {
     nsRunnable *runnable;
+    nsresult nsres;
+
+    if(!content_utils)
+        return FALSE;
 
     runnable = calloc(1, sizeof(*runnable));
     if(!runnable)
-        return;
+        return FALSE;
 
     runnable->nsIRunnable_iface.lpVtbl = &nsRunnableVtbl;
     runnable->ref = 1;
@@ -723,9 +727,10 @@ static void add_script_runner(HTMLDocumentNode *This, runnable_proc_t proc, nsIS
         nsISupports_AddRef(arg2);
     runnable->arg2 = arg2;
 
-    nsIContentUtils_AddScriptRunner(content_utils, &runnable->nsIRunnable_iface);
+    nsres = nsIContentUtils_AddScriptRunner(content_utils, &runnable->nsIRunnable_iface);
 
     nsIRunnable_Release(&runnable->nsIRunnable_iface);
+    return NS_SUCCEEDED(nsres);
 }
 
 static inline HTMLDocumentNode *impl_from_nsIDocumentObserver(nsIDocumentObserver *iface)
@@ -1101,8 +1106,18 @@ JSContext *get_context_from_document(nsIDOMDocument *nsdoc)
     return ctx;
 }
 
+static ExternalCycleCollectionParticipant mutation_node_list_ccp;
+static nsresult NSAPI mutation_node_list_traverse(void*,void*,nsCycleCollectionTraversalCallback*);
+static nsresult NSAPI mutation_node_list_unlink(void*);
+static void NSAPI mutation_node_list_delete_cycle_collectable(void*);
+
 void init_mutation(nsIComponentManager *component_manager)
 {
+    static const CCObjCallback node_list_ccp_callback = {
+        mutation_node_list_traverse,
+        mutation_node_list_unlink,
+        mutation_node_list_delete_cycle_collectable
+    };
     nsIFactory *factory;
     nsresult nsres;
 
@@ -1121,17 +1136,60 @@ void init_mutation(nsIComponentManager *component_manager)
         return;
     }
 
+    ccp_init(&mutation_node_list_ccp, &node_list_ccp_callback);
     nsres = nsIFactory_CreateInstance(factory, NULL, &IID_nsIContentUtils, (void**)&content_utils);
     nsIFactory_Release(factory);
     if(NS_FAILED(nsres))
         ERR("Could not create nsIContentUtils instance: %08lx\n", nsres);
 }
 
+struct mutation_observer_target {
+    struct list entry;
+    HTMLDOMNode *node;
+    nsINode *native_node;
+    BOOL native_registered;
+    BOOL transient;
+    BOOL character_data;
+    BOOL child_list;
+    BOOL subtree;
+};
+
+struct mutation_observer_record {
+    struct list entry;
+    HTMLDOMNode *target;
+    BOOL child_list;
+    nsIDOMNode *previous_sibling;
+    nsIDOMNode *next_sibling;
+    UINT32 added_count;
+    nsIDOMNode **added_nodes;
+    UINT32 removed_count;
+    nsIDOMNode **removed_nodes;
+};
+
+struct mutation_observer_runner {
+    nsISupports nsISupports_iface;
+    LONG ref;
+    ULONG generation;
+};
+
+struct mutation_node_list {
+    nsIDOMNodeList nsIDOMNodeList_iface;
+    nsCycleCollectingAutoRefCnt ccref;
+    UINT32 count;
+    nsIDOMNode **nodes;
+};
+
 struct mutation_observer {
     IWineMSHTMLMutationObserver IWineMSHTMLMutationObserver_iface;
+    nsIMutationObserver nsIMutationObserver_iface;
 
     DispatchEx dispex;
     IDispatch *callback;
+    struct list targets;
+    struct list records;
+    ULONG delivery_generation;
+    BOOL delivery_pending;
+    BOOL observing_ref;
 };
 
 static inline struct mutation_observer *impl_from_IWineMSHTMLMutationObserver(IWineMSHTMLMutationObserver *iface)
@@ -1139,35 +1197,1321 @@ static inline struct mutation_observer *impl_from_IWineMSHTMLMutationObserver(IW
     return CONTAINING_RECORD(iface, struct mutation_observer, IWineMSHTMLMutationObserver_iface);
 }
 
+static inline struct mutation_observer *impl_from_nsIMutationObserver(nsIMutationObserver *iface)
+{
+    return CONTAINING_RECORD(iface, struct mutation_observer, nsIMutationObserver_iface);
+}
+
+static inline struct mutation_observer_runner *impl_from_mutation_runner(nsISupports *iface)
+{
+    return CONTAINING_RECORD(iface, struct mutation_observer_runner, nsISupports_iface);
+}
+
+static inline struct mutation_node_list *impl_from_mutation_node_list(nsIDOMNodeList *iface)
+{
+    return CONTAINING_RECORD(iface, struct mutation_node_list, nsIDOMNodeList_iface);
+}
+
+static void mutation_observer_clear_records(struct mutation_observer *This);
+static void mutation_observer_disconnect_internal(struct mutation_observer *This);
+static HRESULT mutation_observer_create_records(struct mutation_observer *This, IDispatch **ret);
+static HRESULT mutation_observer_get_native_node(HTMLDOMNode *node, nsINode **ret);
+static void mutation_observer_schedule(struct mutation_observer *This);
+
+static nsresult NSAPI mutation_runner_QueryInterface(nsISupports *iface, nsIIDRef riid, void **result)
+{
+    if(!IsEqualGUID(riid, &IID_nsISupports)) {
+        *result = NULL;
+        return NS_NOINTERFACE;
+    }
+
+    *result = iface;
+    nsISupports_AddRef(iface);
+    return NS_OK;
+}
+
+static nsrefcnt NSAPI mutation_runner_AddRef(nsISupports *iface)
+{
+    struct mutation_observer_runner *This = impl_from_mutation_runner(iface);
+    return InterlockedIncrement(&This->ref);
+}
+
+static nsrefcnt NSAPI mutation_runner_Release(nsISupports *iface)
+{
+    struct mutation_observer_runner *This = impl_from_mutation_runner(iface);
+    LONG ref = InterlockedDecrement(&This->ref);
+
+    if(!ref)
+        free(This);
+    return ref;
+}
+
+static const nsISupportsVtbl mutation_runner_vtbl = {
+    mutation_runner_QueryInterface,
+    mutation_runner_AddRef,
+    mutation_runner_Release
+};
+
+static nsresult NSAPI mutation_node_list_QueryInterface(nsIDOMNodeList *iface, nsIIDRef riid, void **result)
+{
+    struct mutation_node_list *This = impl_from_mutation_node_list(iface);
+
+    if(IsEqualGUID(riid, &IID_nsXPCOMCycleCollectionParticipant)) {
+        *result = &mutation_node_list_ccp;
+        return NS_OK;
+    }
+    if(IsEqualGUID(riid, &IID_nsCycleCollectionISupports)) {
+        *result = iface;
+        return NS_OK;
+    }
+    if(!IsEqualGUID(riid, &IID_nsISupports) && !IsEqualGUID(riid, &IID_nsIDOMNodeList)) {
+        *result = NULL;
+        return NS_NOINTERFACE;
+    }
+
+    *result = iface;
+    ccref_incr(&This->ccref, (nsISupports *)iface);
+    return NS_OK;
+}
+
+static nsrefcnt NSAPI mutation_node_list_AddRef(nsIDOMNodeList *iface)
+{
+    struct mutation_node_list *This = impl_from_mutation_node_list(iface);
+    return ccref_incr(&This->ccref, (nsISupports *)iface);
+}
+
+static nsrefcnt NSAPI mutation_node_list_Release(nsIDOMNodeList *iface)
+{
+    struct mutation_node_list *This = impl_from_mutation_node_list(iface);
+    return ccref_decr(&This->ccref, (nsISupports *)iface, &mutation_node_list_ccp);
+}
+
+static nsresult NSAPI mutation_node_list_traverse(void *ccp, void *object,
+        nsCycleCollectionTraversalCallback *callback)
+{
+    struct mutation_node_list *This = impl_from_mutation_node_list(object);
+    UINT32 i;
+
+    describe_cc_node(&This->ccref, "MutationNodeList", callback);
+    for(i = 0; i < This->count; i++)
+        note_cc_edge((nsISupports *)This->nodes[i], "node", callback);
+    return NS_OK;
+}
+
+static nsresult NSAPI mutation_node_list_unlink(void *object)
+{
+    struct mutation_node_list *This = impl_from_mutation_node_list(object);
+    UINT32 i;
+
+    for(i = 0; i < This->count; i++)
+        nsIDOMNode_Release(This->nodes[i]);
+    free(This->nodes);
+    This->nodes = NULL;
+    This->count = 0;
+    return NS_OK;
+}
+
+static void NSAPI mutation_node_list_delete_cycle_collectable(void *object)
+{
+    struct mutation_node_list *This = impl_from_mutation_node_list(object);
+
+    mutation_node_list_unlink(object);
+    free(This);
+}
+
+static nsresult NSAPI mutation_node_list_Item(nsIDOMNodeList *iface, UINT32 index, nsIDOMNode **ret)
+{
+    struct mutation_node_list *This = impl_from_mutation_node_list(iface);
+
+    if(!ret)
+        return NS_ERROR_FAILURE;
+    *ret = NULL;
+    if(index >= This->count)
+        return NS_ERROR_FAILURE;
+
+    nsIDOMNode_AddRef(This->nodes[index]);
+    *ret = This->nodes[index];
+    return NS_OK;
+}
+
+static nsresult NSAPI mutation_node_list_GetLength(nsIDOMNodeList *iface, UINT32 *ret)
+{
+    struct mutation_node_list *This = impl_from_mutation_node_list(iface);
+
+    if(!ret)
+        return NS_ERROR_FAILURE;
+    *ret = This->count;
+    return NS_OK;
+}
+
+static const nsIDOMNodeListVtbl mutation_node_list_vtbl = {
+    mutation_node_list_QueryInterface,
+    mutation_node_list_AddRef,
+    mutation_node_list_Release,
+    mutation_node_list_Item,
+    mutation_node_list_GetLength
+};
+
+static BOOL mutation_observer_array_size(UINT32 count, SIZE_T element_size, SIZE_T *size)
+{
+    if(count && element_size > ~(SIZE_T)0 / count)
+        return FALSE;
+    *size = (SIZE_T)count * element_size;
+    return TRUE;
+}
+
+static HRESULT mutation_node_list_create(UINT32 count, nsIDOMNode *const *nodes, nsIDOMNodeList **ret)
+{
+    struct mutation_node_list *list;
+    UINT32 i;
+
+    *ret = NULL;
+    list = calloc(1, sizeof(*list));
+    if(!list)
+        return E_OUTOFMEMORY;
+
+    list->nsIDOMNodeList_iface.lpVtbl = &mutation_node_list_vtbl;
+    ccref_init(&list->ccref, 1);
+    list->count = count;
+    if(count) {
+        SIZE_T size;
+
+        if(!mutation_observer_array_size(count, sizeof(*list->nodes), &size)) {
+            free(list);
+            return E_OUTOFMEMORY;
+        }
+        list->nodes = calloc(1, size);
+        if(!list->nodes) {
+            free(list);
+            return E_OUTOFMEMORY;
+        }
+        for(i = 0; i < count; i++) {
+            nsIDOMNode_AddRef(nodes[i]);
+            list->nodes[i] = nodes[i];
+        }
+    }
+
+    *ret = &list->nsIDOMNodeList_iface;
+    return S_OK;
+}
+
+static void mutation_observer_free_record(struct mutation_observer_record *record)
+{
+    UINT32 i;
+
+    if(record->target)
+        node_release(record->target);
+    if(record->previous_sibling)
+        nsIDOMNode_Release(record->previous_sibling);
+    if(record->next_sibling)
+        nsIDOMNode_Release(record->next_sibling);
+    for(i = 0; i < record->added_count; i++)
+        nsIDOMNode_Release(record->added_nodes[i]);
+    for(i = 0; i < record->removed_count; i++)
+        nsIDOMNode_Release(record->removed_nodes[i]);
+    free(record->added_nodes);
+    free(record->removed_nodes);
+    free(record);
+}
+
+static void mutation_observer_clear_records(struct mutation_observer *This)
+{
+    struct mutation_observer_record *record, *next;
+
+    LIST_FOR_EACH_ENTRY_SAFE(record, next, &This->records, struct mutation_observer_record, entry) {
+        list_remove(&record->entry);
+        mutation_observer_free_record(record);
+    }
+}
+
+static void mutation_observer_detach_records(struct mutation_observer *This, struct list *records)
+{
+    struct mutation_observer_record *record;
+
+    list_init(records);
+    while(!list_empty(&This->records)) {
+        record = LIST_ENTRY(list_head(&This->records), struct mutation_observer_record, entry);
+        list_remove(&record->entry);
+        list_add_tail(records, &record->entry);
+    }
+}
+
+static void mutation_observer_restore_records(struct mutation_observer *This, struct list *records)
+{
+    struct mutation_observer_record *record;
+
+    while(!list_empty(records)) {
+        record = LIST_ENTRY(list_tail(records), struct mutation_observer_record, entry);
+        list_remove(&record->entry);
+        list_add_head(&This->records, &record->entry);
+    }
+}
+
+static HRESULT mutation_observer_create_array(struct mutation_observer *This, IWineJSDispatch **ret)
+{
+    HTMLInnerWindow *window;
+    HRESULT hres;
+
+    *ret = NULL;
+    window = get_script_global(&This->dispex);
+    if(!window || !window->jscript) {
+        if(window)
+            IHTMLWindow2_Release(&window->base.IHTMLWindow2_iface);
+        return E_UNEXPECTED;
+    }
+
+    hres = IWineJScript_CreateArray(window->jscript, 0, ret);
+    IHTMLWindow2_Release(&window->base.IHTMLWindow2_iface);
+    return hres;
+}
+
+static HRESULT mutation_observer_define(IWineJSDispatch *object, const WCHAR *name, VARIANT *value)
+{
+    return IWineJSDispatch_DefineProperty(object, name, PROPF_ENUMERABLE, value);
+}
+
+static HRESULT mutation_observer_define_array_element(IWineJSDispatch *object, const WCHAR *name,
+        VARIANT *value)
+{
+    return IWineJSDispatch_DefineProperty(object, name,
+            PROPF_ENUMERABLE | PROPF_WRITABLE | PROPF_CONFIGURABLE, value);
+}
+
+static HRESULT mutation_observer_define_null(IWineJSDispatch *object, const WCHAR *name)
+{
+    VARIANT value;
+    HRESULT hres;
+
+    VariantInit(&value);
+    V_VT(&value) = VT_NULL;
+    hres = mutation_observer_define(object, name, &value);
+    VariantClear(&value);
+    return hres;
+}
+
+static HRESULT mutation_observer_define_string(IWineJSDispatch *object, const WCHAR *name, const WCHAR *value)
+{
+    VARIANT var;
+    HRESULT hres;
+
+    VariantInit(&var);
+    V_VT(&var) = VT_BSTR;
+    V_BSTR(&var) = SysAllocString(value);
+    if(!V_BSTR(&var))
+        return E_OUTOFMEMORY;
+    hres = mutation_observer_define(object, name, &var);
+    VariantClear(&var);
+    return hres;
+}
+
+static HRESULT mutation_observer_define_node(IWineJSDispatch *object, const WCHAR *name,
+        nsIDOMNode *node)
+{
+    HTMLDOMNode *html_node;
+    IDispatch *dispatch;
+    VARIANT value;
+    HRESULT hres;
+
+    if(!node)
+        return mutation_observer_define_null(object, name);
+
+    hres = get_node(node, TRUE, &html_node);
+    if(FAILED(hres))
+        return hres;
+    hres = IHTMLDOMNode_QueryInterface(&html_node->IHTMLDOMNode_iface, &IID_IDispatch,
+            (void **)&dispatch);
+    node_release(html_node);
+    if(FAILED(hres))
+        return hres;
+
+    VariantInit(&value);
+    V_VT(&value) = VT_DISPATCH;
+    V_DISPATCH(&value) = dispatch;
+    hres = mutation_observer_define(object, name, &value);
+    VariantClear(&value);
+    return hres;
+}
+
+static HRESULT mutation_observer_define_nodes(IWineJSDispatch *object, const WCHAR *name,
+        DispatchEx *owner, UINT32 count, nsIDOMNode *const *nodes)
+{
+    IHTMLDOMChildrenCollection *collection;
+    nsIDOMNodeList *node_list;
+    VARIANT value;
+    HRESULT hres;
+
+    hres = mutation_node_list_create(count, nodes, &node_list);
+    if(FAILED(hres))
+        return hres;
+    hres = create_child_collection(node_list, owner, &collection);
+    nsIDOMNodeList_Release(node_list);
+    if(FAILED(hres))
+        return hres;
+
+    VariantInit(&value);
+    V_VT(&value) = VT_DISPATCH;
+    V_DISPATCH(&value) = (IDispatch *)collection;
+    hres = mutation_observer_define(object, name, &value);
+    VariantClear(&value);
+    return hres;
+}
+
+static HRESULT mutation_observer_create_record(struct mutation_observer *This,
+        IWineJScript *script, struct mutation_observer_record *record, IDispatch **ret)
+{
+    IWineJSDispatch *object;
+    VARIANT value;
+    HRESULT hres;
+
+    *ret = NULL;
+    hres = IWineJScript_CreateObject(script, &object);
+    if(FAILED(hres))
+        return hres;
+
+    hres = mutation_observer_define_string(object, L"type",
+            record->child_list ? L"childList" : L"characterData");
+    if(SUCCEEDED(hres)) {
+        VariantInit(&value);
+        V_VT(&value) = VT_DISPATCH;
+        V_DISPATCH(&value) = (IDispatch *)&record->target->IHTMLDOMNode_iface;
+        IDispatch_AddRef(V_DISPATCH(&value));
+        hres = mutation_observer_define(object, L"target", &value);
+        VariantClear(&value);
+    }
+    if(SUCCEEDED(hres))
+        hres = mutation_observer_define_node(object, L"previousSibling", record->previous_sibling);
+    if(SUCCEEDED(hres))
+        hres = mutation_observer_define_node(object, L"nextSibling", record->next_sibling);
+    if(SUCCEEDED(hres)) hres = mutation_observer_define_null(object, L"attributeName");
+    if(SUCCEEDED(hres)) hres = mutation_observer_define_null(object, L"attributeNamespace");
+    if(SUCCEEDED(hres)) hres = mutation_observer_define_null(object, L"oldValue");
+    if(SUCCEEDED(hres))
+        hres = mutation_observer_define_nodes(object, L"addedNodes", &This->dispex,
+                record->added_count, record->added_nodes);
+    if(SUCCEEDED(hres))
+        hres = mutation_observer_define_nodes(object, L"removedNodes", &This->dispex,
+                record->removed_count, record->removed_nodes);
+
+    if(SUCCEEDED(hres))
+        *ret = (IDispatch *)object;
+    else
+        IWineJSDispatch_Release(object);
+    return hres;
+}
+
+static HRESULT mutation_observer_create_records(struct mutation_observer *This, IDispatch **ret)
+{
+    HTMLInnerWindow *window;
+    IWineJSDispatch *array;
+    struct list records;
+    struct mutation_observer_record *record;
+    ULONG index = 0;
+    WCHAR name[32];
+    VARIANT value;
+    HRESULT hres;
+
+    *ret = NULL;
+    hres = mutation_observer_create_array(This, &array);
+    if(FAILED(hres))
+        return hres;
+
+    window = get_script_global(&This->dispex);
+    if(!window || !window->jscript) {
+        if(window)
+            IHTMLWindow2_Release(&window->base.IHTMLWindow2_iface);
+        IWineJSDispatch_Release(array);
+        return E_UNEXPECTED;
+    }
+
+    hres = S_OK;
+    mutation_observer_detach_records(This, &records);
+    LIST_FOR_EACH_ENTRY(record, &records, struct mutation_observer_record, entry) {
+        IDispatch *record_disp;
+
+        hres = mutation_observer_create_record(This, window->jscript, record, &record_disp);
+        if(FAILED(hres))
+            break;
+
+        swprintf(name, ARRAY_SIZE(name), L"%u", index++);
+        VariantInit(&value);
+        V_VT(&value) = VT_DISPATCH;
+        V_DISPATCH(&value) = record_disp;
+        hres = mutation_observer_define_array_element(array, name, &value);
+        VariantClear(&value);
+        if(FAILED(hres))
+            break;
+    }
+
+    IHTMLWindow2_Release(&window->base.IHTMLWindow2_iface);
+    if(FAILED(hres)) {
+        mutation_observer_restore_records(This, &records);
+        IWineJSDispatch_Release(array);
+        return hres;
+    }
+
+    while(!list_empty(&records)) {
+        record = LIST_ENTRY(list_head(&records), struct mutation_observer_record, entry);
+        list_remove(&record->entry);
+        mutation_observer_free_record(record);
+    }
+
+    *ret = (IDispatch *)array;
+    return S_OK;
+}
+
+static nsresult NSAPI mutation_observer_ns_QueryInterface(nsIMutationObserver *iface,
+        nsIIDRef riid, void **result)
+{
+    struct mutation_observer *This = impl_from_nsIMutationObserver(iface);
+
+    if(!IsEqualGUID(riid, &IID_nsISupports) && !IsEqualGUID(riid, &IID_nsIMutationObserver)) {
+        *result = NULL;
+        return NS_NOINTERFACE;
+    }
+
+    *result = &This->nsIMutationObserver_iface;
+    IWineMSHTMLMutationObserver_AddRef(&This->IWineMSHTMLMutationObserver_iface);
+    return NS_OK;
+}
+
+static nsrefcnt NSAPI mutation_observer_ns_AddRef(nsIMutationObserver *iface)
+{
+    struct mutation_observer *This = impl_from_nsIMutationObserver(iface);
+    return IWineMSHTMLMutationObserver_AddRef(&This->IWineMSHTMLMutationObserver_iface);
+}
+
+static nsrefcnt NSAPI mutation_observer_ns_Release(nsIMutationObserver *iface)
+{
+    struct mutation_observer *This = impl_from_nsIMutationObserver(iface);
+    return IWineMSHTMLMutationObserver_Release(&This->IWineMSHTMLMutationObserver_iface);
+}
+
+static BOOL mutation_observer_target_matches(struct mutation_observer_target *target, nsIDOMNode *content)
+{
+    nsIDOMNode *current = content, *parent;
+    BOOL ret = FALSE;
+
+    nsIDOMNode_AddRef(current);
+    for(;;) {
+        if(current == target->node->nsnode) {
+            ret = TRUE;
+            break;
+        }
+        if(!target->subtree || NS_FAILED(nsIDOMNode_GetParentNode(current, &parent)) || !parent)
+            break;
+        nsIDOMNode_Release(current);
+        current = parent;
+    }
+    nsIDOMNode_Release(current);
+    return ret;
+}
+
+static BOOL mutation_observer_matches(struct mutation_observer *This, nsIDOMNode *content,
+        BOOL child_list)
+{
+    struct mutation_observer_target *target;
+
+    LIST_FOR_EACH_ENTRY(target, &This->targets, struct mutation_observer_target, entry) {
+        if((child_list ? target->child_list : target->character_data)
+                && mutation_observer_target_matches(target, content))
+            return TRUE;
+    }
+    return FALSE;
+}
+
+static BOOL mutation_observer_transient_options(struct mutation_observer *This, nsIDOMNode *content,
+        BOOL *character_data, BOOL *child_list)
+{
+    struct mutation_observer_target *target;
+    BOOL matched = FALSE;
+
+    *character_data = *child_list = FALSE;
+    LIST_FOR_EACH_ENTRY(target, &This->targets, struct mutation_observer_target, entry) {
+        if(!target->subtree || !mutation_observer_target_matches(target, content))
+            continue;
+        matched = TRUE;
+        *character_data |= target->character_data;
+        *child_list |= target->child_list;
+    }
+    return matched;
+}
+
+static void mutation_observer_remove_target(struct mutation_observer *This,
+        struct mutation_observer_target *target)
+{
+    BOOL native_registered = target->native_registered;
+
+    target->native_registered = FALSE;
+    list_remove(&target->entry);
+    if(native_registered && content_utils)
+        nsIContentUtils_RemoveMutationObserver(content_utils, target->native_node,
+                &This->nsIMutationObserver_iface);
+    nsISupports_Release((nsISupports *)target->native_node);
+    node_release(target->node);
+    free(target);
+}
+
+static BOOL mutation_observer_has_transients(struct mutation_observer *This)
+{
+    struct mutation_observer_target *target;
+
+    LIST_FOR_EACH_ENTRY(target, &This->targets, struct mutation_observer_target, entry) {
+        if(target->transient)
+            return TRUE;
+    }
+    return FALSE;
+}
+
+static void mutation_observer_clear_transients(struct mutation_observer *This)
+{
+    struct mutation_observer_target *target, *next;
+
+    LIST_FOR_EACH_ENTRY_SAFE(target, next, &This->targets, struct mutation_observer_target, entry) {
+        if(target->transient)
+            mutation_observer_remove_target(This, target);
+    }
+    if(list_empty(&This->targets) && This->observing_ref) {
+        This->observing_ref = FALSE;
+        IWineMSHTMLMutationObserver_Release(&This->IWineMSHTMLMutationObserver_iface);
+    }
+}
+
+static HRESULT mutation_observer_add_transient(struct mutation_observer *This,
+        nsIDOMNode *node, BOOL character_data, BOOL child_list)
+{
+    struct mutation_observer_target *target, *entry;
+    HTMLDOMNode *html_node;
+    nsINode *native_node;
+    BOOL native_registered = FALSE;
+    nsresult nsres;
+    HRESULT hres;
+
+    hres = get_node(node, TRUE, &html_node);
+    if(FAILED(hres))
+        return hres;
+    hres = mutation_observer_get_native_node(html_node, &native_node);
+    if(FAILED(hres)) {
+        node_release(html_node);
+        return hres;
+    }
+
+    LIST_FOR_EACH_ENTRY(target, &This->targets, struct mutation_observer_target, entry) {
+        if(target->native_node != native_node)
+            continue;
+        native_registered = TRUE;
+        if(target->transient) {
+            target->character_data |= character_data;
+            target->child_list |= child_list;
+            nsISupports_Release((nsISupports *)native_node);
+            node_release(html_node);
+            return S_OK;
+        }
+    }
+
+    entry = calloc(1, sizeof(*entry));
+    if(!entry) {
+        nsISupports_Release((nsISupports *)native_node);
+        node_release(html_node);
+        return E_OUTOFMEMORY;
+    }
+    if(!native_registered) {
+        nsres = nsIContentUtils_AddMutationObserver(content_utils, native_node,
+                &This->nsIMutationObserver_iface);
+        if(NS_FAILED(nsres)) {
+            nsISupports_Release((nsISupports *)native_node);
+            node_release(html_node);
+            free(entry);
+            return map_nsresult(nsres);
+        }
+        entry->native_registered = TRUE;
+    }
+
+    entry->node = html_node;
+    entry->native_node = native_node;
+    entry->transient = TRUE;
+    entry->character_data = character_data;
+    entry->child_list = child_list;
+    entry->subtree = TRUE;
+    list_add_tail(&This->targets, &entry->entry);
+    return S_OK;
+}
+
+static nsresult mutation_observer_deliver(HTMLDocumentNode *doc, nsISupports *arg1, nsISupports *arg2)
+{
+    struct mutation_observer *This = impl_from_nsIMutationObserver((nsIMutationObserver *)arg1);
+    struct mutation_observer_runner *runner = arg2 ? impl_from_mutation_runner(arg2) : NULL;
+    DISPID named_arg = DISPID_THIS;
+    VARIANT args[3], result;
+    DISPPARAMS params = {args, &named_arg, ARRAY_SIZE(args), 1};
+    IDispatch *records, *callback;
+    HRESULT hres;
+
+    if(!runner || !This->delivery_pending || runner->generation != This->delivery_generation)
+        return NS_OK;
+
+    This->delivery_pending = FALSE;
+    mutation_observer_clear_transients(This);
+    if(list_empty(&This->records) || !This->callback)
+        return NS_OK;
+
+    hres = mutation_observer_create_records(This, &records);
+    if(FAILED(hres)) {
+        WARN("Could not create MutationObserver records array: %08lx\n", hres);
+        mutation_observer_schedule(This);
+        return NS_OK;
+    }
+
+    callback = This->callback;
+    IDispatch_AddRef(callback);
+    V_VT(args) = VT_DISPATCH;
+    V_DISPATCH(args) = (IDispatch *)&This->IWineMSHTMLMutationObserver_iface;
+    V_VT(args + 1) = VT_DISPATCH;
+    V_DISPATCH(args + 1) = (IDispatch *)&This->IWineMSHTMLMutationObserver_iface;
+    V_VT(args + 2) = VT_DISPATCH;
+    V_DISPATCH(args + 2) = records;
+    VariantInit(&result);
+    hres = call_disp_func(callback, &params, &result);
+    VariantClear(&result);
+    IDispatch_Release(callback);
+    IDispatch_Release(records);
+    if(FAILED(hres))
+        WARN("MutationObserver callback failed: %08lx\n", hres);
+    return NS_OK;
+}
+
+static void mutation_observer_schedule(struct mutation_observer *This)
+{
+    struct mutation_observer_target *target;
+    struct mutation_observer_runner *runner;
+
+    if(This->delivery_pending || (list_empty(&This->records)
+            && !mutation_observer_has_transients(This)) || list_empty(&This->targets))
+        return;
+
+    target = LIST_ENTRY(list_head(&This->targets), struct mutation_observer_target, entry);
+    runner = calloc(1, sizeof(*runner));
+    if(!runner)
+        return;
+
+    runner->nsISupports_iface.lpVtbl = &mutation_runner_vtbl;
+    runner->ref = 1;
+    runner->generation = ++This->delivery_generation;
+    This->delivery_pending = TRUE;
+
+    if(!add_script_runner(target->node->doc, mutation_observer_deliver,
+            (nsISupports *)&This->nsIMutationObserver_iface, &runner->nsISupports_iface)) {
+        This->delivery_pending = FALSE;
+        ++This->delivery_generation;
+        nsISupports_Release(&runner->nsISupports_iface);
+        return;
+    }
+    nsISupports_Release(&runner->nsISupports_iface);
+}
+
+struct mutation_node_array {
+    nsIDOMNode **nodes;
+    UINT32 count;
+    UINT32 capacity;
+};
+
+static void mutation_node_array_clear(struct mutation_node_array *array)
+{
+    UINT32 i;
+
+    for(i = 0; i < array->count; i++)
+        nsIDOMNode_Release(array->nodes[i]);
+    free(array->nodes);
+    array->nodes = NULL;
+    array->count = array->capacity = 0;
+}
+
+static BOOL mutation_node_array_append(struct mutation_node_array *array, nsIDOMNode *node)
+{
+    nsIDOMNode **nodes;
+    UINT32 capacity;
+    SIZE_T size;
+
+    if(!node || array->count == ~(UINT32)0)
+        return FALSE;
+    if(array->count == array->capacity) {
+        if(array->capacity > ~(UINT32)0 / 2)
+            capacity = ~(UINT32)0;
+        else
+            capacity = array->capacity ? array->capacity * 2 : 4;
+        if(!mutation_observer_array_size(capacity, sizeof(*nodes), &size))
+            return FALSE;
+        nodes = realloc(array->nodes, size);
+        if(!nodes)
+            return FALSE;
+        array->nodes = nodes;
+        array->capacity = capacity;
+    }
+
+    nsIDOMNode_AddRef(node);
+    array->nodes[array->count++] = node;
+    return TRUE;
+}
+
+static void mutation_observer_queue(struct mutation_observer *This, BOOL child_list,
+        nsIDOMNode *target, nsIDOMNode *const *added_nodes, UINT32 added_count,
+        nsIDOMNode *const *removed_nodes, UINT32 removed_count,
+        nsIDOMNode *previous_sibling, nsIDOMNode *next_sibling)
+{
+    struct mutation_observer_record *record;
+    UINT32 i;
+    SIZE_T added_size, removed_size;
+
+    if(!target || (added_count && !added_nodes) || (removed_count && !removed_nodes)
+            || !mutation_observer_array_size(added_count, sizeof(*record->added_nodes), &added_size)
+            || !mutation_observer_array_size(removed_count, sizeof(*record->removed_nodes), &removed_size))
+        return;
+    if(!(record = calloc(1, sizeof(*record))))
+        return;
+
+    if(FAILED(get_node(target, TRUE, &record->target)))
+        goto failed;
+    record->child_list = child_list;
+    if(previous_sibling) {
+        nsIDOMNode_AddRef(previous_sibling);
+        record->previous_sibling = previous_sibling;
+    }
+    if(next_sibling) {
+        nsIDOMNode_AddRef(next_sibling);
+        record->next_sibling = next_sibling;
+    }
+    if(added_count) {
+        record->added_nodes = calloc(1, added_size);
+        if(!record->added_nodes)
+            goto failed;
+        for(i = 0; i < added_count; i++) {
+            nsIDOMNode_AddRef(added_nodes[i]);
+            record->added_nodes[i] = added_nodes[i];
+        }
+        record->added_count = added_count;
+    }
+    if(removed_count) {
+        record->removed_nodes = calloc(1, removed_size);
+        if(!record->removed_nodes)
+            goto failed;
+        for(i = 0; i < removed_count; i++) {
+            nsIDOMNode_AddRef(removed_nodes[i]);
+            record->removed_nodes[i] = removed_nodes[i];
+        }
+        record->removed_count = removed_count;
+    }
+
+    list_add_tail(&This->records, &record->entry);
+    mutation_observer_schedule(This);
+    return;
+
+failed:
+    mutation_observer_free_record(record);
+}
+
+static void NSAPI mutation_observer_CharacterDataWillChange(nsIMutationObserver *iface,
+        nsIDocument *document, nsIContent *content, void *info)
+{
+}
+
+static void NSAPI mutation_observer_CharacterDataChanged(nsIMutationObserver *iface,
+        nsIDocument *document, nsIContent *content, void *info)
+{
+    struct mutation_observer *This = impl_from_nsIMutationObserver(iface);
+    nsIDOMNode *nsnode;
+    HTMLDOMNode *node;
+    nsresult nsres;
+    HRESULT hres;
+    struct mutation_observer_record *record;
+
+    if(!content)
+        return;
+    nsres = nsISupports_QueryInterface((nsISupports *)content, &IID_nsIDOMNode, (void **)&nsnode);
+    if(NS_FAILED(nsres) || !mutation_observer_matches(This, nsnode, FALSE)) {
+        if(NS_SUCCEEDED(nsres))
+            nsIDOMNode_Release(nsnode);
+        return;
+    }
+
+    hres = get_node(nsnode, TRUE, &node);
+    nsIDOMNode_Release(nsnode);
+    if(FAILED(hres))
+        return;
+
+    record = calloc(1, sizeof(*record));
+    if(!record) {
+        node_release(node);
+        return;
+    }
+    record->target = node;
+    list_add_tail(&This->records, &record->entry);
+    mutation_observer_schedule(This);
+}
+
+static void NSAPI mutation_observer_AttributeWillChange(nsIMutationObserver *iface, nsIDocument *document,
+        void *element, LONG namespace_id, nsIAtom *attribute, LONG mod_type, const nsAttrValue *new_value)
+{
+}
+
+static void NSAPI mutation_observer_AttributeChanged(nsIMutationObserver *iface, nsIDocument *document,
+        void *element, LONG namespace_id, nsIAtom *attribute, LONG mod_type, const nsAttrValue *old_value)
+{
+}
+
+static void NSAPI mutation_observer_NativeAnonymousChildListChange(nsIMutationObserver *iface,
+        nsIDocument *document, nsIContent *content, cpp_bool is_remove)
+{
+}
+
+static void NSAPI mutation_observer_AttributeSetToCurrentValue(nsIMutationObserver *iface,
+        nsIDocument *document, void *element, LONG namespace_id, nsIAtom *attribute)
+{
+}
+
+static void NSAPI mutation_observer_ContentAppended(nsIMutationObserver *iface, nsIDocument *document,
+        nsIContent *container, nsIContent *first_new_content, LONG new_index)
+{
+    struct mutation_observer *This = impl_from_nsIMutationObserver(iface);
+    struct mutation_node_array added = {0};
+    nsIDOMNode *container_node, *node = NULL, *next, *previous = NULL;
+    nsresult nsres;
+    BOOL success = TRUE;
+
+    if(!container || !first_new_content)
+        return;
+    if(NS_FAILED(nsIContent_QueryInterface(container, &IID_nsIDOMNode, (void **)&container_node)))
+        return;
+    if(!mutation_observer_matches(This, container_node, TRUE)) {
+        nsIDOMNode_Release(container_node);
+        return;
+    }
+    if(NS_FAILED(nsIContent_QueryInterface(first_new_content, &IID_nsIDOMNode, (void **)&node)))
+        goto done;
+    nsres = nsIDOMNode_GetPreviousSibling(node, &previous);
+    if(NS_FAILED(nsres))
+        goto done;
+
+    /* ContentAppended supplies the first new child of an append operation; the
+       appended range is contiguous and ends at the container's last child. */
+    while(node) {
+        if(!mutation_node_array_append(&added, node)) {
+            success = FALSE;
+            nsIDOMNode_Release(node);
+            node = NULL;
+            break;
+        }
+        next = NULL;
+        nsres = nsIDOMNode_GetNextSibling(node, &next);
+        nsIDOMNode_Release(node);
+        node = next;
+        if(NS_FAILED(nsres)) {
+            if(node)
+                nsIDOMNode_Release(node);
+            node = NULL;
+            success = FALSE;
+            break;
+        }
+    }
+    if(success && added.count)
+        mutation_observer_queue(This, TRUE, container_node, added.nodes, added.count,
+                NULL, 0, previous, NULL);
+
+done:
+    if(node)
+        nsIDOMNode_Release(node);
+    if(previous)
+        nsIDOMNode_Release(previous);
+    mutation_node_array_clear(&added);
+    nsIDOMNode_Release(container_node);
+}
+
+static void NSAPI mutation_observer_ContentInserted(nsIMutationObserver *iface, nsIDocument *document,
+        nsIContent *container, nsIContent *child, LONG index)
+{
+    struct mutation_observer *This = impl_from_nsIMutationObserver(iface);
+    nsIDOMNode *container_node, *child_node, *previous = NULL, *next = NULL;
+    nsresult nsres;
+
+    if(!container || !child)
+        return;
+    if(NS_FAILED(nsIContent_QueryInterface(container, &IID_nsIDOMNode, (void **)&container_node)))
+        return;
+    if(!mutation_observer_matches(This, container_node, TRUE))
+        goto done;
+    if(NS_FAILED(nsIContent_QueryInterface(child, &IID_nsIDOMNode, (void **)&child_node)))
+        goto done;
+    nsres = nsIDOMNode_GetPreviousSibling(child_node, &previous);
+    if(NS_SUCCEEDED(nsres))
+        nsres = nsIDOMNode_GetNextSibling(child_node, &next);
+    if(NS_SUCCEEDED(nsres))
+        mutation_observer_queue(This, TRUE, container_node, &child_node, 1,
+                NULL, 0, previous, next);
+    nsIDOMNode_Release(child_node);
+    if(previous)
+        nsIDOMNode_Release(previous);
+    if(next)
+        nsIDOMNode_Release(next);
+
+done:
+    nsIDOMNode_Release(container_node);
+}
+
+static void NSAPI mutation_observer_ContentRemoved(nsIMutationObserver *iface, nsIDocument *document,
+        nsIContent *container, nsIContent *child, LONG index, nsIContent *previous_sibling)
+{
+    struct mutation_observer *This = impl_from_nsIMutationObserver(iface);
+    nsIDOMNode *container_node, *child_node, *previous = NULL, *next = NULL;
+    BOOL character_data, child_list, queue_child_list;
+    nsresult nsres;
+
+    if(!container || !child)
+        return;
+    if(NS_FAILED(nsIContent_QueryInterface(container, &IID_nsIDOMNode, (void **)&container_node)))
+        return;
+    queue_child_list = mutation_observer_matches(This, container_node, TRUE);
+    mutation_observer_transient_options(This, container_node, &character_data, &child_list);
+    if(!queue_child_list && !character_data && !child_list)
+        goto done;
+    if(NS_FAILED(nsIContent_QueryInterface(child, &IID_nsIDOMNode, (void **)&child_node)))
+        goto done;
+    if(queue_child_list) {
+        if(previous_sibling) {
+            nsres = nsIContent_QueryInterface(previous_sibling, &IID_nsIDOMNode, (void **)&previous);
+            if(NS_SUCCEEDED(nsres))
+                nsres = nsIDOMNode_GetNextSibling(previous, &next);
+        }else {
+            nsres = nsIDOMNode_GetFirstChild(container_node, &next);
+        }
+        if(NS_SUCCEEDED(nsres))
+            mutation_observer_queue(This, TRUE, container_node, NULL, 0,
+                    &child_node, 1, previous, next);
+    }
+    if((character_data || child_list) &&
+            SUCCEEDED(mutation_observer_add_transient(This, child_node, character_data, child_list)))
+        mutation_observer_schedule(This);
+    nsIDOMNode_Release(child_node);
+    if(previous)
+        nsIDOMNode_Release(previous);
+    if(next)
+        nsIDOMNode_Release(next);
+
+done:
+    nsIDOMNode_Release(container_node);
+}
+
+static void NSAPI mutation_observer_NodeWillBeDestroyed(nsIMutationObserver *iface, const nsINode *node)
+{
+    struct mutation_observer *This = impl_from_nsIMutationObserver(iface);
+    struct mutation_observer_target *target, *next;
+    BOOL release_observer = FALSE;
+
+    IWineMSHTMLMutationObserver_AddRef(&This->IWineMSHTMLMutationObserver_iface);
+    LIST_FOR_EACH_ENTRY_SAFE(target, next, &This->targets, struct mutation_observer_target, entry) {
+        if(target->native_node != node)
+            continue;
+        target->native_registered = FALSE;
+        list_remove(&target->entry);
+        nsISupports_Release((nsISupports *)target->native_node);
+        node_release(target->node);
+        free(target);
+    }
+    if(list_empty(&This->targets) && This->observing_ref) {
+        This->observing_ref = FALSE;
+        release_observer = TRUE;
+    }
+    if(release_observer)
+        IWineMSHTMLMutationObserver_Release(&This->IWineMSHTMLMutationObserver_iface);
+    IWineMSHTMLMutationObserver_Release(&This->IWineMSHTMLMutationObserver_iface);
+}
+
+static void NSAPI mutation_observer_ParentChainChanged(nsIMutationObserver *iface, nsIContent *content)
+{
+}
+
+static const nsIMutationObserverVtbl mutation_observer_ns_vtbl = {
+    mutation_observer_ns_QueryInterface,
+    mutation_observer_ns_AddRef,
+    mutation_observer_ns_Release,
+    mutation_observer_CharacterDataWillChange,
+    mutation_observer_CharacterDataChanged,
+    mutation_observer_AttributeWillChange,
+    mutation_observer_AttributeChanged,
+    mutation_observer_NativeAnonymousChildListChange,
+    mutation_observer_AttributeSetToCurrentValue,
+    mutation_observer_ContentAppended,
+    mutation_observer_ContentInserted,
+    mutation_observer_ContentRemoved,
+    mutation_observer_NodeWillBeDestroyed,
+    mutation_observer_ParentChainChanged
+};
+
+static inline struct mutation_observer *mutation_observer_from_DispatchEx(DispatchEx *iface)
+{
+    return CONTAINING_RECORD(iface, struct mutation_observer, dispex);
+}
+
 DISPEX_IDISPATCH_IMPL(MutationObserver, IWineMSHTMLMutationObserver,
                       impl_from_IWineMSHTMLMutationObserver(iface)->dispex)
+
+static void mutation_observer_disconnect_internal(struct mutation_observer *This)
+{
+    struct mutation_observer_target *target, *next;
+
+    ++This->delivery_generation;
+    This->delivery_pending = FALSE;
+    LIST_FOR_EACH_ENTRY_SAFE(target, next, &This->targets, struct mutation_observer_target, entry)
+        mutation_observer_remove_target(This, target);
+    mutation_observer_clear_records(This);
+    if(This->observing_ref) {
+        This->observing_ref = FALSE;
+        IWineMSHTMLMutationObserver_Release(&This->IWineMSHTMLMutationObserver_iface);
+    }
+}
 
 static HRESULT WINAPI MutationObserver_disconnect(IWineMSHTMLMutationObserver *iface)
 {
     struct mutation_observer *This = impl_from_IWineMSHTMLMutationObserver(iface);
 
-    FIXME("(%p), stub\n", This);
-
+    TRACE("(%p)\n", This);
+    IWineMSHTMLMutationObserver_AddRef(iface);
+    mutation_observer_disconnect_internal(This);
+    IWineMSHTMLMutationObserver_Release(iface);
     return S_OK;
+}
+
+static HRESULT mutation_observer_get_option(IDispatch *options, const WCHAR *name,
+        VARIANT *value, BOOL *present)
+{
+    DISPPARAMS params = {0};
+    LPOLESTR names[] = {(WCHAR *)name};
+    DISPID id;
+    HRESULT hres;
+
+    VariantInit(value);
+    *present = FALSE;
+    hres = IDispatch_GetIDsOfNames(options, &IID_NULL, names, 1, LOCALE_SYSTEM_DEFAULT, &id);
+    if(hres == DISP_E_UNKNOWNNAME)
+        return S_OK;
+    if(FAILED(hres))
+        return hres;
+
+    hres = IDispatch_Invoke(options, id, &IID_NULL, LOCALE_SYSTEM_DEFAULT,
+            DISPATCH_PROPERTYGET, &params, value, NULL, NULL);
+    if(SUCCEEDED(hres))
+        *present = V_VT(value) != VT_EMPTY;
+    return hres;
+}
+
+static HRESULT mutation_observer_option_present(IDispatch *options, const WCHAR *name, BOOL *present)
+{
+    VARIANT value;
+    HRESULT hres;
+
+    hres = mutation_observer_get_option(options, name, &value, present);
+    VariantClear(&value);
+    return hres;
+}
+
+static HRESULT mutation_observer_to_boolean(VARIANT *value, BOOL *ret)
+{
+    VARIANT v;
+    HRESULT hres;
+
+    VariantInit(&v);
+    hres = VariantCopyInd(&v, value);
+    if(FAILED(hres))
+        return hres;
+
+    switch(V_VT(&v)) {
+    case VT_EMPTY:
+    case VT_NULL:
+        *ret = FALSE;
+        break;
+    case VT_BOOL:
+        *ret = V_BOOL(&v) != VARIANT_FALSE;
+        break;
+    case VT_I1:
+        *ret = V_I1(&v) != 0;
+        break;
+    case VT_UI1:
+        *ret = V_UI1(&v) != 0;
+        break;
+    case VT_I2:
+        *ret = V_I2(&v) != 0;
+        break;
+    case VT_UI2:
+        *ret = V_UI2(&v) != 0;
+        break;
+    case VT_I4:
+        *ret = V_I4(&v) != 0;
+        break;
+    case VT_UI4:
+        *ret = V_UI4(&v) != 0;
+        break;
+    case VT_I8:
+        *ret = V_I8(&v) != 0;
+        break;
+    case VT_UI8:
+        *ret = V_UI8(&v) != 0;
+        break;
+    case VT_INT:
+        *ret = V_INT(&v) != 0;
+        break;
+    case VT_UINT:
+        *ret = V_UINT(&v) != 0;
+        break;
+    case VT_R4:
+        *ret = V_R4(&v) != 0 && V_R4(&v) == V_R4(&v);
+        break;
+    case VT_R8:
+    case VT_DATE:
+        *ret = V_R8(&v) != 0 && V_R8(&v) == V_R8(&v);
+        break;
+    case VT_CY:
+        *ret = V_CY(&v).int64 != 0;
+        break;
+    case VT_BSTR:
+        *ret = V_BSTR(&v) && SysStringLen(V_BSTR(&v));
+        break;
+    case VT_DISPATCH:
+        *ret = V_DISPATCH(&v) != NULL;
+        break;
+    case VT_UNKNOWN:
+        *ret = V_UNKNOWN(&v) != NULL;
+        break;
+    default:
+        hres = DISP_E_TYPEMISMATCH;
+    }
+
+    VariantClear(&v);
+    return hres;
+}
+
+static HRESULT mutation_observer_get_bool(IDispatch *options, const WCHAR *name, BOOL *ret, BOOL *present)
+{
+    VARIANT value;
+    HRESULT hres;
+
+    *ret = FALSE;
+    hres = mutation_observer_get_option(options, name, &value, present);
+    if(SUCCEEDED(hres))
+        hres = mutation_observer_to_boolean(&value, ret);
+    VariantClear(&value);
+    return hres;
+}
+
+static HRESULT mutation_observer_get_native_node(HTMLDOMNode *node, nsINode **ret)
+{
+    UINT16 node_type;
+    nsresult nsres;
+
+    *ret = NULL;
+    nsres = nsIDOMNode_GetNodeType(node->nsnode, &node_type);
+    if(NS_FAILED(nsres))
+        return map_nsresult(nsres);
+    if(node_type == DOCUMENT_NODE)
+        nsres = nsIDOMNode_QueryInterface(node->nsnode, &IID_nsIDocument, (void **)ret);
+    else
+        nsres = nsIDOMNode_QueryInterface(node->nsnode, &IID_nsIContent, (void **)ret);
+    return NS_FAILED(nsres) ? map_nsresult(nsres) : S_OK;
 }
 
 static HRESULT WINAPI MutationObserver_observe(IWineMSHTMLMutationObserver *iface, IHTMLDOMNode *target,
                                                IDispatch *options)
 {
     struct mutation_observer *This = impl_from_IWineMSHTMLMutationObserver(iface);
+    struct mutation_observer_target *entry;
+    HTMLDOMNode *node;
+    nsINode *native_node;
+    BOOL attributes, attribute_old, character_data, character_data_old, child_list, subtree;
+    BOOL attributes_present, attribute_old_present, character_data_present;
+    BOOL character_data_old_present, ignored, filter_present;
+    nsresult nsres;
+    HRESULT hres;
 
-    FIXME("(%p)->(%p %p), stub\n", This, target, options);
+    TRACE("(%p)->(%p %p)\n", This, target, options);
 
+    if(!target || !options || !(node = unsafe_impl_from_IHTMLDOMNode(target)))
+        return E_INVALIDARG;
+    if(FAILED(hres = mutation_observer_get_bool(options, L"attributes", &attributes, &attributes_present))
+            || FAILED(hres = mutation_observer_get_bool(options, L"attributeOldValue", &attribute_old,
+                    &attribute_old_present))
+            || FAILED(hres = mutation_observer_get_bool(options, L"characterData", &character_data,
+                    &character_data_present))
+            || FAILED(hres = mutation_observer_get_bool(options, L"characterDataOldValue", &character_data_old,
+                    &character_data_old_present))
+            || FAILED(hres = mutation_observer_get_bool(options, L"childList", &child_list, &ignored))
+            || FAILED(hres = mutation_observer_get_bool(options, L"subtree", &subtree, &ignored))
+            || FAILED(hres = mutation_observer_option_present(options, L"attributeFilter", &filter_present)))
+        return hres;
+
+    if(!attributes_present && (attribute_old_present || filter_present))
+        attributes = TRUE;
+    if(!character_data_present && character_data_old_present)
+        character_data = TRUE;
+    if(attributes || attribute_old || character_data_old || filter_present)
+        return E_NOTIMPL;
+    if(!character_data && !child_list)
+        return E_INVALIDARG;
+
+    LIST_FOR_EACH_ENTRY(entry, &This->targets, struct mutation_observer_target, entry) {
+        if(entry->node == node) {
+            entry->transient = FALSE;
+            entry->character_data = character_data;
+            entry->child_list = child_list;
+            entry->subtree = subtree;
+            return S_OK;
+        }
+    }
+
+    if(!content_utils || !node->nsnode)
+        return E_UNEXPECTED;
+    hres = mutation_observer_get_native_node(node, &native_node);
+    if(FAILED(hres))
+        return hres;
+
+    entry = calloc(1, sizeof(*entry));
+    if(!entry) {
+        nsISupports_Release((nsISupports *)native_node);
+        return E_OUTOFMEMORY;
+    }
+    nsres = nsIContentUtils_AddMutationObserver(content_utils, native_node,
+            &This->nsIMutationObserver_iface);
+    if(NS_FAILED(nsres)) {
+        nsISupports_Release((nsISupports *)native_node);
+        free(entry);
+        return map_nsresult(nsres);
+    }
+
+    node_addref(node);
+    entry->node = node;
+    entry->native_node = native_node;
+    entry->native_registered = TRUE;
+    entry->character_data = character_data;
+    entry->child_list = child_list;
+    entry->subtree = subtree;
+    list_add_tail(&This->targets, &entry->entry);
+    if(!This->observing_ref) {
+        This->observing_ref = TRUE;
+        IWineMSHTMLMutationObserver_AddRef(iface);
+    }
     return S_OK;
 }
 
 static HRESULT WINAPI MutationObserver_takeRecords(IWineMSHTMLMutationObserver *iface, IDispatch **ret)
 {
     struct mutation_observer *This = impl_from_IWineMSHTMLMutationObserver(iface);
+    HRESULT hres;
 
-    FIXME("(%p)->(%p), stub\n", This, ret);
-
-    return E_NOTIMPL;
+    TRACE("(%p)->(%p)\n", This, ret);
+    if(!ret)
+        return E_POINTER;
+    *ret = NULL;
+    ++This->delivery_generation;
+    This->delivery_pending = FALSE;
+    hres = mutation_observer_create_records(This, ret);
+    if(mutation_observer_has_transients(This))
+        mutation_observer_schedule(This);
+    return hres;
 }
 
 static const IWineMSHTMLMutationObserverVtbl WineMSHTMLMutationObserverVtbl = {
@@ -1183,37 +2527,59 @@ static const IWineMSHTMLMutationObserverVtbl WineMSHTMLMutationObserverVtbl = {
     MutationObserver_takeRecords
 };
 
-static inline struct mutation_observer *mutation_observer_from_DispatchEx(DispatchEx *iface)
-{
-    return CONTAINING_RECORD(iface, struct mutation_observer, dispex);
-}
-
 static void *mutation_observer_query_interface(DispatchEx *dispex, REFIID riid)
 {
     struct mutation_observer *This = mutation_observer_from_DispatchEx(dispex);
 
     if(IsEqualGUID(&IID_IWineMSHTMLMutationObserver, riid))
         return &This->IWineMSHTMLMutationObserver_iface;
-
     return NULL;
 }
 
 static void mutation_observer_traverse(DispatchEx *dispex, nsCycleCollectionTraversalCallback *cb)
 {
     struct mutation_observer *This = mutation_observer_from_DispatchEx(dispex);
+    struct mutation_observer_target *target;
+    struct mutation_observer_record *record;
+
     if(This->callback)
         note_cc_edge((nsISupports*)This->callback, "callback", cb);
+    if(This->delivery_pending)
+        note_cc_edge((nsISupports*)&This->nsIMutationObserver_iface, "scheduled_runner", cb);
+    LIST_FOR_EACH_ENTRY(target, &This->targets, struct mutation_observer_target, entry) {
+        note_cc_edge((nsISupports*)&target->node->IHTMLDOMNode_iface, "target", cb);
+        note_cc_edge((nsISupports*)target->native_node, "native_target", cb);
+    }
+    LIST_FOR_EACH_ENTRY(record, &This->records, struct mutation_observer_record, entry) {
+        UINT32 i;
+
+        note_cc_edge((nsISupports*)&record->target->IHTMLDOMNode_iface, "record_target", cb);
+        if(record->previous_sibling)
+            note_cc_edge((nsISupports *)record->previous_sibling, "previous_sibling", cb);
+        if(record->next_sibling)
+            note_cc_edge((nsISupports *)record->next_sibling, "next_sibling", cb);
+        for(i = 0; i < record->added_count; i++)
+            note_cc_edge((nsISupports *)record->added_nodes[i], "added_node", cb);
+        for(i = 0; i < record->removed_count; i++)
+            note_cc_edge((nsISupports *)record->removed_nodes[i], "removed_node", cb);
+    }
 }
 
 static void mutation_observer_unlink(DispatchEx *dispex)
 {
     struct mutation_observer *This = mutation_observer_from_DispatchEx(dispex);
+
+    IWineMSHTMLMutationObserver_AddRef(&This->IWineMSHTMLMutationObserver_iface);
+    mutation_observer_disconnect_internal(This);
+    IWineMSHTMLMutationObserver_Release(&This->IWineMSHTMLMutationObserver_iface);
     unlink_ref(&This->callback);
 }
 
 static void mutation_observer_destructor(DispatchEx *dispex)
 {
     struct mutation_observer *This = mutation_observer_from_DispatchEx(dispex);
+
+    mutation_observer_disconnect_internal(This);
     free(This);
 }
 
@@ -1245,17 +2611,15 @@ static HRESULT create_mutation_observer(DispatchEx *owner, IDispatch *callback,
     struct mutation_observer *obj;
 
     TRACE("(callback = %p, ret = %p)\n", callback, ret);
-
     obj = calloc(1, sizeof(*obj));
     if(!obj)
-    {
-        ERR("No memory.\n");
         return E_OUTOFMEMORY;
-    }
 
     obj->IWineMSHTMLMutationObserver_iface.lpVtbl = &WineMSHTMLMutationObserverVtbl;
+    obj->nsIMutationObserver_iface.lpVtbl = &mutation_observer_ns_vtbl;
+    list_init(&obj->targets);
+    list_init(&obj->records);
     init_dispatch_with_owner(&obj->dispex, &MutationObserver_dispex, owner);
-
     IDispatch_AddRef(callback);
     obj->callback = callback;
     *ret = &obj->IWineMSHTMLMutationObserver_iface;
@@ -1269,6 +2633,7 @@ static HRESULT mutation_observer_ctor_value(DispatchEx *dispex, LCID lcid,
     struct constructor *This = constructor_from_DispatchEx(dispex);
     VARIANT *callback;
     IWineMSHTMLMutationObserver *mutation_observer;
+    BOOL callable;
     HRESULT hres;
     int argc = params->cArgs - params->cNamedArgs;
 
@@ -1290,21 +2655,23 @@ static HRESULT mutation_observer_ctor_value(DispatchEx *dispex, LCID lcid,
         return E_UNEXPECTED;
 
     callback = params->rgvarg + (params->cArgs - 1);
-    if (V_VT(callback) != VT_DISPATCH) {
-        FIXME("Should return TypeMismatchError\n");
+    if (V_VT(callback) != VT_DISPATCH || !V_DISPATCH(callback))
         return E_FAIL;
-    }
-
+    if (!This->window->jscript)
+        return E_UNEXPECTED;
+    hres = IWineJScript_IsCallable(This->window->jscript, V_DISPATCH(callback), &callable);
+    if (FAILED(hres))
+        return hres;
+    if (!callable)
+        return E_FAIL;
     if (!res)
         return S_OK;
 
     hres = create_mutation_observer(&This->dispex, V_DISPATCH(callback), &mutation_observer);
     if (FAILED(hres))
         return hres;
-
     V_VT(res) = VT_DISPATCH;
     V_DISPATCH(res) = (IDispatch*)mutation_observer;
-
     return S_OK;
 }
 

--- a/dlls/mshtml/tests/mutationobserver.js
+++ b/dlls/mshtml/tests/mutationobserver.js
@@ -1,0 +1,339 @@
+/*
+ * Copyright 2026 Elkana Bardugo
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+function expect_throw(func, message) {
+    var threw = false;
+    try {
+        func();
+    } catch (e) {
+        threw = true;
+    }
+    ok(threw, message);
+}
+
+function expect_no_throw(func, message) {
+    var threw = false;
+    try {
+        func();
+    } catch (e) {
+        threw = true;
+    }
+    ok(!threw, message);
+}
+
+function test_constructor_and_observe_validation() {
+    var observer = new MutationObserver(function() {});
+    var text = document.createTextNode("text"), default_get_count = 0;
+    var truthy = {};
+
+    Object.defineProperty(truthy, "valueOf", {get: function() {
+        default_get_count++;
+        throw new Error("valueOf accessed");
+    }});
+    Object.defineProperty(truthy, "toString", {get: function() {
+        default_get_count++;
+        throw new Error("toString accessed");
+    }});
+
+    expect_throw(function() { new MutationObserver(null); }, "null callback rejected");
+    expect_throw(function() { new MutationObserver({}); }, "non-callable callback rejected");
+    expect_throw(function() { observer.observe(null, {}); }, "null target rejected");
+    expect_throw(function() { observer.observe(text, null); }, "null options rejected");
+    expect_throw(function() { observer.observe(text, {}); }, "empty options rejected");
+    expect_throw(function() { observer.observe(text, {attributes: true}); }, "attributes rejected honestly");
+    expect_throw(function() { observer.observe(text, {attributeOldValue: true}); }, "attributeOldValue true implies unsupported attributes");
+    expect_throw(function() { observer.observe(text, {attributeOldValue: false}); }, "present attributeOldValue implies unsupported attributes");
+    expect_throw(function() { observer.observe(text, {attributeFilter: []}); }, "attributeFilter implies unsupported attributes");
+    observer.observe(text, {childList: true});
+    observer.disconnect();
+    expect_throw(function() { observer.observe(text, {characterDataOldValue: true}); }, "characterDataOldValue true rejected honestly");
+    expect_no_throw(function() { observer.observe(text, {characterDataOldValue: false}); },
+                    "false characterDataOldValue implies supported characterData");
+    observer.disconnect();
+    expect_no_throw(function() { observer.observe(text, {characterData: true, attributeFilter: undefined}); },
+                    "undefined attributeFilter is treated as absent");
+    observer.disconnect();
+    expect_no_throw(function() { observer.observe(text, {characterData: truthy}); },
+                    "object characterData option is truthy");
+    ok(default_get_count === 0, "object option truthiness did not access default properties");
+    observer.disconnect();
+    observer.observe(text, {characterData: true, attributes: false, attributeOldValue: false,
+                           characterDataOldValue: false, childList: false});
+    observer.disconnect();
+    next_test();
+}
+
+function test_take_records_and_fields() {
+    var text = document.createTextNode("first"), observer;
+    var array_constructor = window.Array, records, record, threw = false;
+
+    observer = new MutationObserver(function() {
+        ok(false, "takeRecords mutation was delivered early");
+    });
+    observer.observe(text, {characterData: true});
+    text.data = "second";
+    window.Array = function() { throw new Error("poisoned Array called"); };
+    try {
+        records = observer.takeRecords();
+    } catch (e) {
+        threw = true;
+    }
+    window.Array = array_constructor;
+    ok(!threw, "takeRecords ignored poisoned window.Array");
+    if (threw)
+        records = [];
+    ok(records instanceof Array, "takeRecords returned an intrinsic Array");
+    ok(records.length === 1, "takeRecords returned one record");
+    record = records[0];
+    ok(record.type === "characterData", "record type");
+    ok(record.target === text, "record target identity");
+    ok(record.previousSibling === null, "previousSibling is null");
+    ok(record.nextSibling === null, "nextSibling is null");
+    ok(record.attributeName === null, "attributeName is null");
+    ok(record.attributeNamespace === null, "attributeNamespace is null");
+    ok(record.oldValue === null, "oldValue is null");
+    ok(record.addedNodes.length === 0, "addedNodes is an empty NodeList");
+    ok(record.removedNodes.length === 0, "removedNodes is an empty NodeList");
+    record.type = "changed";
+    record.target = null;
+    delete record.oldValue;
+    ok(record.type === "characterData", "record type is read-only");
+    ok(record.target === text, "record target is read-only");
+    ok(record.oldValue === null, "record oldValue is non-configurable");
+    ok(observer.takeRecords().length === 0, "takeRecords drained the queue");
+    observer.disconnect();
+    next_test();
+}
+
+function test_subtree_and_disconnect() {
+    var parent = document.createElement("div"), child = document.createElement("span");
+    var text = document.createTextNode("first"), observer, records;
+
+    child.appendChild(text);
+    parent.appendChild(child);
+    observer = new MutationObserver(function() {
+        ok(false, "subtree mutation was delivered early");
+    });
+    observer.observe(parent, {characterData: true, subtree: true});
+    text.data = "second";
+    records = observer.takeRecords();
+    ok(records.length === 1, "subtree mutation matched");
+    ok(records[0].target === text, "subtree target identity");
+
+    text.data = "third";
+    observer.disconnect();
+    ok(observer.takeRecords().length === 0, "disconnect cleared pending records");
+    next_test();
+}
+
+function test_childlist_records_and_snapshots() {
+    var parent = document.createElement("div"), first = document.createElement("i");
+    var second = document.createElement("b"), inserted = document.createElement("em");
+    var batch_first = document.createElement("strong"), batch_second = document.createElement("small");
+    var fragment = document.createDocumentFragment(), observer, records, record, snapshot;
+
+    observer = new MutationObserver(function() {
+        ok(false, "childList mutation was delivered before takeRecords");
+    });
+    observer.observe(parent, {childList: true});
+
+    parent.appendChild(first);
+    records = observer.takeRecords();
+    ok(records.length === 1, "append produced one childList record");
+    record = records[0];
+    ok(record.type === "childList", "append record type");
+    ok(record.target === parent, "append record target");
+    ok(record.previousSibling === null, "append previousSibling is null");
+    ok(record.nextSibling === null, "append nextSibling is null");
+    ok(record.addedNodes.length === 1, "append addedNodes length");
+    snapshot = record.addedNodes;
+    ok(snapshot instanceof NodeList, "addedNodes is a NodeList");
+    ok(snapshot === record.addedNodes, "addedNodes snapshot identity is stable");
+    ok(snapshot[0] === first, "append addedNodes indexed access");
+    ok(snapshot.item(0) === first, "append addedNodes.item(0)");
+    ok(record.removedNodes instanceof NodeList, "removedNodes is a NodeList");
+    ok(record.removedNodes.length === 0, "append removedNodes is empty");
+
+    parent.appendChild(second);
+    ok(observer.takeRecords().length === 1, "second append was queued");
+    parent.insertBefore(inserted, second);
+    records = observer.takeRecords();
+    ok(records.length === 1, "insert-before produced one childList record");
+    record = records[0];
+    ok(record.addedNodes.length === 1 && record.addedNodes.item(0) === inserted,
+       "insert-before added node snapshot");
+    ok(record.previousSibling === first, "insert-before previousSibling");
+    ok(record.nextSibling === second, "insert-before nextSibling");
+
+    fragment.appendChild(batch_first);
+    fragment.appendChild(batch_second);
+    parent.appendChild(fragment);
+    records = observer.takeRecords();
+    ok(records.length === 1, "fragment append coalesced to one native childList record");
+    record = records[0];
+    ok(record.addedNodes.length === 2, "fragment append addedNodes length");
+    ok(record.addedNodes.item(0) === batch_first, "fragment append first node");
+    ok(record.addedNodes.item(1) === batch_second, "fragment append second node");
+    ok(record.previousSibling === second, "fragment append previousSibling");
+    ok(record.nextSibling === null, "fragment append nextSibling is null");
+
+    parent.removeChild(inserted);
+    records = observer.takeRecords();
+    ok(records.length === 1, "removal produced one childList record");
+    record = records[0];
+    ok(record.addedNodes.length === 0, "removal addedNodes is empty");
+    ok(record.removedNodes.length === 1, "removal removedNodes length");
+    ok(record.removedNodes.item(0) === inserted, "removal removedNodes.item(0)");
+    ok(record.previousSibling === first, "removal previousSibling");
+    ok(record.nextSibling === second, "removal nextSibling");
+
+    parent.removeChild(first);
+    ok(observer.takeRecords().length === 1, "snapshot follow-up removal was queued");
+    observer.disconnect();
+    CollectGarbage();
+    ok(snapshot.length === 1 && snapshot.item(0) === first,
+       "addedNodes snapshot survived disconnect and garbage collection");
+    next_test();
+}
+
+function test_childlist_subtree_and_disconnect() {
+    var root = document.createElement("div"), child = document.createElement("span");
+    var grandchild = document.createElement("b"), after_disconnect = document.createElement("i");
+    var observer, records;
+
+    root.appendChild(child);
+    observer = new MutationObserver(function() {
+        ok(false, "subtree childList mutation was delivered before takeRecords");
+    });
+    observer.observe(root, {childList: true, subtree: true});
+    child.appendChild(grandchild);
+    records = observer.takeRecords();
+    ok(records.length === 1, "subtree childList mutation matched");
+    ok(records[0].target === child, "subtree childList target is container");
+    ok(records[0].addedNodes.item(0) === grandchild, "subtree added node");
+
+    child.removeChild(grandchild);
+    ok(observer.takeRecords().length === 1, "subtree removal matched");
+    observer.disconnect();
+    child.appendChild(after_disconnect);
+    ok(observer.takeRecords().length === 0, "disconnect cleared childList observation");
+    next_test();
+}
+
+function test_detached_subtree_before_delivery() {
+    var root = document.createElement("div"), child = document.createElement("span");
+    var text = document.createTextNode("first"), observer, records;
+
+    child.appendChild(text);
+    root.appendChild(child);
+    observer = new MutationObserver(function() {
+        ok(false, "detached subtree mutations were delivered before takeRecords");
+    });
+    observer.observe(root, {childList: true, characterData: true, subtree: true});
+    root.removeChild(child);
+    text.data = "second";
+    records = observer.takeRecords();
+    ok(records.length === 2, "removal and detached descendant mutation were queued");
+    ok(records[0].type === "childList" && records[0].removedNodes.item(0) === child,
+       "detached subtree removal record");
+    ok(records[1].type === "characterData" && records[1].target === text,
+       "detached descendant mutation record");
+
+    text.data = "third";
+    records = observer.takeRecords();
+    ok(records.length === 1 && records[0].target === text,
+       "takeRecords preserves transient observation until the checkpoint");
+    observer.disconnect();
+    next_test();
+}
+
+function test_childlist_reentrant_delivery() {
+    var parent = document.createElement("div"), first = document.createElement("i");
+    var second = document.createElement("b"), observer, callback_count = 0, finished = false;
+    var timeout = window.setTimeout(function() {
+        if (finished)
+            return;
+        finished = true;
+        ok(false, "childList MutationObserver callback timed out");
+        next_test();
+    }, 5000);
+
+    observer = new MutationObserver(function(records, callback_observer) {
+        callback_count++;
+        ok(this === observer, "childList callback this is observer");
+        ok(callback_observer === observer, "childList callback observer identity");
+        ok(records.length === 1, "childList callback received one record");
+        if (callback_count === 1) {
+            ok(records[0].addedNodes.item(0) === first, "first reentrant record node");
+            CollectGarbage();
+            parent.appendChild(second);
+            return;
+        }
+        ok(callback_count === 2, "reentrant childList mutation delivered later");
+        ok(records[0].addedNodes.item(0) === second, "second reentrant record node");
+        finished = true;
+        window.clearTimeout(timeout);
+        callback_observer.disconnect();
+        next_test();
+    });
+
+    observer.observe(parent, {childList: true});
+    CollectGarbage();
+    parent.appendChild(first);
+}
+
+function test_reentrant_delivery_and_lifetime() {
+    var text = document.createTextNode("first"), callback_count = 0, finished = false;
+    var timeout = window.setTimeout(function() {
+        if (finished)
+            return;
+        finished = true;
+        ok(false, "MutationObserver callback timed out");
+        next_test();
+    }, 5000);
+    var observer = new MutationObserver(function(records, callback_observer) {
+        callback_count++;
+        ok(this === observer, "callback this is observer");
+        ok(records instanceof Array, "callback records is an Array");
+        ok(callback_observer === observer, "callback observer identity");
+        ok(records.length === 1, "callback received one record");
+        if (callback_count === 1) {
+            CollectGarbage();
+            text.data = "third";
+            return;
+        }
+        ok(callback_count === 2, "reentrant mutation delivered later");
+        finished = true;
+        window.clearTimeout(timeout);
+        this.disconnect();
+        next_test();
+    });
+
+    observer.observe(text, {characterData: true});
+    CollectGarbage();
+    text.data = "second";
+}
+
+var tests = [test_constructor_and_observe_validation,
+             test_take_records_and_fields,
+             test_childlist_records_and_snapshots,
+             test_childlist_subtree_and_disconnect,
+             test_detached_subtree_before_delivery,
+             test_childlist_reentrant_delivery,
+             test_subtree_and_disconnect,
+             test_reentrant_delivery_and_lifetime];

--- a/dlls/mshtml/tests/mutationobserver.js
+++ b/dlls/mshtml/tests/mutationobserver.js
@@ -141,6 +141,35 @@ function test_subtree_and_disconnect() {
     next_test();
 }
 
+function test_reobserve_replaces_options() {
+    var parent = document.createElement("div"), child = document.createElement("span");
+    var text = document.createTextNode("first"), direct = document.createElement("i");
+    var observer, records;
+
+    child.appendChild(text);
+    parent.appendChild(child);
+    observer = new MutationObserver(function() {
+        ok(false, "re-observed mutation was delivered before takeRecords");
+    });
+    observer.observe(parent, {characterData: true, subtree: true});
+    observer.observe(parent, {childList: true});
+    text.data = "second";
+    child.appendChild(document.createElement("b"));
+    parent.appendChild(direct);
+    records = observer.takeRecords();
+    ok(records.length === 1 && records[0].type === "childList" && records[0].target === parent,
+       "re-observe replaced characterData and subtree options");
+
+    observer.observe(parent, {characterData: true, subtree: true});
+    parent.appendChild(document.createElement("em"));
+    text.data = "third";
+    records = observer.takeRecords();
+    ok(records.length === 1 && records[0].type === "characterData" && records[0].target === text,
+       "second re-observe replaced childList options");
+    observer.disconnect();
+    next_test();
+}
+
 function test_childlist_records_and_snapshots() {
     var parent = document.createElement("div"), first = document.createElement("i");
     var second = document.createElement("b"), inserted = document.createElement("em");
@@ -152,6 +181,7 @@ function test_childlist_records_and_snapshots() {
     });
     observer.observe(parent, {childList: true});
 
+    first.id = "snapshot-first";
     parent.appendChild(first);
     records = observer.takeRecords();
     ok(records.length === 1, "append produced one childList record");
@@ -189,6 +219,7 @@ function test_childlist_records_and_snapshots() {
     ok(record.addedNodes.length === 2, "fragment append addedNodes length");
     ok(record.addedNodes.item(0) === batch_first, "fragment append first node");
     ok(record.addedNodes.item(1) === batch_second, "fragment append second node");
+    ok(record.addedNodes.item(2) === null, "fragment append out-of-range item is null");
     ok(record.previousSibling === second, "fragment append previousSibling");
     ok(record.nextSibling === null, "fragment append nextSibling is null");
 
@@ -205,8 +236,9 @@ function test_childlist_records_and_snapshots() {
     parent.removeChild(first);
     ok(observer.takeRecords().length === 1, "snapshot follow-up removal was queued");
     observer.disconnect();
+    first = null;
     CollectGarbage();
-    ok(snapshot.length === 1 && snapshot.item(0) === first,
+    ok(snapshot.length === 1 && snapshot.item(0).id === "snapshot-first",
        "addedNodes snapshot survived disconnect and garbage collection");
     next_test();
 }
@@ -331,6 +363,7 @@ function test_reentrant_delivery_and_lifetime() {
 
 var tests = [test_constructor_and_observe_validation,
              test_take_records_and_fields,
+             test_reobserve_replaces_options,
              test_childlist_records_and_snapshots,
              test_childlist_subtree_and_disconnect,
              test_detached_subtree_before_delivery,

--- a/dlls/mshtml/tests/rsrc.rc
+++ b/dlls/mshtml/tests/rsrc.rc
@@ -19,6 +19,9 @@
 /* @makedep: winetest.js */
 winetest.js HTML "winetest.js"
 
+/* @makedep: mutationobserver.js */
+mutationobserver.js HTML "mutationobserver.js"
+
 /* @makedep: exectest.html */
 exectest.html HTML "exectest.html"
 

--- a/dlls/mshtml/tests/script.c
+++ b/dlls/mshtml/tests/script.c
@@ -5223,6 +5223,7 @@ static void run_js_tests(void)
     run_script_as_http_with_mode("xhr.js", NULL, "10");
     run_script_as_http_with_mode("xhr.js", NULL, "11");
     run_script_as_http_with_mode("dom.js", NULL, "11");
+    run_script_as_http_with_mode("mutationobserver.js", NULL, "11");
     run_script_as_http_with_mode("es5.js", NULL, "11");
     run_script_as_http_with_mode("events.js", NULL, "9");
     run_script_as_http_with_mode("navigation.js", NULL, NULL);


### PR DESCRIPTION
## Stack

PR 3 of 8. Stacked on #26; merge only after #26.

## Summary

- Implement ordered MutationObserver record creation and delivery.
- Support subtree observation, removed-subtree transients, and reentrant callbacks.
- Preserve stable NodeList-compatible snapshots and cycle-collection lifetimes.
- Add focused JavaScript coverage for validation, records, snapshots, and lifecycle.

## Functional boundary

Includes only the JScript bridge and MSHTML MutationObserver behavior.

Excludes WinRT prerequisites in #25-#26 and all manager, DirectComposition, and Wayland work in later PRs.

## Validation

- `git diff --check` and JavaScript syntax validation passed on the source integration.
- Both x86_64 and i386 MSHTML/JScript targets linked in the validated integration build.
- Runtime execution remains dependent on an authorized Gecko fixture; no external MSI was executed.

## Provenance

- Base branch: `feature/outlook-new-02-environment-probes`.
- Reconstructed from final integration HEAD `cf77f3b43ce5981bac562d692d25c74dc1ed6be1`.
- The original dirty integration worktree was not modified.

## Review notes

Treat missing Gecko as a harness limitation, not a passing or failing product result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Implement asynchronous MSHTML MutationObserver behavior for text and child-node changes.

New Features:
- Implement MutationObserver support for character-data and child-list changes, including subtree observation and detached-subtree tracking.
- Deliver mutation records asynchronously with ordered snapshots, reentrant callback handling, and takeRecords support.

Bug Fixes:
- Preserve mutation record and NodeList lifetimes across disconnection and garbage collection.

Enhancements:
- Extend the JScript bridge with intrinsic array creation and callable validation for MutationObserver integration.
- Improve NodeList-compatible collection behavior for out-of-range item access.

Documentation:
- Document reliable observation of text and child-node changes for modern Office web views.

Tests:
- Add JavaScript coverage for validation, mutation records, snapshots, subtree behavior, detached subtrees, disconnection, and reentrant delivery.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added JavaScript `MutationObserver` support, including asynchronous notifications, subtree tracking, mutation records, and disconnect handling.
  * Added JavaScript array creation with a specified length.
  * Added callable-function detection for dispatch objects.

* **Bug Fixes**
  * Improved error reporting when script setup or scheduling fails.
  * Corrected out-of-range DOM collection access to return a null result.

* **Tests**
  * Added comprehensive coverage for mutation observation, callbacks, records, detached nodes, and observer lifecycle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->