### PR TITLE
wine4office: Prepare and close New Outlook reliably

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- Let modern Office identify the current user without exposing machine, account,
+  or application identifiers.
+- Let packaged Office components discover their local application-data folders
+  and education-environment state.
+- Let modern Office web views observe text and child-node changes reliably.
+- Keep Outlook shortcuts working safely across Store package changes and
+  classic Outlook fallback.
+
 ## 0.2.0-beta.1 — 2026-08-19
 
 - Let Office finish proofing-language updates without crashing Click-to-Run.

--- a/programs/wine4officeclose/Makefile.in
+++ b/programs/wine4officeclose/Makefile.in
@@ -1,5 +1,5 @@
 MODULE    = wine4officeclose.exe
-IMPORTS   = user32
+IMPORTS   = user32 ntdll
 
 EXTRADLLFLAGS = -mconsole -municode
 

--- a/programs/wine4officeclose/tests/wine4officeclose.c
+++ b/programs/wine4officeclose/tests/wine4officeclose.c
@@ -107,7 +107,7 @@ static BOOL run_close_utility_discovery(const WCHAR *utility, DWORD *exit_code)
     return TRUE;
 }
 
-static void test_owned_window_is_the_only_close_target(void)
+static void test_owned_window_is_the_only_close_target(const WCHAR *executable)
 {
     WCHAR module[32768], utility[32768], full_utility[32768];
     WCHAR child_path[MAX_PATH], temp_path[MAX_PATH], command[32768], *slash;
@@ -138,7 +138,7 @@ static void test_owned_window_is_the_only_close_target(void)
         ok(exit_code == 2, "Close utility accepted no targets: %lu\n", exit_code);
 
     ok(GetTempPathW(ARRAY_SIZE(temp_path), temp_path), "GetTempPathW failed: %lu\n", GetLastError());
-    swprintf(child_path, ARRAY_SIZE(child_path), L"%swinword.exe", temp_path);
+    swprintf(child_path, ARRAY_SIZE(child_path), L"%s%s", temp_path, executable);
     ok(CopyFileW(module, child_path, FALSE), "CopyFileW failed: %lu\n", GetLastError());
 
     security.nLength = sizeof(security);
@@ -177,7 +177,8 @@ static void test_owned_window_is_the_only_close_target(void)
     {
         ok(run_close_utility(utility, child_info.dwProcessId, &exit_code),
            "Could not launch close utility\n");
-        ok(exit_code == 0, "Close utility returned %lu\n", exit_code);
+        ok(exit_code == 0, "Close utility returned %lu for %s\n", exit_code,
+           wine_dbgstr_w(executable));
         ok(WaitForSingleObject(child_info.hProcess, 5000) == WAIT_OBJECT_0,
            "Owned Office-like process remained open\n");
         ok(IsWindow(unrelated), "Unrelated top-level window was closed\n");
@@ -199,7 +200,8 @@ static void test_owned_window_is_the_only_close_target(void)
         {
             ok(run_close_utility_discovery(utility, &exit_code),
                "Could not launch close utility discovery\n");
-            ok(exit_code == 0, "Close utility discovery returned %lu\n", exit_code);
+            ok(exit_code == 0, "Close utility discovery returned %lu for %s\n", exit_code,
+               wine_dbgstr_w(executable));
             ok(WaitForSingleObject(child_info.hProcess, 5000) == WAIT_OBJECT_0,
                "Discovered Office-like process remained open\n");
             ok(IsWindow(unrelated), "Discovery closed an unrelated top-level window\n");
@@ -224,5 +226,8 @@ START_TEST(wine4officeclose)
     if (child)
         run_owned_child(child + ARRAY_SIZE(L" --child ") - 1);
     else
-        test_owned_window_is_the_only_close_target();
+    {
+        test_owned_window_is_the_only_close_target(L"winword.exe");
+        test_owned_window_is_the_only_close_target(L"olk.exe");
+    }
 }

--- a/programs/wine4officeclose/wine4officeclose.c
+++ b/programs/wine4officeclose/wine4officeclose.c
@@ -41,6 +41,7 @@ static const WCHAR *office_targets[] =
     L"msaccess.exe",
     L"mspub.exe",
     L"onenote.exe",
+    L"olk.exe",
     L"outlook.exe",
     L"powerpnt.exe",
     L"visio.exe",

--- a/tools/wine4office-manager/tests/test_backend.py
+++ b/tools/wine4office-manager/tests/test_backend.py
@@ -636,6 +636,21 @@ touch "$WINEPREFIX/system.reg" "$WINEPREFIX/user.reg"
             ],
         )
 
+    def test_owned_office_pids_includes_new_outlook(self):
+        prefix = self._make_prefix(self.home / ".wine4office")
+        completed = mock.Mock(
+            returncode=0,
+            stdout='"OLK.EXE","4132","Console","1","12 K"\n'
+                   '"services.exe","43","Services","0","8 K"\n',
+            stderr="",
+        )
+        with mock.patch.object(
+            backend.subprocess, "run", return_value=completed
+        ):
+            self.assertEqual(
+                backend._owned_office_pids(prefix, self.wine), [4132]
+            )
+
     def test_stop_wine_hard_kills_when_graceful_close_fails(self):
         prefix = self._make_prefix(self.home / ".wine4office")
         with mock.patch.object(
@@ -1057,6 +1072,165 @@ touch "$WINEPREFIX/system.reg" "$WINEPREFIX/user.reg"
         self.assertIn("Name=Microsoft Teams (Wine4Office)", desktop_file.read_text())
         self.assertIn(f"executable={shlex.quote(str(teams))}", launcher.read_text())
         self.assertNotIn("%U", desktop_file.read_text())
+
+    def test_outlook_package_parser_rejects_malformed_versions_and_identity(self):
+        valid = backend.parse_windows_apps_package_name(
+            "Microsoft.OutlookForWindows_1.2026.720.100_x64__8wekyb3d8bbwe"
+        )
+        self.assertEqual(
+            valid,
+            (
+                "Microsoft.OutlookForWindows", (1, 2026, 720, 100),
+                "x64", "8wekyb3d8bbwe",
+            ),
+        )
+        for malformed in (
+            "Microsoft.OutlookForWindows_1.2026.bad.100_x64__8wekyb3d8bbwe",
+            "Microsoft.OutlookForWindows_1.2026.720.100_x64__other",
+            "Microsoft.OutlookForWindows_1.2026.720.100_x64__8wekyb3d8bbwe.extra",
+            "Microsoft.OutlookForWindows_1..720_x64__8wekyb3d8bbwe",
+            "Microsoft.OutlookForWindows_1.2026.720_x64__8wekyb3d8bbwe",
+            "Microsoft.OutlookForWindows_1.2026.720.100.1_x64__8wekyb3d8bbwe",
+            "Microsoft.OutlookForWindows_1.2026.70000.100_x64__8wekyb3d8bbwe",
+        ):
+            with self.subTest(malformed=malformed):
+                self.assertIsNone(backend.parse_windows_apps_package_name(malformed))
+
+    def test_outlook_detection_selects_highest_valid_package_with_olk(self):
+        prefix = self._make_prefix(self.home / ".wine4office")
+        windows_apps = prefix / "drive_c/Program Files/WindowsApps"
+        malformed = windows_apps / (
+            "Microsoft.OutlookForWindows_1.2026.bad.100_x64__8wekyb3d8bbwe"
+        )
+        missing = windows_apps / (
+            "Microsoft.OutlookForWindows_1.2026.950.100_x64__8wekyb3d8bbwe"
+        )
+        older = windows_apps / (
+            "Microsoft.OutlookForWindows_1.2026.800.100_x64__8wekyb3d8bbwe"
+        )
+        newer = windows_apps / (
+            "Microsoft.OutlookForWindows_1.2026.900.100_x64__8wekyb3d8bbwe"
+        )
+        malformed.mkdir(parents=True)
+        missing.mkdir()
+        older.mkdir()
+        newer.mkdir()
+        (older / "olk.exe").write_bytes(b"older")
+        (newer / "olk.exe").write_bytes(b"newer")
+
+        installation = backend.find_office_app_info(str(prefix), "outlook")
+
+        self.assertIsNotNone(installation)
+        self.assertEqual(installation.executable, newer / "olk.exe")
+        self.assertEqual(installation.package.identity, newer.name)
+        self.assertTrue(installation.is_new_outlook)
+
+    def test_outlook_detection_falls_back_to_classic_for_invalid_new_package(self):
+        prefix = self._make_prefix(self.home / ".wine4office")
+        package = prefix / (
+            "drive_c/Program Files/WindowsApps/"
+            "Microsoft.OutlookForWindows_1.2026.900.bad_x64__8wekyb3d8bbwe"
+        )
+        package.mkdir(parents=True)
+        (package / "olk.exe").write_bytes(b"new")
+        classic = prefix / "drive_c/Program Files/Microsoft Office/root/Office16"
+        classic.mkdir(parents=True)
+        outlook = classic / "OUTLOOK.EXE"
+        outlook.write_bytes(b"classic")
+
+        installation = backend.find_office_app_info(str(prefix), "outlook")
+
+        self.assertIsNotNone(installation)
+        self.assertEqual(installation.executable, outlook)
+        self.assertIsNone(installation.package)
+        self.assertFalse(installation.is_new_outlook)
+
+    def test_outlook_detection_rejects_symlinked_windowsapps_ancestor(self):
+        for ancestor in ("drive_c", "drive_c/Program Files"):
+            with self.subTest(ancestor=ancestor):
+                prefix = self._make_prefix(self.home / ancestor.replace("/", "-") / ".wine4office")
+                outside = self.home / ancestor.replace("/", "-") / "outside"
+                windows_apps = outside / "WindowsApps"
+                package = windows_apps / (
+                    "Microsoft.OutlookForWindows_1.2026.900.100_x64__8wekyb3d8bbwe"
+                )
+                package.mkdir(parents=True)
+                (package / "olk.exe").write_bytes(b"outside")
+                symlink = prefix / ancestor
+                if symlink.exists():
+                    symlink.rmdir()
+                symlink.parent.mkdir(parents=True, exist_ok=True)
+                target = outside if ancestor == "drive_c" else outside
+                if ancestor == "drive_c":
+                    (outside / "Program Files").mkdir()
+                    windows_apps.rename(outside / "Program Files/WindowsApps")
+                symlink.symlink_to(target, target_is_directory=True)
+
+                self.assertIsNone(backend.find_office_app_info(str(prefix), "outlook"))
+
+    def test_outlook_detection_rejects_symlinked_classic_ancestor(self):
+        prefix = self._make_prefix(self.home / ".wine4office")
+        (prefix / "drive_c").rmdir()
+        outside = self.home / "outside-drive-c"
+        classic = outside / "Program Files/Microsoft Office/root/Office16"
+        classic.mkdir(parents=True)
+        (classic / "OUTLOOK.EXE").write_bytes(b"outside")
+        (prefix / "drive_c").symlink_to(outside, target_is_directory=True)
+
+        self.assertIsNone(backend.find_office_app_info(str(prefix), "outlook"))
+
+    def test_outlook_detection_rejects_symlinked_classic_executable(self):
+        prefix = self._make_prefix(self.home / ".wine4office")
+        classic = prefix / "drive_c/Program Files/Microsoft Office/root/Office16"
+        classic.mkdir(parents=True)
+        outside = self.home / "outside-outlook.exe"
+        outside.write_bytes(b"outside")
+        (classic / "OUTLOOK.EXE").symlink_to(outside)
+
+        self.assertIsNone(backend.find_office_app_info(str(prefix), "outlook"))
+
+    def test_outlook_detection_rejects_symlinked_package(self):
+        prefix = self._make_prefix(self.home / ".wine4office")
+        windows_apps = prefix / "drive_c/Program Files/WindowsApps"
+        windows_apps.mkdir(parents=True)
+        outside = self.home / "outside-outlook-package"
+        outside.mkdir()
+        (outside / "olk.exe").write_bytes(b"outside")
+        package = windows_apps / (
+            "Microsoft.OutlookForWindows_1.2026.900.100_x64__8wekyb3d8bbwe"
+        )
+        package.symlink_to(outside, target_is_directory=True)
+        classic = prefix / "drive_c/Program Files/Microsoft Office/root/Office16"
+        classic.mkdir(parents=True)
+        outlook = classic / "OUTLOOK.EXE"
+        outlook.write_bytes(b"classic")
+
+        installation = backend.find_office_app_info(str(prefix), "outlook")
+
+        self.assertIsNotNone(installation)
+        self.assertEqual(installation.executable, outlook)
+        self.assertIsNone(installation.package)
+
+    def test_outlook_detection_rejects_symlinked_executable(self):
+        prefix = self._make_prefix(self.home / ".wine4office")
+        package = prefix / (
+            "drive_c/Program Files/WindowsApps/"
+            "Microsoft.OutlookForWindows_1.2026.900.100_x64__8wekyb3d8bbwe"
+        )
+        package.mkdir(parents=True)
+        outside = self.home / "outside-olk.exe"
+        outside.write_bytes(b"outside")
+        (package / "olk.exe").symlink_to(outside)
+        classic = prefix / "drive_c/Program Files/Microsoft Office/root/Office16"
+        classic.mkdir(parents=True)
+        outlook = classic / "OUTLOOK.EXE"
+        outlook.write_bytes(b"classic")
+
+        installation = backend.find_office_app_info(str(prefix), "outlook")
+
+        self.assertIsNotNone(installation)
+        self.assertEqual(installation.executable, outlook)
+        self.assertIsNone(installation.package)
 
     def test_additional_office_applications_are_detected(self):
         prefix = self.home / ".wine4office"
@@ -1535,6 +1709,198 @@ touch "$WINEPREFIX/system.reg" "$WINEPREFIX/user.reg"
         self.assertEqual(command, [str(self.wine), str(outlook)])
         self.assertIn("mshtml=", popen.call_args.kwargs["env"]["WINEDLLOVERRIDES"].split(";"))
         self.assertNotIn("mshtml=b", popen.call_args.kwargs["env"]["WINEDLLOVERRIDES"].split(";"))
+
+    def test_new_outlook_launch_skips_classic_first_run_setup(self):
+        prefix = self._make_prefix(self.home / ".wine4office")
+        package = prefix / (
+            "drive_c/Program Files/WindowsApps/"
+            "Microsoft.OutlookForWindows_1.2026.720.100_x64__8wekyb3d8bbwe"
+        )
+        package.mkdir(parents=True)
+        outlook = package / "olk.exe"
+        outlook.write_bytes(b"exe")
+        process = mock.Mock(pid=7654)
+
+        with mock.patch.object(backend, "ensure_safe_x11_defaults"), \
+             mock.patch.object(backend.subprocess, "run") as run, \
+             mock.patch.object(backend.subprocess, "Popen", return_value=process) as popen:
+            pid = backend.launch_app(str(prefix), str(self.wine), "outlook")
+
+        self.assertEqual(pid, 7654)
+        run.assert_not_called()
+        self.assertEqual(popen.call_args.args[0], [str(self.wine), str(outlook)])
+        self.assertIn(
+            "mshtml=b", popen.call_args.kwargs["env"]["WINEDLLOVERRIDES"].split(";")
+        )
+
+    def test_outlook_shortcut_policy_uses_validated_package_identity(self):
+        prefix = self._make_prefix(self.home / ".wine4office")
+        package_name = (
+            "Microsoft.OutlookForWindows_1.2026.720.100_x64__8wekyb3d8bbwe"
+        )
+        package = prefix / "drive_c/Program Files/WindowsApps" / package_name
+        package.mkdir(parents=True)
+        outlook = package / "olk.exe"
+        outlook.write_bytes(b"exe")
+        icon = backend.data_home() / "icons/wine4office/outlook.ico"
+        icon.parent.mkdir(parents=True)
+        icon.write_bytes(b"cached icon")
+
+        backend.create_app_shortcuts(["outlook"], str(prefix), str(self.wine), False)
+
+        launcher = backend.shortcut_launcher_path("outlook")
+        text = launcher.read_text()
+        self.assertIn(f"outlook_package_identity={shlex.quote(package_name)}", text)
+        self.assertIn("if [[ $managed_prefix == true && -z $outlook_package_identity ]]; then", text)
+
+        log = self.root / "new-outlook-shortcut.log"
+        self._script(
+            "wine",
+            "#!/bin/bash\n"
+            "printf 'ARG=%s\\n' \"$@\" >> \"$WINE4OFFICE_TEST_LOG\"\n",
+        )
+        environment = os.environ.copy()
+        environment["WINE4OFFICE_TEST_LOG"] = str(log)
+        subprocess.run([str(launcher)], env=environment, check=True)
+        self.assertNotIn("reg", log.read_text())
+
+    def test_new_outlook_shortcut_rediscovers_updated_package(self):
+        prefix = self._make_prefix(self.home / ".wine4office")
+        windows_apps = prefix / "drive_c/Program Files/WindowsApps"
+        old_package = windows_apps / (
+            "Microsoft.OutlookForWindows_1.2026.720.100_x64__8wekyb3d8bbwe"
+        )
+        old_package.mkdir(parents=True)
+        (old_package / "olk.exe").write_bytes(b"old")
+        icon = backend.data_home() / "icons/wine4office/outlook.ico"
+        icon.parent.mkdir(parents=True)
+        icon.write_bytes(b"cached icon")
+
+        backend.create_app_shortcuts(["outlook"], str(prefix), str(self.wine), False)
+        (old_package / "olk.exe").unlink()
+        old_package.rmdir()
+        new_package = windows_apps / (
+            "Microsoft.OutlookForWindows_1.2027.10.5_x64__8wekyb3d8bbwe"
+        )
+        new_package.mkdir()
+        new_outlook = new_package / "olk.exe"
+        new_outlook.write_bytes(b"new")
+
+        log = self.root / "updated-new-outlook-shortcut.log"
+        self._script(
+            "wine",
+            "#!/bin/bash\n"
+            "printf 'ARG=%s\\n' \"$@\" >> \"$WINE4OFFICE_TEST_LOG\"\n",
+        )
+        environment = os.environ.copy()
+        environment["WINE4OFFICE_TEST_LOG"] = str(log)
+        subprocess.run(
+            [str(backend.shortcut_launcher_path("outlook"))],
+            env=environment, check=True,
+        )
+
+        arguments = log.read_text().splitlines()
+        self.assertEqual(arguments, [f"ARG={new_outlook.resolve()}"])
+
+    def test_new_outlook_shortcut_rejects_malformed_higher_version(self):
+        prefix = self._make_prefix(self.home / ".wine4office")
+        windows_apps = prefix / "drive_c/Program Files/WindowsApps"
+        old_package = windows_apps / (
+            "Microsoft.OutlookForWindows_1.2026.720.100_x64__8wekyb3d8bbwe"
+        )
+        old_package.mkdir(parents=True)
+        (old_package / "olk.exe").write_bytes(b"old")
+        icon = backend.data_home() / "icons/wine4office/outlook.ico"
+        icon.parent.mkdir(parents=True)
+        icon.write_bytes(b"cached icon")
+
+        backend.create_app_shortcuts(["outlook"], str(prefix), str(self.wine), False)
+        (old_package / "olk.exe").unlink()
+        old_package.rmdir()
+        for package_name in (
+            "Microsoft.OutlookForWindows_9.9.9_x64__8wekyb3d8bbwe",
+            "Microsoft.OutlookForWindows_9.9.9.9.9_x64__8wekyb3d8bbwe",
+            "Microsoft.OutlookForWindows_9.9.70000.9_x64__8wekyb3d8bbwe",
+        ):
+            package = windows_apps / package_name
+            package.mkdir()
+            (package / "olk.exe").write_bytes(b"malformed")
+
+        log = self.root / "malformed-new-outlook-shortcut.log"
+        self._script(
+            "wine",
+            "#!/bin/bash\n"
+            "printf 'ARG=%s\\n' \"$@\" >> \"$WINE4OFFICE_TEST_LOG\"\n",
+        )
+        environment = os.environ.copy()
+        environment["WINE4OFFICE_TEST_LOG"] = str(log)
+        result = subprocess.run(
+            [str(backend.shortcut_launcher_path("outlook"))],
+            env=environment, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            text=True, check=False,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse(log.exists())
+
+    def test_new_outlook_shortcut_rejects_symlinked_windowsapps_ancestor(self):
+        prefix = self._make_prefix(self.home / ".wine4office")
+        program_files = prefix / "drive_c/Program Files"
+        old_package = program_files / "WindowsApps" / (
+            "Microsoft.OutlookForWindows_1.2026.720.100_x64__8wekyb3d8bbwe"
+        )
+        old_package.mkdir(parents=True)
+        (old_package / "olk.exe").write_bytes(b"old")
+        icon = backend.data_home() / "icons/wine4office/outlook.ico"
+        icon.parent.mkdir(parents=True)
+        icon.write_bytes(b"cached icon")
+        backend.create_app_shortcuts(["outlook"], str(prefix), str(self.wine), False)
+
+        (old_package / "olk.exe").unlink()
+        old_package.rmdir()
+        (program_files / "WindowsApps").rmdir()
+        program_files.rmdir()
+        outside = self.home / "outside-program-files"
+        package = outside / "WindowsApps" / (
+            "Microsoft.OutlookForWindows_1.2027.10.5_x64__8wekyb3d8bbwe"
+        )
+        package.mkdir(parents=True)
+        (package / "olk.exe").write_bytes(b"outside")
+        program_files.symlink_to(outside, target_is_directory=True)
+
+        log = self.root / "escaped-new-outlook-shortcut.log"
+        self._script(
+            "wine",
+            "#!/bin/bash\n"
+            "printf 'ARG=%s\\n' \"$@\" >> \"$WINE4OFFICE_TEST_LOG\"\n",
+        )
+        environment = os.environ.copy()
+        environment["WINE4OFFICE_TEST_LOG"] = str(log)
+        result = subprocess.run(
+            [str(backend.shortcut_launcher_path("outlook"))],
+            env=environment, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            text=True, check=False,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse(log.exists())
+
+    def test_classic_outlook_shortcut_keeps_classic_setup(self):
+        prefix = self._make_prefix(self.home / ".wine4office")
+        classic = prefix / "drive_c/Program Files/Microsoft Office/root/Office16"
+        classic.mkdir(parents=True)
+        outlook = classic / "OUTLOOK.EXE"
+        outlook.write_bytes(b"exe")
+        icon = backend.data_home() / "icons/wine4office/outlook.ico"
+        icon.parent.mkdir(parents=True)
+        icon.write_bytes(b"cached icon")
+
+        backend.create_app_shortcuts(["outlook"], str(prefix), str(self.wine), False)
+
+        launcher = backend.shortcut_launcher_path("outlook")
+        text = launcher.read_text()
+        self.assertIn("outlook_package_identity=''", text)
+        self.assertIn("outlook_key=", text)
 
     def test_shortcut_creation_rejects_missing_wine(self):
         with self.assertRaisesRegex(FileNotFoundError, "Wine executable is missing"):

--- a/tools/wine4office-manager/tests/test_backend.py
+++ b/tools/wine4office-manager/tests/test_backend.py
@@ -1096,6 +1096,26 @@ touch "$WINEPREFIX/system.reg" "$WINEPREFIX/user.reg"
             with self.subTest(malformed=malformed):
                 self.assertIsNone(backend.parse_windows_apps_package_name(malformed))
 
+    def test_windows_apps_package_skips_concurrent_removal(self):
+        package = self.home / (
+            "Microsoft.OutlookForWindows_1.2026.720.100_x64__8wekyb3d8bbwe"
+        )
+        package.mkdir()
+
+        with mock.patch.object(Path, "resolve", side_effect=FileNotFoundError):
+            self.assertIsNone(backend.parse_windows_apps_package(package))
+
+    def test_windows_apps_discovery_tolerates_directory_removal(self):
+        prefix = self._make_prefix(self.home / ".wine4office-removed-windowsapps")
+        windows_apps = prefix / "drive_c/Program Files/WindowsApps"
+        windows_apps.mkdir(parents=True)
+
+        with mock.patch.object(Path, "iterdir", side_effect=FileNotFoundError):
+            self.assertEqual(
+                list(backend.windows_apps_packages(prefix, (backend.OUTLOOK_PACKAGE_FAMILY,))),
+                [],
+            )
+
     def test_outlook_detection_selects_highest_valid_package_with_olk(self):
         prefix = self._make_prefix(self.home / ".wine4office")
         windows_apps = prefix / "drive_c/Program Files/WindowsApps"
@@ -1160,13 +1180,39 @@ touch "$WINEPREFIX/system.reg" "$WINEPREFIX/user.reg"
                 if symlink.exists():
                     symlink.rmdir()
                 symlink.parent.mkdir(parents=True, exist_ok=True)
-                target = outside if ancestor == "drive_c" else outside
                 if ancestor == "drive_c":
                     (outside / "Program Files").mkdir()
                     windows_apps.rename(outside / "Program Files/WindowsApps")
-                symlink.symlink_to(target, target_is_directory=True)
+                symlink.symlink_to(outside, target_is_directory=True)
 
                 self.assertIsNone(backend.find_office_app_info(str(prefix), "outlook"))
+
+    def test_outlook_detection_rejects_symlinked_windowsapps_directory(self):
+        prefix = self._make_prefix(self.home / ".wine4office-windowsapps-link")
+        program_files = prefix / "drive_c/Program Files"
+        program_files.mkdir(parents=True)
+        outside = self.home / "outside-windowsapps"
+        package = outside / (
+            "Microsoft.OutlookForWindows_1.2026.900.100_x64__8wekyb3d8bbwe"
+        )
+        package.mkdir(parents=True)
+        (package / "olk.exe").write_bytes(b"outside")
+        (program_files / "WindowsApps").symlink_to(outside, target_is_directory=True)
+
+        self.assertIsNone(backend.find_office_app_info(str(prefix), "outlook"))
+
+    def test_teams_detection_rejects_symlinked_package_executable(self):
+        prefix = self._make_prefix(self.home / ".wine4office-teams-link")
+        package = prefix / (
+            "drive_c/Program Files/WindowsApps/"
+            "MSTeams_1.2026.900.100_x64__8wekyb3d8bbwe"
+        )
+        package.mkdir(parents=True)
+        outside = self.home / "outside-ms-teams.exe"
+        outside.write_bytes(b"outside")
+        (package / "ms-teams.exe").symlink_to(outside)
+
+        self.assertIsNone(backend.find_office_app_info(str(prefix), "teams"))
 
     def test_outlook_detection_rejects_symlinked_classic_ancestor(self):
         prefix = self._make_prefix(self.home / ".wine4office")
@@ -1841,6 +1887,7 @@ touch "$WINEPREFIX/system.reg" "$WINEPREFIX/user.reg"
         )
 
         self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Office application is unavailable", result.stderr)
         self.assertFalse(log.exists())
 
     def test_new_outlook_shortcut_rejects_symlinked_windowsapps_ancestor(self):
@@ -1883,7 +1930,46 @@ touch "$WINEPREFIX/system.reg" "$WINEPREFIX/user.reg"
         )
 
         self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Office application is unavailable", result.stderr)
         self.assertFalse(log.exists())
+
+    def test_new_outlook_shortcut_falls_back_to_classic_after_package_removal(self):
+        prefix = self._make_prefix(self.home / ".wine4office")
+        package = prefix / (
+            "drive_c/Program Files/WindowsApps/"
+            "Microsoft.OutlookForWindows_1.2026.720.100_x64__8wekyb3d8bbwe"
+        )
+        package.mkdir(parents=True)
+        outlook = package / "olk.exe"
+        outlook.write_bytes(b"new")
+        classic = prefix / "drive_c/Program Files/Microsoft Office/root/Office16"
+        classic.mkdir(parents=True)
+        classic_outlook = classic / "OUTLOOK.EXE"
+        classic_outlook.write_bytes(b"classic")
+        icon = backend.data_home() / "icons/wine4office/outlook.ico"
+        icon.parent.mkdir(parents=True)
+        icon.write_bytes(b"cached icon")
+        backend.create_app_shortcuts(["outlook"], str(prefix), str(self.wine), False)
+        outlook.unlink()
+        package.rmdir()
+
+        log = self.root / "classic-fallback-shortcut.log"
+        self._script(
+            "wine",
+            "#!/bin/bash\n"
+            "printf 'ARG=%s\\n' \"$@\" >> \"$WINE4OFFICE_TEST_LOG\"\n",
+        )
+        environment = os.environ.copy()
+        environment["WINE4OFFICE_TEST_LOG"] = str(log)
+
+        subprocess.run(
+            [str(backend.shortcut_launcher_path("outlook"))],
+            env=environment, check=True,
+        )
+
+        self.assertEqual(
+            log.read_text().splitlines()[-1], f"ARG={classic_outlook.resolve()}",
+        )
 
     def test_classic_outlook_shortcut_keeps_classic_setup(self):
         prefix = self._make_prefix(self.home / ".wine4office")

--- a/tools/wine4office-manager/wine4office_backend.py
+++ b/tools/wine4office-manager/wine4office_backend.py
@@ -1492,8 +1492,12 @@ def parse_windows_apps_package(path_value: PathValue) -> WindowsAppsPackage | No
     if parsed is None or path.is_symlink() or not path.is_dir():
         return None
     family, version, architecture, publisher_id = parsed
+    try:
+        resolved = path.resolve(strict=True)
+    except OSError:
+        return None
     return WindowsAppsPackage(
-        family, version, architecture, publisher_id, path.resolve(strict=True),
+        family, version, architecture, publisher_id, resolved,
     )
 
 
@@ -1513,7 +1517,11 @@ def windows_apps_packages(
     except ValueError:
         return
     expected_families = set(families)
-    for package_path in windows_apps.iterdir():
+    try:
+        package_paths = list(windows_apps.iterdir())
+    except OSError:
+        return
+    for package_path in package_paths:
         package = parse_windows_apps_package(package_path)
         if package is None:
             continue
@@ -1544,26 +1552,36 @@ def _package_app_candidates(
             yield InstalledApp(package.path / executable_name, package)
 
 
+def _validated_package_app(candidate: InstalledApp) -> InstalledApp | None:
+    """Return a package app only when its executable remains a contained real file."""
+    executable = candidate.executable
+    try:
+        if executable.is_symlink() or not executable.is_file():
+            return None
+        resolved = executable.resolve(strict=True)
+        resolved.relative_to(candidate.package.path)
+    except (OSError, ValueError):
+        return None
+    return InstalledApp(resolved, candidate.package)
+
+
 def teams_candidates(prefix: Path) -> Iterable[Path]:
     """Yield installed new-Teams executables, newest package version first."""
     for candidate in _package_app_candidates(
             prefix, ("MSTeams", "Microsoft.MSTeams"),
             ("ms-teams.exe", "MSTeams.exe")):
-        yield candidate.executable
+        validated = _validated_package_app(candidate)
+        if validated is not None:
+            yield validated.executable
 
 
 def outlook_candidates(prefix: Path) -> Iterable[InstalledApp]:
     """Yield validated New Outlook packages, newest version first, then classic."""
     for candidate in _package_app_candidates(
             prefix, (OUTLOOK_PACKAGE_FAMILY,), ("olk.exe",)):
-        executable = candidate.executable
-        if executable.is_symlink() or not executable.is_file():
-            continue
-        try:
-            executable.resolve(strict=True).relative_to(candidate.package.path)
-        except ValueError:
-            continue
-        yield candidate
+        validated = _validated_package_app(candidate)
+        if validated is not None:
+            yield validated
     for executable in office_candidates(prefix, APP_META["outlook"]["exe"]):
         yield InstalledApp(executable)
 
@@ -1731,9 +1749,7 @@ def launch_app_process(
     """
     prefix = validate_prefix(prefix_value)
     wine = require_wine(wine_value)
-    installation = find_office_app_info(str(prefix), app)
-    if installation is None:
-        raise FileNotFoundError(f"{APP_META[app]['exe']} is not installed in {prefix}")
+    installation = installed_app(prefix, app)
     executable = installation.executable
     managed = is_prefix_owned(prefix)
     ensure_safe_x11_defaults(str(prefix), str(wine), use_x11)
@@ -2069,6 +2085,8 @@ def _shortcut_launcher_text(app: str, prefix: Path, wine: Path,
             'new_outlook_executable=',
             'new_outlook_identity=',
             'new_outlook_version=',
+            '# Keep this package parser, version ordering, and containment logic synchronized',
+            '# with parse_windows_apps_package_name() and outlook_candidates() in the manager.',
             'version_is_newer() {',
             '    local left=$1 right=$2 left_part right_part',
             '    local -a left_parts right_parts',
@@ -2095,8 +2113,11 @@ def _shortcut_launcher_text(app: str, prefix: Path, wine: Path,
             '    fi',
             'done',
             'if [[ $windows_apps_safe == true ]]; then',
-            '    windows_apps_resolved=$(readlink -f -- "$windows_apps")',
-            '    case "$windows_apps_resolved/" in "$prefix_resolved/"*) ;; *) windows_apps_safe=false ;; esac',
+            '    if windows_apps_resolved=$(readlink -f -- "$windows_apps"); then',
+            '        case "$windows_apps_resolved/" in "$prefix_resolved/"*) ;; *) windows_apps_safe=false ;; esac',
+            '    else',
+            '        windows_apps_safe=false',
+            '    fi',
             'fi',
             'if [[ $windows_apps_safe == true ]]; then',
             '    for package in "$windows_apps"/Microsoft.OutlookForWindows_*__8wekyb3d8bbwe; do',
@@ -2112,11 +2133,11 @@ def _shortcut_launcher_text(app: str, prefix: Path, wine: Path,
             '            fi',
             '        done',
             '        [[ $package_version_valid == true ]] || continue',
-            '        package_resolved=$(readlink -f -- "$package")',
+            '        package_resolved=$(readlink -f -- "$package") || continue',
             '        case "$package_resolved/" in "$windows_apps_resolved/"*) ;; *) continue ;; esac',
             '        candidate="$package/olk.exe"',
             '        [[ -f "$candidate" && ! -L "$candidate" ]] || continue',
-            '        candidate_resolved=$(readlink -f -- "$candidate")',
+            '        candidate_resolved=$(readlink -f -- "$candidate") || continue',
             '        case "$candidate_resolved" in "$package_resolved/"*) ;; *) continue ;; esac',
             '        if [[ -z "$new_outlook_version" ]] || version_is_newer "$package_version" "$new_outlook_version"; then',
             '            new_outlook_version=$package_version',
@@ -2128,6 +2149,25 @@ def _shortcut_launcher_text(app: str, prefix: Path, wine: Path,
             'if [[ -n "$new_outlook_executable" ]]; then',
             '    executable=$new_outlook_executable',
             '    outlook_package_identity=$new_outlook_identity',
+            'else',
+            '    for classic_candidate in "$prefix_resolved/drive_c/Program Files/Microsoft Office/root/Office16/OUTLOOK.EXE" "$prefix_resolved/drive_c/Program Files (x86)/Microsoft Office/root/Office16/OUTLOOK.EXE" "$prefix_resolved/drive_c/Program Files/Microsoft Office/Office16/OUTLOOK.EXE" "$prefix_resolved/drive_c/Program Files (x86)/Microsoft Office/Office16/OUTLOOK.EXE"; do',
+            '        [[ -f "$classic_candidate" && ! -L "$classic_candidate" ]] || continue',
+            '        classic_relative=${classic_candidate#"$prefix_resolved/"}',
+            '        [[ $classic_relative != "$classic_candidate" ]] || continue',
+            '        classic_safe=true',
+            '        classic_current=$prefix_resolved',
+            "        IFS='/' read -r -a classic_parts <<< \"$classic_relative\"",
+            '        for classic_part in "${classic_parts[@]}"; do',
+            '            classic_current="$classic_current/$classic_part"',
+            '            if [[ -L "$classic_current" ]]; then',
+            '                classic_safe=false',
+            '                break',
+            '            fi',
+            '        done',
+            '        [[ $classic_safe == true ]] || continue',
+            '        classic_resolved=$(readlink -f -- "$classic_candidate") || continue',
+            '        case "$classic_resolved" in "$prefix_resolved/"*) executable=$classic_resolved; break ;; esac',
+            '    done',
             'fi',
         ])
     lines.extend([

--- a/tools/wine4office-manager/wine4office_backend.py
+++ b/tools/wine4office-manager/wine4office_backend.py
@@ -7,6 +7,7 @@ import csv
 import io
 import fcntl
 import hashlib
+from dataclasses import dataclass
 from html.parser import HTMLParser
 import json
 import os
@@ -33,6 +34,44 @@ from pathlib import Path, PurePosixPath
 from typing import Callable, Iterable
 
 PathValue = str | os.PathLike[str]
+WINDOWS_APPS_PUBLISHER_ID = "8wekyb3d8bbwe"
+OUTLOOK_PACKAGE_FAMILY = "Microsoft.OutlookForWindows"
+_WINDOWS_APPS_PACKAGE_NAME = re.compile(
+    rf"^(?P<family>[A-Za-z0-9][A-Za-z0-9.-]*)_"
+    rf"(?P<version>[0-9]+(?:\.[0-9]+)*)_"
+    rf"(?P<architecture>[A-Za-z0-9.-]+)__{re.escape(WINDOWS_APPS_PUBLISHER_ID)}$"
+)
+
+
+@dataclass(frozen=True)
+class WindowsAppsPackage:
+    family: str
+    version: tuple[int, ...]
+    architecture: str
+    publisher_id: str
+    path: Path
+
+    @property
+    def identity(self) -> str:
+        return self.path.name
+
+
+@dataclass(frozen=True)
+class InstalledApp:
+    executable: Path
+    package: WindowsAppsPackage | None = None
+
+    @property
+    def is_new_outlook(self) -> bool:
+        package = self.package
+        return (
+            package is not None
+            and package.family == OUTLOOK_PACKAGE_FAMILY
+            and package.publisher_id == WINDOWS_APPS_PUBLISHER_ID
+            and self.executable == package.path / "olk.exe"
+        )
+
+
 OFFICE_TELEMETRY_POLICY_KEY = (
     r"HKCU\Software\Policies\Microsoft\Office\Common\ClientTelemetry"
 )
@@ -41,7 +80,7 @@ OFFICE_TELEMETRY_DISABLED = "3"
 WINE_DECORATED_VALUE = "Decorated"
 WINE_XVIDMODE_VALUE = "UseXVidMode"
 OFFICE_X11_EXECUTABLES = (
-    "WINWORD.EXE", "EXCEL.EXE", "POWERPNT.EXE", "OUTLOOK.EXE",
+    "WINWORD.EXE", "EXCEL.EXE", "POWERPNT.EXE", "OUTLOOK.EXE", "OLK.EXE",
     "ONENOTE.EXE", "MSACCESS.EXE", "MSPUB.EXE", "VISIO.EXE", "WINPROJ.EXE",
 )
 STOP_GRACE_SECONDS = 10.0
@@ -1399,51 +1438,165 @@ def create_environment(prefix_value: str, wine_value: str, recreate: bool, outpu
 
 
 def office_candidates(prefix: Path, executable: str) -> Iterable[Path]:
-    roots = [
-        prefix / "drive_c/Program Files/Microsoft Office/root/Office16",
-        prefix / "drive_c/Program Files (x86)/Microsoft Office/root/Office16",
-        prefix / "drive_c/Program Files/Microsoft Office/Office16",
-        prefix / "drive_c/Program Files (x86)/Microsoft Office/Office16",
-    ]
-    for root in roots:
-        yield root / executable
+    prefix = prefix.resolve(strict=True)
+    roots = (
+        "drive_c/Program Files/Microsoft Office/root/Office16",
+        "drive_c/Program Files (x86)/Microsoft Office/root/Office16",
+        "drive_c/Program Files/Microsoft Office/Office16",
+        "drive_c/Program Files (x86)/Microsoft Office/Office16",
+    )
+    for relative_root in roots:
+        root = prefix
+        for component in Path(relative_root).parts:
+            root /= component
+            if root.is_symlink() or not root.is_dir():
+                break
+        else:
+            root = root.resolve(strict=True)
+            candidate = root / executable
+            try:
+                root.relative_to(prefix)
+                resolved = candidate.resolve(strict=True)
+                resolved.relative_to(root)
+            except (FileNotFoundError, OSError, ValueError):
+                continue
+            if not candidate.is_symlink() and resolved.is_file():
+                yield resolved
 
+
+
+def parse_windows_apps_package_name(
+        name: str,
+) -> tuple[str, tuple[int, ...], str, str] | None:
+    """Parse a WindowsApps identity with a numeric version and publisher ID."""
+    match = _WINDOWS_APPS_PACKAGE_NAME.fullmatch(name)
+    if match is None:
+        return None
+    try:
+        version = tuple(int(part) for part in match.group("version").split("."))
+    except ValueError:
+        return None
+    if len(version) != 4 or any(part > 0xffff for part in version):
+        return None
+    return (
+        match.group("family"), version, match.group("architecture"),
+        WINDOWS_APPS_PUBLISHER_ID,
+    )
+
+
+def parse_windows_apps_package(path_value: PathValue) -> WindowsAppsPackage | None:
+    """Return validated package metadata for an existing WindowsApps directory."""
+    raw_value = path_value.strip() if isinstance(path_value, str) else os.fspath(path_value)
+    path = Path(os.path.expandvars(raw_value)).expanduser()
+    parsed = parse_windows_apps_package_name(path.name)
+    if parsed is None or path.is_symlink() or not path.is_dir():
+        return None
+    family, version, architecture, publisher_id = parsed
+    return WindowsAppsPackage(
+        family, version, architecture, publisher_id, path.resolve(strict=True),
+    )
+
+
+def windows_apps_packages(
+        prefix: Path, families: Iterable[str],
+) -> Iterable[WindowsAppsPackage]:
+    """Yield validated package identities for the requested package families."""
+    prefix = prefix.resolve(strict=True)
+    windows_apps = prefix
+    for component in ("drive_c", "Program Files", "WindowsApps"):
+        windows_apps /= component
+        if windows_apps.is_symlink() or not windows_apps.is_dir():
+            return
+    windows_apps = windows_apps.resolve(strict=True)
+    try:
+        windows_apps.relative_to(prefix)
+    except ValueError:
+        return
+    expected_families = set(families)
+    for package_path in windows_apps.iterdir():
+        package = parse_windows_apps_package(package_path)
+        if package is None:
+            continue
+        try:
+            package.path.relative_to(windows_apps)
+        except ValueError:
+            continue
+        if package.family in expected_families:
+            yield package
+
+
+def sorted_windows_apps_packages(
+        prefix: Path, families: Iterable[str],
+) -> list[WindowsAppsPackage]:
+    """Return validated packages in descending numeric version order."""
+    return sorted(
+        windows_apps_packages(prefix, families),
+        key=lambda package: (package.version, package.identity),
+        reverse=True,
+    )
+
+
+def _package_app_candidates(
+        prefix: Path, families: Iterable[str], executable_names: Iterable[str],
+) -> Iterable[InstalledApp]:
+    for package in sorted_windows_apps_packages(prefix, families):
+        for executable_name in executable_names:
+            yield InstalledApp(package.path / executable_name, package)
 
 
 def teams_candidates(prefix: Path) -> Iterable[Path]:
     """Yield installed new-Teams executables, newest package version first."""
-    windows_apps = prefix / "drive_c/Program Files/WindowsApps"
-    packages: list[tuple[tuple[int, ...], str, Path]] = []
-    for package_pattern in (
-            "MSTeams_*__8wekyb3d8bbwe",
-            "Microsoft.MSTeams_*__8wekyb3d8bbwe"):
-        for package in windows_apps.glob(package_pattern):
-            if not package.is_dir():
-                continue
-            parts = package.name.split("_")
-            try:
-                version = tuple(int(part) for part in parts[1].split("."))
-            except (IndexError, ValueError):
-                continue
-            packages.append((version, package.name, package))
-    for _version, _name, package in sorted(packages, reverse=True):
-        yield package / "ms-teams.exe"
-        yield package / "MSTeams.exe"
+    for candidate in _package_app_candidates(
+            prefix, ("MSTeams", "Microsoft.MSTeams"),
+            ("ms-teams.exe", "MSTeams.exe")):
+        yield candidate.executable
 
 
-def find_office_app(prefix_value: str, app: str) -> Path | None:
+def outlook_candidates(prefix: Path) -> Iterable[InstalledApp]:
+    """Yield validated New Outlook packages, newest version first, then classic."""
+    for candidate in _package_app_candidates(
+            prefix, (OUTLOOK_PACKAGE_FAMILY,), ("olk.exe",)):
+        executable = candidate.executable
+        if executable.is_symlink() or not executable.is_file():
+            continue
+        try:
+            executable.resolve(strict=True).relative_to(candidate.package.path)
+        except ValueError:
+            continue
+        yield candidate
+    for executable in office_candidates(prefix, APP_META["outlook"]["exe"]):
+        yield InstalledApp(executable)
+
+
+def _office_app_candidates(prefix: Path, app: str) -> Iterable[InstalledApp]:
+    executable = APP_META[app]["exe"]
+    if app == "teams":
+        yield from (
+            InstalledApp(candidate)
+            for candidate in teams_candidates(prefix)
+        )
+    elif app == "outlook":
+        yield from outlook_candidates(prefix)
+    else:
+        yield from (
+            InstalledApp(candidate)
+            for candidate in office_candidates(prefix, executable)
+        )
+
+
+def find_office_app_info(prefix_value: str, app: str) -> InstalledApp | None:
     if app not in APP_META:
         raise ValueError(f"Unknown Office application: {app}")
     prefix = validate_prefix(prefix_value)
-    executable = APP_META[app]["exe"]
-    candidates = (
-        teams_candidates(prefix)
-        if app == "teams" else office_candidates(prefix, executable)
-    )
-    for candidate in candidates:
-        if candidate.is_file():
+    for candidate in _office_app_candidates(prefix, app):
+        if candidate.executable.is_file():
             return candidate
     return None
+
+
+def find_office_app(prefix_value: str, app: str) -> Path | None:
+    candidate = find_office_app_info(prefix_value, app)
+    return candidate.executable if candidate is not None else None
 
 
 def environment_status(prefix_value: str, wine_value: str) -> dict:
@@ -1578,9 +1731,10 @@ def launch_app_process(
     """
     prefix = validate_prefix(prefix_value)
     wine = require_wine(wine_value)
-    executable = find_office_app(str(prefix), app)
-    if not executable:
+    installation = find_office_app_info(str(prefix), app)
+    if installation is None:
         raise FileNotFoundError(f"{APP_META[app]['exe']} is not installed in {prefix}")
+    executable = installation.executable
     managed = is_prefix_owned(prefix)
     ensure_safe_x11_defaults(str(prefix), str(wine), use_x11)
     if app == "word":
@@ -1588,7 +1742,7 @@ def launch_app_process(
     register_cloud_fonts(prefix, wine, helper, use_x11)
     env = wine_environment(prefix, wine, use_x11)
     arguments = [_windows_document_path(document, wine, env) for document in documents]
-    if app == "outlook" and managed:
+    if app == "outlook" and managed and not installation.is_new_outlook:
         prepare_outlook_first_run(prefix, wine, env)
         env = _outlook_environment(env)
     if capture_diagnostics:
@@ -1846,11 +2000,15 @@ def write_desktop_file(path: Path, name: str, comment: str, command: list[str], 
     os.replace(temporary, path)
 
 
-def installed_app_executable(prefix: Path, app: str) -> Path:
-    executable = find_office_app(str(prefix), app)
-    if executable is None:
+def installed_app(prefix: Path, app: str) -> InstalledApp:
+    installation = find_office_app_info(str(prefix), app)
+    if installation is None:
         raise FileNotFoundError(f"{APP_META[app]['exe']} is not installed in {prefix}")
-    return executable
+    return installation
+
+
+def installed_app_executable(prefix: Path, app: str) -> Path:
+    return installed_app(prefix, app).executable
 
 
 def shortcut_launcher_directory() -> Path:
@@ -1880,12 +2038,17 @@ def _install_shortcut_font_helper(helper: Path | None) -> Path | None:
     return destination
 
 
-def _shortcut_launcher_text(app: str, prefix: Path, wine: Path, executable: Path,
-                            font_helper: Path | None) -> str:
+def _shortcut_launcher_text(app: str, prefix: Path, wine: Path,
+                            installation: InstalledApp, font_helper: Path | None) -> str:
+    executable = installation.executable
     prefix_value = shlex.quote(str(prefix))
     wine_value = shlex.quote(str(wine))
     executable_value = shlex.quote(str(executable))
     helper_value = shlex.quote(str(font_helper)) if font_helper else "''"
+    outlook_package_identity = (
+        shlex.quote(installation.package.identity)
+        if installation.is_new_outlook else "''"
+    )
     winappsdk_runtime = office_winappsdk_runtime_environment(prefix)
     lines = [
         "#!/usr/bin/env bash",
@@ -1895,7 +2058,79 @@ def _shortcut_launcher_text(app: str, prefix: Path, wine: Path, executable: Path
         f"prefix={prefix_value}",
         f"wine={wine_value}",
         f"executable={executable_value}",
+        f"outlook_package_identity={outlook_package_identity}",
         f"font_helper={helper_value}",
+    ]
+    if app == "outlook" and installation.is_new_outlook:
+        lines.extend([
+            'windows_apps="$prefix/drive_c/Program Files/WindowsApps"',
+            'executable=',
+            'outlook_package_identity=',
+            'new_outlook_executable=',
+            'new_outlook_identity=',
+            'new_outlook_version=',
+            'version_is_newer() {',
+            '    local left=$1 right=$2 left_part right_part',
+            '    local -a left_parts right_parts',
+            "    IFS='.' read -r -a left_parts <<< \"$left\"",
+            "    IFS='.' read -r -a right_parts <<< \"$right\"",
+            '    local count=${#left_parts[@]} index',
+            '    (( ${#right_parts[@]} > count )) && count=${#right_parts[@]}',
+            '    for ((index = 0; index < count; index++)); do',
+            '        left_part=${left_parts[index]:-0}',
+            '        right_part=${right_parts[index]:-0}',
+            '        (( 10#$left_part > 10#$right_part )) && return 0',
+            '        (( 10#$left_part < 10#$right_part )) && return 1',
+            '    done',
+            '    return 1',
+            '}',
+            'prefix_resolved=$(readlink -f -- "$prefix")',
+            'windows_apps_safe=true',
+            'current=$prefix',
+            'for component in drive_c "Program Files" WindowsApps; do',
+            '    current="$current/$component"',
+            '    if [[ ! -d "$current" || -L "$current" ]]; then',
+            '        windows_apps_safe=false',
+            '        break',
+            '    fi',
+            'done',
+            'if [[ $windows_apps_safe == true ]]; then',
+            '    windows_apps_resolved=$(readlink -f -- "$windows_apps")',
+            '    case "$windows_apps_resolved/" in "$prefix_resolved/"*) ;; *) windows_apps_safe=false ;; esac',
+            'fi',
+            'if [[ $windows_apps_safe == true ]]; then',
+            '    for package in "$windows_apps"/Microsoft.OutlookForWindows_*__8wekyb3d8bbwe; do',
+            '        [[ -d "$package" && ! -L "$package" ]] || continue',
+            '        package_identity=${package##*/}',
+            r'        [[ $package_identity =~ ^Microsoft\.OutlookForWindows_([0-9]+)\.([0-9]+)\.([0-9]+)\.([0-9]+)_([A-Za-z0-9.-]+)__8wekyb3d8bbwe$ ]] || continue',
+            '        package_version=${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.${BASH_REMATCH[3]}.${BASH_REMATCH[4]}',
+            '        package_version_valid=true',
+            '        for package_version_part in "${BASH_REMATCH[@]:1:4}"; do',
+            '            if (( 10#$package_version_part > 65535 )); then',
+            '                package_version_valid=false',
+            '                break',
+            '            fi',
+            '        done',
+            '        [[ $package_version_valid == true ]] || continue',
+            '        package_resolved=$(readlink -f -- "$package")',
+            '        case "$package_resolved/" in "$windows_apps_resolved/"*) ;; *) continue ;; esac',
+            '        candidate="$package/olk.exe"',
+            '        [[ -f "$candidate" && ! -L "$candidate" ]] || continue',
+            '        candidate_resolved=$(readlink -f -- "$candidate")',
+            '        case "$candidate_resolved" in "$package_resolved/"*) ;; *) continue ;; esac',
+            '        if [[ -z "$new_outlook_version" ]] || version_is_newer "$package_version" "$new_outlook_version"; then',
+            '            new_outlook_version=$package_version',
+            '            new_outlook_identity=$package_identity',
+            '            new_outlook_executable=$candidate_resolved',
+            '        fi',
+            '    done',
+            'fi',
+            'if [[ -n "$new_outlook_executable" ]]; then',
+            '    executable=$new_outlook_executable',
+            '    outlook_package_identity=$new_outlook_identity',
+            'fi',
+        ])
+    lines.extend([
         'if [[ ! -x "$wine" ]]; then',
         '    printf \'Wine4Office launcher: Wine is unavailable: %s\\n\' "$wine" >&2',
         "    exit 1",
@@ -1935,7 +2170,7 @@ def _shortcut_launcher_text(app: str, prefix: Path, wine: Path, executable: Path
         'elif [[ $managed_prefix == true && -n ${WAYLAND_DISPLAY:-} ]]; then',
         "    unset DISPLAY",
         "fi",
-    ]
+    ])
     if app == "word":
         lines.extend([
             'if [[ $managed_prefix == true ]]; then',
@@ -1978,7 +2213,7 @@ def _shortcut_launcher_text(app: str, prefix: Path, wine: Path, executable: Path
     ])
     if app == "outlook":
         lines.extend([
-            'if [[ $managed_prefix == true ]]; then',
+            'if [[ $managed_prefix == true && -z $outlook_package_identity ]]; then',
             r"outlook_key='HKCU\Software\Microsoft\Office\16.0\Outlook'",
             'outlook_query=$("$wine" reg query "$outlook_key" /v LastUILanguage 2>/dev/null || true)',
             'if [[ $outlook_query != *LastUILanguage* ]]; then',
@@ -2089,14 +2324,14 @@ def _shortcut_launcher_text(app: str, prefix: Path, wine: Path, executable: Path
     return "\n".join(lines)
 
 
-def write_shortcut_launcher(app: str, prefix: Path, wine: Path, executable: Path,
-                            font_helper: Path | None) -> Path:
+def write_shortcut_launcher(app: str, prefix: Path, wine: Path,
+                            installation: InstalledApp, font_helper: Path | None) -> Path:
     path = shortcut_launcher_path(app)
     path.parent.mkdir(parents=True, exist_ok=True)
     temporary = path.with_name(f".{path.name}.{os.getpid()}.{time.time_ns()}.tmp")
     try:
         temporary.write_text(
-            _shortcut_launcher_text(app, prefix, wine, executable, font_helper)
+            _shortcut_launcher_text(app, prefix, wine, installation, font_helper)
         )
         temporary.chmod(0o755)
         os.replace(temporary, path)
@@ -2115,10 +2350,11 @@ def create_app_shortcuts(apps: Iterable[str], prefix_value: PathValue, wine_valu
         if app not in APP_META:
             raise ValueError(f"Unknown Office application: {app}")
         meta = APP_META[app]
-        executable = installed_app_executable(prefix, app)
+        installation = installed_app(prefix, app)
+        executable = installation.executable
         icon = app_icon_path(app, executable)
         launcher = write_shortcut_launcher(
-            app, prefix, wine, executable, installed_helper
+            app, prefix, wine, installation, installed_helper
         )
         command = [str(launcher)]
         if meta["mime"]:
@@ -2169,15 +2405,16 @@ def refresh_managed_app_shortcuts(prefix_value: PathValue, wine_value: PathValue
     installed_helper = _install_shortcut_font_helper(helper)
     for app, paths in existing.items():
         meta = APP_META[app]
-        executable = find_office_app(str(prefix), app)
-        if executable is None:
+        installation = find_office_app_info(str(prefix), app)
+        if installation is None:
             result["skipped"][app] = (
                 f"{meta['exe']} is not installed in {prefix}"
             )
             continue
+        executable = installation.executable
         icon = app_icon_path(app, executable)
         launcher = write_shortcut_launcher(
-            app, prefix, wine, executable, installed_helper
+            app, prefix, wine, installation, installed_helper
         )
         command = [str(launcher)]
         if meta["mime"]:


### PR DESCRIPTION
## Stack

PR 4 of 8. Stacked on #27; merge only after #27.

## Summary

- Discover the newest valid `Microsoft.OutlookForWindows` package safely.
- Launch New Outlook from validated package metadata with classic Outlook fallback.
- Reject symlinked package and executable paths outside the trusted WindowsApps tree.
- Include New Outlook in authenticated, environment-scoped graceful shutdown.

## Functional boundary

Includes Wine4Office Manager discovery/launch policy and `wine4officeclose` ownership handling.

Excludes WinRT and DOM prerequisites in #25-#27 and graphics/input integration in later PRs.

## Validation

- `git diff --check` passes.
- The source integration's complete manager backend suite passed 335 tests with environment-only skips.
- x86_64 and i386 close-helper regressions passed; headless WM_CLOSE delivery remained an explicit harness skip.

## Provenance

- Base branch: `feature/outlook-new-03-mutation-observer`.
- Reconstructed from final integration HEAD `cf77f3b43ce5981bac562d692d25c74dc1ed6be1`.
- No account password, RDP password, or package credential is included.

## Review notes

Package identity is metadata-driven; no fixed Outlook version or installation path is encoded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Support reliable, secure New Outlook discovery, launching, shortcut refresh, and graceful shutdown while retaining classic Outlook fallback.

Bug Fixes:
- Make New Outlook discovery and shortcut launching resilient to package updates, removals, malformed metadata, and unsafe symlink paths.
- Include New Outlook processes in authenticated graceful shutdown handling.

Enhancements:
- Add metadata-driven selection of the newest valid New Outlook package with safe fallback to classic Outlook.
- Avoid classic Outlook first-run setup when launching New Outlook and preserve it for classic Outlook.

Build:
- Add the ntdll import required by the close-helper changes.

Documentation:
- Document safer Outlook shortcut behavior across Store package changes and classic Outlook fallback.

Tests:
- Add backend coverage for package parsing, version selection, fallback behavior, path containment, shortcut refresh, and New Outlook shutdown.
- Extend close-helper regression coverage to New Outlook executables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for detecting and launching the new Outlook app alongside classic Outlook.
  - Outlook shortcuts now automatically select the newest valid installation.
  - Office and Teams app discovery now supports installed Windows applications more reliably.
  - Shortcuts can open local files, file URLs, and non-local documents.

- **Bug Fixes**
  - Improved protection against invalid or unsafe application installations.
  - Preserved classic Outlook first-run behavior while avoiding it for new Outlook.
  - Added support for recognizing Outlook processes during window and application detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->