### PR TITLE
server: Authorize cross-process DComp input topology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- Let modern Office identify the current user without exposing machine, account,
+  or application identifiers.
+- Let packaged Office components discover their local application-data folders
+  and education-environment state.
+- Let modern Office web views observe text and child-node changes reliably.
+- Keep Outlook shortcuts working safely across Store package changes and
+  classic Outlook fallback.
+- Improve keyboard and IME input across cross-process DirectComposition views.
+
 ## 0.2.0-beta.1 — 2026-08-19
 
 - Let Office finish proofing-language updates without crashing Click-to-Run.

--- a/dlls/dcomp/device.c
+++ b/dlls/dcomp/device.c
@@ -735,13 +735,15 @@ static HRESULT WINAPI dcomp_visual_SetClip(IDCompositionVisual2 *iface, const D2
 
 static void dcomp_visual_unbind_content(struct dcomp_visual *visual)
 {
-    typedef void (WINAPI *bind_composition_window_t)(HWND, HWND);
+    typedef void (WINAPI *bind_composition_window_t)(HWND, HWND, const struct wine_dcomp_ime_token *);
     typedef HRESULT (WINAPI *set_composition_description_t)(IDXGISwapChain1 *,
             const struct wine_dcomp_visual_desc *);
     bind_composition_window_t bind_composition_window;
     set_composition_description_t set_composition_description;
     IDXGISwapChain1 *swapchain;
+    struct wine_dcomp_ime_token ime_token;
     HMODULE dxgi;
+    UINT ime_token_size = sizeof(ime_token);
     HWND window;
 
     if (!visual->applied_content || FAILED(visual->applied_content->lpVtbl->QueryInterface(
@@ -752,6 +754,9 @@ static void dcomp_visual_unbind_content(struct dcomp_visual *visual)
             && (set_composition_description = (set_composition_description_t)GetProcAddress(dxgi,
             "__wine_dxgi_set_composition_description")))
         set_composition_description(swapchain, NULL);
+    if (FAILED(swapchain->lpVtbl->GetPrivateData(swapchain, &WINE_DCOMP_IME_TOKEN_GUID,
+            &ime_token_size, &ime_token)))
+        ime_token.low = ime_token.high = 0;
     if (SUCCEEDED(swapchain->lpVtbl->GetHwnd(swapchain, &window)))
     {
         RemovePropW(window, L"__wine_dcomp_clip_enabled");
@@ -775,7 +780,7 @@ static void dcomp_visual_unbind_content(struct dcomp_visual *visual)
         if ((dxgi = GetModuleHandleW(L"dxgi.dll")) &&
             (bind_composition_window = (bind_composition_window_t)GetProcAddress(dxgi,
                     "__wine_dxgi_bind_composition_window")))
-            bind_composition_window(window, NULL);
+            bind_composition_window(window, NULL, &ime_token);
         else
             ShowWindow(window, SW_HIDE);
     }
@@ -784,13 +789,15 @@ static void dcomp_visual_unbind_content(struct dcomp_visual *visual)
 
 static void dcomp_visual_bind_content(struct dcomp_visual *visual)
 {
-    typedef void (WINAPI *bind_composition_window_t)(HWND, HWND);
+    typedef void (WINAPI *bind_composition_window_t)(HWND, HWND, const struct wine_dcomp_ime_token *);
     bind_composition_window_t bind_composition_window;
     typedef HRESULT (WINAPI *set_composition_description_t)(IDXGISwapChain1 *,
             const struct wine_dcomp_visual_desc *);
     IDXGISwapChain1 *swapchain;
     set_composition_description_t set_composition_description;
+    struct wine_dcomp_ime_token ime_token;
     HMODULE dxgi;
+    UINT ime_token_size = sizeof(ime_token);
     HWND window;
     RECT rect;
 
@@ -803,6 +810,9 @@ static void dcomp_visual_bind_content(struct dcomp_visual *visual)
             && (set_composition_description = (set_composition_description_t)GetProcAddress(dxgi,
             "__wine_dxgi_set_composition_description")))
         set_composition_description(swapchain, &visual->applied_description);
+    if (FAILED(swapchain->lpVtbl->GetPrivateData(swapchain, &WINE_DCOMP_IME_TOKEN_GUID,
+            &ime_token_size, &ime_token)))
+        ime_token.low = ime_token.high = 0;
     if (SUCCEEDED(swapchain->lpVtbl->GetHwnd(swapchain, &window)))
     {
         LONG offset_x, offset_y, scale_x, scale_y;
@@ -841,7 +851,7 @@ static void dcomp_visual_bind_content(struct dcomp_visual *visual)
         if ((dxgi = GetModuleHandleW(L"dxgi.dll"))
                 && (bind_composition_window = (bind_composition_window_t)GetProcAddress(dxgi,
                 "__wine_dxgi_bind_composition_window")))
-            bind_composition_window(window, visual->target_window);
+            bind_composition_window(window, visual->target_window, &ime_token);
         else if (visual->target_window && window != visual->target_window)
         {
             GetClientRect(visual->target_window, &rect);

--- a/dlls/dxgi/dxgi.spec
+++ b/dlls/dxgi/dxgi.spec
@@ -4,5 +4,5 @@
 @ stdcall DXGID3D10CreateDevice(ptr ptr ptr long ptr long ptr)
 @ stdcall DXGID3D10RegisterLayers(ptr long)
 @ stdcall DXGIGetDebugInterface1(long ptr ptr)
-@ stdcall __wine_dxgi_bind_composition_window(long long)
+@ stdcall __wine_dxgi_bind_composition_window(long long ptr)
 @ stdcall __wine_dxgi_set_composition_description(ptr ptr)

--- a/dlls/dxgi/dxgi_private.h
+++ b/dlls/dxgi/dxgi_private.h
@@ -20,6 +20,7 @@
 #define __WINE_DXGI_PRIVATE_H
 
 #include "wine/debug.h"
+#include "wine/server.h"
 
 #include <assert.h>
 
@@ -39,6 +40,7 @@
 #endif
 #include "wine/wined3d.h"
 #include "wine/winedxgi.h"
+#include "wine/dcomp.h"
 
 enum dxgi_frame_latency
 {
@@ -185,6 +187,8 @@ struct d3d11_swapchain
     ID3D11Texture2D *present1_scratch;
     BOOL present1_shadow_valid;
     HWND composition_window;
+    SRWLOCK ime_token_lock;
+    struct wine_dcomp_ime_token ime_token;
 
     DXGI_SWAP_CHAIN_FULLSCREEN_DESC fullscreen_desc;
     IDXGIOutput *target;
@@ -192,7 +196,7 @@ struct d3d11_swapchain
     LONG in_set_fullscreen_state;
 };
 
-void d3d11_swapchain_set_composition_window(IDXGISwapChain1 *iface, HWND window);
+void dxgi_swapchain_set_composition_window(IDXGISwapChain1 *iface, HWND window);
 
 HRESULT d3d11_swapchain_init(struct d3d11_swapchain *swapchain, struct dxgi_device *device,
         struct wined3d_swapchain_desc *desc, const DXGI_SWAP_CHAIN_FULLSCREEN_DESC *fullscreen_desc);

--- a/dlls/dxgi/factory.c
+++ b/dlls/dxgi/factory.c
@@ -823,17 +823,6 @@ static void dxgi_composition_window_update_caption(HWND window, HWND root)
     UpdateWindow(caption);
 }
 
-static void dxgi_composition_window_clear_task_delegate(HWND window, HWND target)
-{
-    HWND root = target ? GetAncestor(target, GA_ROOT) : NULL;
-
-    if (root && GetPropW(root, dcomp_task_delegated_prop) == window)
-    {
-        RemovePropW(root, dcomp_task_delegated_prop);
-        PostMessageW(root, WM_WAYLAND_DCOMP_EXPORT, 0, 0);
-    }
-}
-
 static void dxgi_composition_window_update_identity(HWND window, HWND root)
 {
     WCHAR current[256], title[256];
@@ -998,11 +987,6 @@ static LRESULT CALLBACK dxgi_composition_window_proc(HWND window, UINT message, 
                 if ((root = GetPropW(window, dcomp_caption_window_prop))) DestroyWindow(root);
                 RemovePropW(window, dcomp_caption_window_prop);
                 KillTimer(window, 1);
-                if (GetPropW(target, L"__wine_dcomp_base_presentation") == window)
-                {
-                    RemovePropW(target, L"__wine_dcomp_base_presentation");
-                    dxgi_composition_window_clear_task_delegate(window, target);
-                }
                 break;
 
             case WM_MOUSEMOVE:
@@ -1040,55 +1024,43 @@ static LRESULT CALLBACK dxgi_composition_window_proc(HWND window, UINT message, 
             : DefWindowProcW(window, message, wparam, lparam);
 }
 
-void WINAPI __wine_dxgi_bind_composition_window(HWND window, HWND target)
+void WINAPI __wine_dxgi_bind_composition_window(HWND window, HWND target,
+        const struct wine_dcomp_ime_token *ime_token)
 {
     HWND old_target = GetPropW(window, L"__wine_dcomp_detached_window");
-    HWND input_window, old_input_window, old_target_root, target_root;
+    HWND input_window, target_root;
     BOOL base_presentation;
     DWORD exstyle, target_style, target_exstyle;
     BOOL transparent_base;
+    NTSTATUS status;
     RECT rect;
 
     TRACE("Binding composition window %p to target %p (old target %p).\n",
             window, target, old_target);
 
-    old_input_window = GetPropW(window, L"__wine_dcomp_input_window");
-    old_target_root = old_target ? GetAncestor(old_target, GA_ROOT) : NULL;
-
-    if (old_target && old_target != target
-            && GetPropW(old_target, L"__wine_dcomp_base_presentation") == window)
-        RemovePropW(old_target, L"__wine_dcomp_base_presentation");
-    if (old_target && old_target != target)
-        dxgi_composition_window_clear_task_delegate(window, old_target);
-
     if (!target)
     {
+        SERVER_START_REQ(update_dcomp_task_delegate)
+        {
+            req->token_low = ime_token ? ime_token->low : 0;
+            req->token_high = ime_token ? ime_token->high : 0;
+            req->presentation = wine_server_user_handle(window);
+            req->target = 0;
+            req->flags = 0;
+            status = wine_server_call(req);
+        }
+        SERVER_END_REQ;
+        if (status) WARN("Failed to clear DComp task delegation, status %#lx.\n", status);
         if ((input_window = GetPropW(window, dcomp_caption_window_prop))) DestroyWindow(input_window);
         RemovePropW(window, dcomp_caption_window_prop);
-        dxgi_composition_window_clear_task_delegate(window, old_target);
         ShowWindow(window, SW_HIDE);
         RemovePropW(window, L"__wine_dcomp_detached_window");
         RemovePropW(window, L"__wine_dcomp_raised_while_active");
-        RemovePropW(window, L"__wine_dcomp_input_window");
-        RemovePropW(window, L"__wine_dcomp_keyboard_window");
         RemovePropW(window, L"__wine_dcomp_composite_alpha_background");
         RemovePropW(window, L"__wine_dcomp_task_minimized");
         RemovePropW(window, L"__wine_dcomp_task_identity");
         RemovePropW(window, dcomp_task_app_id_prop);
         RemovePropW(window, L"__wine_dcomp_client_rect");
-        if (old_input_window && GetPropW(old_input_window,
-                L"__wine_direct_hardware_input_owner") == window)
-        {
-            RemovePropW(old_input_window, L"__wine_direct_hardware_input");
-            RemovePropW(old_input_window, L"__wine_direct_hardware_input_owner");
-        }
-        if (old_target_root)
-        {
-            if (GetPropW(old_target_root, L"__wine_dcomp_input_window") == old_input_window)
-                RemovePropW(old_target_root, L"__wine_dcomp_input_window");
-            if (GetPropW(old_target_root, L"__wine_dcomp_keyboard_window") == old_input_window)
-                RemovePropW(old_target_root, L"__wine_dcomp_keyboard_window");
-        }
         return;
     }
 
@@ -1101,6 +1073,23 @@ void WINAPI __wine_dxgi_bind_composition_window(HWND window, HWND target)
     base_presentation = old_target == target
             ? GetPropW(target, L"__wine_dcomp_base_presentation") == window
             : !GetPropW(target, L"__wine_dcomp_base_presentation");
+    SERVER_START_REQ(update_dcomp_task_delegate)
+    {
+        req->token_low = ime_token ? ime_token->low : 0;
+        req->token_high = ime_token ? ime_token->high : 0;
+        req->presentation = wine_server_user_handle(window);
+        req->target = wine_server_user_handle(target);
+        req->flags = base_presentation ? DCOMP_TASK_DELEGATE_BASE : 0;
+        if (base_presentation && !transparent_base && target_root)
+            req->flags |= DCOMP_TASK_DELEGATE_TASK;
+        status = wine_server_call(req);
+    }
+    SERVER_END_REQ;
+    if (status)
+    {
+        WARN("Failed to update DComp task delegation, status %#lx.\n", status);
+        return;
+    }
     exstyle = WS_EX_NOACTIVATE | WS_EX_TOOLWINDOW;
     if (!base_presentation || transparent_base) exstyle |= WS_EX_LAYERED | WS_EX_TRANSPARENT;
 
@@ -1108,18 +1097,10 @@ void WINAPI __wine_dxgi_bind_composition_window(HWND window, HWND target)
     SetWindowLongW(window, GWL_STYLE, WS_POPUP);
     SetWindowLongW(window, GWL_EXSTYLE, exstyle);
     SetWindowLongPtrW(window, GWLP_HWNDPARENT, (LONG_PTR)target);
-    if (base_presentation)
+    if (base_presentation && !transparent_base && target_root)
     {
-        SetPropW(target, L"__wine_dcomp_base_presentation", window);
-        if (!transparent_base && target_root)
-        {
-            /* The opaque presentation surface owns the pixels that desktop
-             * compositors use for previews.  Let it represent the Win32 root
-             * in the task list while retaining the root's application identity. */
-            SetPropW(target_root, dcomp_task_delegated_prop, window);
-            PostMessageW(target_root, WM_WAYLAND_DCOMP_EXPORT, 0, 0);
-            dxgi_composition_window_update_identity(window, target_root);
-        }
+        PostMessageW(target_root, WM_WAYLAND_DCOMP_EXPORT, 0, 0);
+        dxgi_composition_window_update_identity(window, target_root);
     }
     if (!base_presentation || transparent_base)
     {
@@ -1135,18 +1116,6 @@ void WINAPI __wine_dxgi_bind_composition_window(HWND window, HWND target)
     else
         RemovePropW(window, L"__wine_dcomp_client_rect");
 
-    if (input_window)
-    {
-        SetPropW(window, L"__wine_dcomp_input_window", input_window);
-        SetPropW(window, L"__wine_dcomp_keyboard_window", input_window);
-        SetPropW(input_window, L"__wine_direct_hardware_input", ULongToHandle(0x57444952));
-        SetPropW(input_window, L"__wine_direct_hardware_input_owner", window);
-        if (target_root)
-        {
-            SetPropW(target_root, L"__wine_dcomp_input_window", input_window);
-            SetPropW(target_root, L"__wine_dcomp_keyboard_window", input_window);
-        }
-    }
     if (target_root) PostMessageW(target_root, WM_WAYLAND_DCOMP_EXPORT, 0, 0);
     if (!GetPropW(window, L"__wine_dcomp_old_proc"))
     {
@@ -1192,7 +1161,7 @@ static HRESULT STDMETHODCALLTYPE dxgi_factory_CreateSwapChainForComposition(IWin
         }
         return hr;
     }
-    if (own_window) d3d11_swapchain_set_composition_window(*swapchain, window);
+    if (own_window) dxgi_swapchain_set_composition_window(*swapchain, window);
     return S_OK;
 }
 

--- a/dlls/dxgi/swapchain.c
+++ b/dlls/dxgi/swapchain.c
@@ -205,18 +205,80 @@ static HWND d3d11_swapchain_get_hwnd(struct d3d11_swapchain *swapchain)
     return wined3d_desc.device_window;
 }
 static const struct IDXGISwapChain4Vtbl d3d11_swapchain_vtbl;
+static const struct IDXGISwapChain4Vtbl d3d12_swapchain_vtbl;
 
+static BOOL dcomp_ime_token_is_zero(const struct wine_dcomp_ime_token *token)
+{
+    return !token->low && !token->high;
+}
+
+static HRESULT get_dcomp_ime_token(HWND presentation, SRWLOCK *lock,
+        struct wine_dcomp_ime_token *token, UINT *data_size, void *data)
+{
+    NTSTATUS status = 0;
+
+    if (!data_size) return E_INVALIDARG;
+    if (!data)
+    {
+        *data_size = sizeof(*token);
+        return S_OK;
+    }
+    if (*data_size < sizeof(*token))
+    {
+        *data_size = sizeof(*token);
+        return DXGI_ERROR_MORE_DATA;
+    }
+
+    AcquireSRWLockExclusive(lock);
+    if (dcomp_ime_token_is_zero(token))
+    {
+        SERVER_START_REQ(create_dcomp_ime_offer)
+        {
+            req->presentation = wine_server_user_handle(presentation);
+            if (!(status = wine_server_call(req)))
+            {
+                token->low = reply->token_low;
+                token->high = reply->token_high;
+            }
+        }
+        SERVER_END_REQ;
+    }
+    if (!status) memcpy(data, token, sizeof(*token));
+    ReleaseSRWLockExclusive(lock);
+
+    if (status)
+    {
+        *data_size = 0;
+        return E_FAIL;
+    }
+    *data_size = sizeof(*token);
+    return S_OK;
+}
+
+static void revoke_dcomp_ime_token(SRWLOCK *lock, struct wine_dcomp_ime_token *token)
+{
+    struct wine_dcomp_ime_token revoked;
+
+    AcquireSRWLockExclusive(lock);
+    revoked = *token;
+    token->low = token->high = 0;
+    ReleaseSRWLockExclusive(lock);
+    if (dcomp_ime_token_is_zero(&revoked)) return;
+
+    SERVER_START_REQ(revoke_dcomp_ime_offer)
+    {
+        req->token_low = revoked.low;
+        req->token_high = revoked.high;
+        wine_server_call(req);
+    }
+    SERVER_END_REQ;
+}
 
 static inline struct d3d11_swapchain *d3d11_swapchain_from_IDXGISwapChain4(IDXGISwapChain4 *iface)
 {
     return CONTAINING_RECORD(iface, struct d3d11_swapchain, IDXGISwapChain4_iface);
 }
 
-void d3d11_swapchain_set_composition_window(IDXGISwapChain1 *iface, HWND window)
-{
-    struct d3d11_swapchain *swapchain = d3d11_swapchain_from_IDXGISwapChain4((IDXGISwapChain4 *)iface);
-    swapchain->composition_window = window;
-}
 HRESULT WINAPI __wine_dxgi_set_composition_description(IDXGISwapChain1 *iface,
         const struct wine_dcomp_visual_desc *desc)
 {
@@ -294,6 +356,8 @@ static ULONG STDMETHODCALLTYPE d3d11_swapchain_Release(IDXGISwapChain4 *iface)
     {
         IWineDXGIDevice *device = swapchain->device;
         HWND composition_window = swapchain->composition_window;
+
+        revoke_dcomp_ime_token(&swapchain->ime_token_lock, &swapchain->ime_token);
         if (swapchain->present1_shadow)
             ID3D11Texture2D_Release(swapchain->present1_shadow);
         if (swapchain->present1_scratch)
@@ -324,6 +388,7 @@ static HRESULT STDMETHODCALLTYPE d3d11_swapchain_SetPrivateData(IDXGISwapChain4 
 
     TRACE("iface %p, guid %s, data_size %u, data %p.\n", iface, debugstr_guid(guid), data_size, data);
 
+    if (IsEqualGUID(guid, &WINE_DCOMP_IME_TOKEN_GUID)) return E_INVALIDARG;
     return dxgi_set_private_data(&swapchain->private_store, guid, data_size, data);
 }
 
@@ -334,6 +399,7 @@ static HRESULT STDMETHODCALLTYPE d3d11_swapchain_SetPrivateDataInterface(IDXGISw
 
     TRACE("iface %p, guid %s, object %p.\n", iface, debugstr_guid(guid), object);
 
+    if (IsEqualGUID(guid, &WINE_DCOMP_IME_TOKEN_GUID)) return E_INVALIDARG;
     return dxgi_set_private_data_interface(&swapchain->private_store, guid, object);
 }
 
@@ -344,6 +410,9 @@ static HRESULT STDMETHODCALLTYPE d3d11_swapchain_GetPrivateData(IDXGISwapChain4 
 
     TRACE("iface %p, guid %s, data_size %p, data %p.\n", iface, debugstr_guid(guid), data_size, data);
 
+    if (IsEqualGUID(guid, &WINE_DCOMP_IME_TOKEN_GUID))
+        return get_dcomp_ime_token(d3d11_swapchain_get_hwnd(swapchain), &swapchain->ime_token_lock,
+                &swapchain->ime_token, data_size, data);
     return dxgi_get_private_data(&swapchain->private_store, guid, data_size, data);
 }
 
@@ -1548,6 +1617,8 @@ struct d3d12_swapchain
     IDXGISwapChain4 IDXGISwapChain4_iface;
     LONG refcount;
     struct wined3d_private_store private_store;
+    SRWLOCK ime_token_lock;
+    struct wine_dcomp_ime_token ime_token;
 
     struct wined3d_swapchain_state *state;
     struct wined3d_swapchain_state_parent state_parent;
@@ -1601,6 +1672,7 @@ struct d3d12_swapchain
     IWineDXGIFactory *factory;
 
     HWND window;
+    HWND composition_window;
     IDXGIOutput *target;
     DXGI_SWAP_CHAIN_DESC1 desc;
     DXGI_SWAP_CHAIN_FULLSCREEN_DESC fullscreen_desc;
@@ -2437,10 +2509,12 @@ static ULONG STDMETHODCALLTYPE d3d12_swapchain_AddRef(IDXGISwapChain4 *iface)
 static void d3d12_swapchain_destroy(struct d3d12_swapchain *swapchain)
 {
     const struct dxgi_vk_funcs *vk_funcs = &swapchain->vk_funcs;
+    HWND composition_window = swapchain->composition_window;
     void *vulkan_module = vk_funcs->vulkan_module;
     struct d3d12_swapchain_op *op, *op2;
     DWORD ret;
 
+    revoke_dcomp_ime_token(&swapchain->ime_token_lock, &swapchain->ime_token);
     EnterCriticalSection(&swapchain->worker_cs);
     swapchain->worker_running = false;
     WakeAllConditionVariable(&swapchain->worker_cv);
@@ -2497,6 +2571,9 @@ static void d3d12_swapchain_destroy(struct d3d12_swapchain *swapchain)
     if (swapchain->factory)
         IWineDXGIFactory_Release(swapchain->factory);
 
+    if (composition_window)
+        DestroyWindow(composition_window);
+
     FreeLibrary(vulkan_module);
 
     wined3d_swapchain_state_destroy(swapchain->state);
@@ -2527,6 +2604,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_swapchain_SetPrivateData(IDXGISwapChain4 
 
     TRACE("iface %p, guid %s, data_size %u, data %p.\n", iface, debugstr_guid(guid), data_size, data);
 
+    if (IsEqualGUID(guid, &WINE_DCOMP_IME_TOKEN_GUID)) return E_INVALIDARG;
     return dxgi_set_private_data(&swapchain->private_store, guid, data_size, data);
 }
 
@@ -2537,6 +2615,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_swapchain_SetPrivateDataInterface(IDXGISw
 
     TRACE("iface %p, guid %s, object %p.\n", iface, debugstr_guid(guid), object);
 
+    if (IsEqualGUID(guid, &WINE_DCOMP_IME_TOKEN_GUID)) return E_INVALIDARG;
     return dxgi_set_private_data_interface(&swapchain->private_store, guid, object);
 }
 
@@ -2547,6 +2626,9 @@ static HRESULT STDMETHODCALLTYPE d3d12_swapchain_GetPrivateData(IDXGISwapChain4 
 
     TRACE("iface %p, guid %s, data_size %p, data %p.\n", iface, debugstr_guid(guid), data_size, data);
 
+    if (IsEqualGUID(guid, &WINE_DCOMP_IME_TOKEN_GUID))
+        return get_dcomp_ime_token(swapchain->window, &swapchain->ime_token_lock,
+                &swapchain->ime_token, data_size, data);
     return dxgi_get_private_data(&swapchain->private_store, guid, data_size, data);
 }
 
@@ -3508,6 +3590,28 @@ static const struct IDXGISwapChain4Vtbl d3d12_swapchain_vtbl =
     /* IDXGISwapChain4 methods */
     d3d12_swapchain_SetHDRMetaData,
 };
+
+void dxgi_swapchain_set_composition_window(IDXGISwapChain1 *iface, HWND window)
+{
+    IDXGISwapChain4 *swapchain4;
+
+    if (!iface || FAILED(IDXGISwapChain1_QueryInterface(iface, &IID_IDXGISwapChain4,
+            (void **)&swapchain4)))
+        return;
+
+    if (swapchain4->lpVtbl == &d3d11_swapchain_vtbl)
+    {
+        struct d3d11_swapchain *swapchain = d3d11_swapchain_from_IDXGISwapChain4(swapchain4);
+        swapchain->composition_window = window;
+    }
+    else if (swapchain4->lpVtbl == &d3d12_swapchain_vtbl)
+    {
+        struct d3d12_swapchain *swapchain = d3d12_swapchain_from_IDXGISwapChain4(swapchain4);
+        swapchain->composition_window = window;
+    }
+
+    IDXGISwapChain4_Release(swapchain4);
+}
 
 static BOOL init_vk_funcs(struct dxgi_vk_funcs *dxgi, VkInstance vk_instance, VkDevice vk_device)
 {

--- a/dlls/dxgi/tests/dxgi.c
+++ b/dlls/dxgi/tests/dxgi.c
@@ -22,11 +22,13 @@
 #define COBJMACROS
 #include "initguid.h"
 #include "dxgi1_6.h"
+#include "dcomp.h"
 #include "d3d11.h"
 #include "d3d12.h"
 #include "d3d12sdklayers.h"
 #include "winternl.h"
 #include "ddk/d3dkmthk.h"
+#include "wine/dcomp.h"
 #include "wine/test.h"
 
 enum frame_latency
@@ -2418,6 +2420,133 @@ done:
     ok(refcount == !is_d3d12, "Got unexpected refcount %lu.\n", refcount);
     check_window_fullscreen_state(creation_desc.OutputWindow, &initial_state.fullscreen_state);
     DestroyWindow(creation_desc.OutputWindow);
+}
+
+static void test_create_composition_swapchain(IUnknown *device, BOOL is_d3d12)
+{
+    typedef HRESULT (WINAPI *dcomp_create_device_proc)(IDXGIDevice *, REFIID, void **);
+    IDXGIFactory *factory_base = NULL;
+    IDXGIFactory2 *factory = NULL;
+    IDXGISwapChain1 *swapchain = NULL;
+    IDCompositionDevice *dcomp_device = NULL;
+    IDCompositionTarget *dcomp_target = NULL;
+    IDCompositionVisual *dcomp_visual = NULL;
+    DXGI_SWAP_CHAIN_DESC1 desc;
+    struct wine_dcomp_ime_token token;
+    dcomp_create_device_proc pDCompositionCreateDevice;
+    HMODULE dcomp = NULL;
+    UINT token_size;
+    HWND window = NULL;
+    HWND target_window = NULL;
+    RECT target_rect, helper_rect;
+    HRESULT hr;
+
+    if (!is_d3d12)
+        return;
+
+    get_factory(device, is_d3d12, &factory_base);
+    hr = IDXGIFactory_QueryInterface(factory_base, &IID_IDXGIFactory2, (void **)&factory);
+    ok(hr == S_OK, "Got unexpected factory query hr %#lx.\n", hr);
+    IDXGIFactory_Release(factory_base);
+    if (FAILED(hr))
+        return;
+
+    memset(&desc, 0, sizeof(desc));
+    desc.Width = 64;
+    desc.Height = 64;
+    desc.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
+    desc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+    desc.BufferCount = 2;
+    desc.SampleDesc.Count = 1;
+    desc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+    desc.Scaling = DXGI_SCALING_STRETCH;
+    desc.AlphaMode = DXGI_ALPHA_MODE_PREMULTIPLIED;
+
+    hr = IDXGIFactory2_CreateSwapChainForComposition(factory, device, &desc, NULL, &swapchain);
+    ok(hr == S_OK, "Got unexpected hr %#lx.\n", hr);
+    if (FAILED(hr))
+        goto done;
+
+    hr = IDXGISwapChain1_GetHwnd(swapchain, &window);
+    ok(hr == S_OK, "Got unexpected hr %#lx.\n", hr);
+    ok(!!window, "Got NULL composition window.\n");
+
+    token_size = sizeof(token);
+    hr = IDXGISwapChain1_GetPrivateData(swapchain, &WINE_DCOMP_IME_TOKEN_GUID, &token_size, &token);
+    ok(hr == S_OK, "Got unexpected token query hr %#lx.\n", hr);
+    ok(token_size == sizeof(token), "Got token size %u.\n", token_size);
+    ok(token.low || token.high, "Got empty DComp token.\n");
+
+    if (!(dcomp = LoadLibraryW(L"dcomp.dll"))
+            || !(pDCompositionCreateDevice = (void *)GetProcAddress(dcomp, "DCompositionCreateDevice")))
+    {
+        win_skip("DCompositionCreateDevice is unavailable.\n");
+        goto done;
+    }
+    target_window = CreateWindowW(L"static", L"dxgi composition target", WS_OVERLAPPEDWINDOW,
+            100, 100, 320, 200, NULL, NULL, NULL, NULL);
+    if (!target_window)
+    {
+        win_skip("Could not create DComp target window.\n");
+        goto done;
+    }
+    ShowWindow(target_window, SW_SHOW);
+    UpdateWindow(target_window);
+
+    hr = pDCompositionCreateDevice(NULL, &IID_IDCompositionDevice, (void **)&dcomp_device);
+    ok(hr == S_OK, "DCompositionCreateDevice failed, hr %#lx.\n", hr);
+    if (FAILED(hr))
+        goto done;
+    hr = IDCompositionDevice_CreateTargetForHwnd(dcomp_device, target_window, FALSE, &dcomp_target);
+    ok(hr == S_OK, "CreateTargetForHwnd failed, hr %#lx.\n", hr);
+    if (FAILED(hr))
+        goto done;
+    hr = IDCompositionDevice_CreateVisual(dcomp_device, &dcomp_visual);
+    ok(hr == S_OK, "CreateVisual failed, hr %#lx.\n", hr);
+    if (FAILED(hr))
+        goto done;
+    hr = IDCompositionVisual_SetContent(dcomp_visual, (IUnknown *)swapchain);
+    ok(hr == S_OK, "SetContent failed, hr %#lx.\n", hr);
+    if (FAILED(hr))
+        goto done;
+    hr = IDCompositionTarget_SetRoot(dcomp_target, dcomp_visual);
+    ok(hr == S_OK, "SetRoot failed, hr %#lx.\n", hr);
+    if (FAILED(hr))
+        goto done;
+    hr = IDCompositionDevice_Commit(dcomp_device);
+    ok(hr == S_OK, "Commit failed, hr %#lx.\n", hr);
+    if (FAILED(hr))
+        goto done;
+
+    hr = IDXGISwapChain1_GetHwnd(swapchain, &window);
+    ok(hr == S_OK, "Got unexpected post-commit GetHwnd hr %#lx.\n", hr);
+    ok(window && IsWindowVisible(window), "Composition helper window %p is not visible.\n", window);
+    ok(GetClientRect(target_window, &target_rect), "GetClientRect failed.\n");
+    MapWindowPoints(target_window, NULL, (POINT *)&target_rect, 2);
+    ok(GetWindowRect(window, &helper_rect), "GetWindowRect failed.\n");
+    ok(helper_rect.left == target_rect.left && helper_rect.top == target_rect.top
+            && helper_rect.right - helper_rect.left == (LONG)desc.Width
+            && helper_rect.bottom - helper_rect.top == (LONG)desc.Height,
+            "Got helper rect {%ld,%ld,%ld,%ld}, target client origin {%ld,%ld}.\n",
+            helper_rect.left, helper_rect.top, helper_rect.right, helper_rect.bottom,
+            target_rect.left, target_rect.top);
+
+    hr = IDCompositionVisual_SetContent(dcomp_visual, NULL);
+    ok(hr == S_OK, "Clearing visual content failed, hr %#lx.\n", hr);
+    hr = IDCompositionDevice_Commit(dcomp_device);
+    ok(hr == S_OK, "Unbind commit failed, hr %#lx.\n", hr);
+    ok(!IsWindowVisible(window), "Unbound composition helper window %p is still visible.\n", window);
+    ok(!GetPropW(window, L"__wine_dcomp_detached_window"),
+            "Unbound composition helper retained its target.\n");
+
+done:
+    if (dcomp_visual) IDCompositionVisual_Release(dcomp_visual);
+    if (dcomp_target) IDCompositionTarget_Release(dcomp_target);
+    if (dcomp_device) IDCompositionDevice_Release(dcomp_device);
+    if (target_window) DestroyWindow(target_window);
+    if (swapchain) IDXGISwapChain1_Release(swapchain);
+    if (factory) IDXGIFactory2_Release(factory);
+    if (dcomp) FreeLibrary(dcomp);
 }
 
 static void test_get_containing_output(IUnknown *device, BOOL is_d3d12)
@@ -9335,6 +9464,7 @@ START_TEST(dxgi)
     }
 
     run_on_d3d12(test_create_swapchain);
+    run_on_d3d12(test_create_composition_swapchain);
     run_on_d3d12(test_set_fullscreen);
     run_on_d3d12(test_resize_target);
     run_on_d3d12(test_resize_fullscreen);

--- a/dlls/dxgi/tests/dxgi.c
+++ b/dlls/dxgi/tests/dxgi.c
@@ -2467,15 +2467,22 @@ static void test_create_composition_swapchain(IUnknown *device, BOOL is_d3d12)
     if (FAILED(hr))
         goto done;
 
-    hr = IDXGISwapChain1_GetHwnd(swapchain, &window);
-    ok(hr == S_OK, "Got unexpected hr %#lx.\n", hr);
-    ok(!!window, "Got NULL composition window.\n");
-
     token_size = sizeof(token);
-    hr = IDXGISwapChain1_GetPrivateData(swapchain, &WINE_DCOMP_IME_TOKEN_GUID, &token_size, &token);
-    ok(hr == S_OK, "Got unexpected token query hr %#lx.\n", hr);
-    ok(token_size == sizeof(token), "Got token size %u.\n", token_size);
-    ok(token.low || token.high, "Got empty DComp token.\n");
+    if (!strcmp(winetest_platform, "wine"))
+    {
+        hr = IDXGISwapChain1_GetHwnd(swapchain, &window);
+        ok(hr == S_OK, "Got unexpected hr %#lx.\n", hr);
+        ok(!!window, "Got NULL composition window.\n");
+        hr = IDXGISwapChain1_GetPrivateData(swapchain, &WINE_DCOMP_IME_TOKEN_GUID, &token_size, &token);
+        ok(hr == S_OK, "Got unexpected token query hr %#lx.\n", hr);
+        ok(token_size == sizeof(token), "Got token size %u.\n", token_size);
+        ok(token.low || token.high, "Got empty DComp token.\n");
+    }
+    else
+    {
+        hr = IDXGISwapChain1_GetPrivateData(swapchain, &WINE_DCOMP_IME_TOKEN_GUID, &token_size, &token);
+        ok(hr == DXGI_ERROR_NOT_FOUND, "Got unexpected native token query hr %#lx.\n", hr);
+    }
 
     if (!(dcomp = LoadLibraryW(L"dcomp.dll"))
             || !(pDCompositionCreateDevice = (void *)GetProcAddress(dcomp, "DCompositionCreateDevice")))
@@ -2518,26 +2525,32 @@ static void test_create_composition_swapchain(IUnknown *device, BOOL is_d3d12)
     if (FAILED(hr))
         goto done;
 
-    hr = IDXGISwapChain1_GetHwnd(swapchain, &window);
-    ok(hr == S_OK, "Got unexpected post-commit GetHwnd hr %#lx.\n", hr);
-    ok(window && IsWindowVisible(window), "Composition helper window %p is not visible.\n", window);
-    ok(GetClientRect(target_window, &target_rect), "GetClientRect failed.\n");
-    MapWindowPoints(target_window, NULL, (POINT *)&target_rect, 2);
-    ok(GetWindowRect(window, &helper_rect), "GetWindowRect failed.\n");
-    ok(helper_rect.left == target_rect.left && helper_rect.top == target_rect.top
-            && helper_rect.right - helper_rect.left == (LONG)desc.Width
-            && helper_rect.bottom - helper_rect.top == (LONG)desc.Height,
-            "Got helper rect {%ld,%ld,%ld,%ld}, target client origin {%ld,%ld}.\n",
-            helper_rect.left, helper_rect.top, helper_rect.right, helper_rect.bottom,
-            target_rect.left, target_rect.top);
+    if (!strcmp(winetest_platform, "wine"))
+    {
+        hr = IDXGISwapChain1_GetHwnd(swapchain, &window);
+        ok(hr == S_OK, "Got unexpected post-commit GetHwnd hr %#lx.\n", hr);
+        ok(window && IsWindowVisible(window), "Composition helper window %p is not visible.\n", window);
+        ok(GetClientRect(target_window, &target_rect), "GetClientRect failed.\n");
+        MapWindowPoints(target_window, NULL, (POINT *)&target_rect, 2);
+        ok(GetWindowRect(window, &helper_rect), "GetWindowRect failed.\n");
+        ok(helper_rect.left == target_rect.left && helper_rect.top == target_rect.top
+                && helper_rect.right - helper_rect.left == (LONG)desc.Width
+                && helper_rect.bottom - helper_rect.top == (LONG)desc.Height,
+                "Got helper rect {%ld,%ld,%ld,%ld}, target client origin {%ld,%ld}.\n",
+                helper_rect.left, helper_rect.top, helper_rect.right, helper_rect.bottom,
+                target_rect.left, target_rect.top);
+    }
 
     hr = IDCompositionVisual_SetContent(dcomp_visual, NULL);
     ok(hr == S_OK, "Clearing visual content failed, hr %#lx.\n", hr);
     hr = IDCompositionDevice_Commit(dcomp_device);
     ok(hr == S_OK, "Unbind commit failed, hr %#lx.\n", hr);
-    ok(!IsWindowVisible(window), "Unbound composition helper window %p is still visible.\n", window);
-    ok(!GetPropW(window, L"__wine_dcomp_detached_window"),
-            "Unbound composition helper retained its target.\n");
+    if (!strcmp(winetest_platform, "wine"))
+    {
+        ok(!IsWindowVisible(window), "Unbound composition helper window %p is still visible.\n", window);
+        ok(!GetPropW(window, L"__wine_dcomp_detached_window"),
+                "Unbound composition helper retained its target.\n");
+    }
 
 done:
     if (dcomp_visual) IDCompositionVisual_Release(dcomp_visual);

--- a/dlls/win32u/imm.c
+++ b/dlls/win32u/imm.c
@@ -525,6 +525,45 @@ static void post_ime_update( HWND hwnd, UINT cursor_pos, WCHAR *comp_str, WCHAR 
     free( tmp );
 }
 
+BOOL process_ime_update( HWND hwnd, const COPYDATASTRUCT *copydata, LRESULT *result )
+{
+    const struct wine_ime_update *update;
+    const WCHAR *comp_str = NULL, *result_str = NULL;
+    SIZE_T char_count, expected_size;
+
+    if (!copydata || copydata->dwData != WINE_IME_UPDATE_COPYDATA) return FALSE;
+    *result = FALSE;
+    if (copydata->cbData < offsetof(struct wine_ime_update, strings) || !copydata->lpData)
+        return TRUE;
+
+    update = copydata->lpData;
+    if (update->comp_len > WINE_IME_UPDATE_MAX_CHARS ||
+        update->result_len > WINE_IME_UPDATE_MAX_CHARS)
+        return TRUE;
+    char_count = (SIZE_T)update->comp_len + update->result_len;
+    if (char_count > WINE_IME_UPDATE_MAX_CHARS ||
+        char_count > (MAXDWORD - offsetof(struct wine_ime_update, strings)) / sizeof(WCHAR))
+        return TRUE;
+    expected_size = offsetof(struct wine_ime_update, strings) + char_count * sizeof(WCHAR);
+    if (copydata->cbData != expected_size) return TRUE;
+
+    if (update->comp_len)
+    {
+        comp_str = update->strings;
+        if (comp_str[update->comp_len - 1] || wcslen( comp_str ) != update->comp_len - 1) return TRUE;
+    }
+    if (update->result_len)
+    {
+        result_str = update->strings + update->comp_len;
+        if (result_str[update->result_len - 1] || wcslen( result_str ) != update->result_len - 1)
+            return TRUE;
+    }
+
+    post_ime_update( hwnd, update->cursor_pos, (WCHAR *)comp_str, (WCHAR *)result_str );
+    *result = TRUE;
+    return TRUE;
+}
+
 static UINT get_comp_clause_count( UINT comp_len, UINT cursor_begin, UINT cursor_end )
 {
     if (cursor_begin == cursor_end || (cursor_begin == 0 && cursor_end == comp_len))

--- a/dlls/win32u/input.c
+++ b/dlls/win32u/input.c
@@ -2581,12 +2581,35 @@ BOOL WINAPI NtUserGetCaretPos( POINT *pt )
     return ret;
 }
 
+BOOL process_ime_set_rect( HWND hwnd, const COPYDATASTRUCT *copydata, LRESULT *result )
+{
+    if (!copydata || copydata->dwData != WINE_IME_SET_RECT_COPYDATA) return FALSE;
+    *result = FALSE;
+    if (copydata->cbData == sizeof(RECT) && copydata->lpData)
+        *result = user_driver->pSetIMECompositionRect( hwnd, *(RECT *)copydata->lpData );
+    return TRUE;
+}
+
 BOOL set_ime_composition_rect( HWND hwnd, RECT rect )
 {
+    static const WCHAR delegated_prop[] = {'_','_','w','i','n','e','_','d','c','o','m','p','_',
+            't','a','s','k','_','d','e','l','e','g','a','t','e','d',0};
+    static const WCHAR input_prop[] = {'_','_','w','i','n','e','_','d','c','o','m','p','_',
+            'i','n','p','u','t','_','w','i','n','d','o','w',0};
+    struct send_message_timeout_params params = { .flags = SMTO_ABORTIFHUNG, .timeout = 250 };
+    COPYDATASTRUCT copydata = { .dwData = WINE_IME_SET_RECT_COPYDATA, .cbData = sizeof(rect), .lpData = &rect };
+    HWND root, input, presentation;
+
     if (!NtUserIsWindow( hwnd )) return FALSE;
     NtUserMapWindowPoints( hwnd, 0, (POINT *)&rect, 2, 0 /* per-monitor DPI */ );
     rect = map_rect_virt_to_raw( rect, no_dpi /* per-monitor DPI */ );
-    return user_driver->pSetIMECompositionRect( NtUserGetAncestor( hwnd, GA_ROOT ), rect );
+    root = NtUserGetAncestor( hwnd, GA_ROOT );
+    input = NtUserGetProp( root, input_prop );
+    presentation = NtUserGetProp( root, delegated_prop );
+    if (!is_dcomp_ime_relationship( presentation, root, input ))
+        return user_driver->pSetIMECompositionRect( root, rect );
+    return NtUserMessageCall( presentation, WM_COPYDATA, (WPARAM)root, (LPARAM)&copydata, &params,
+                             NtUserSendMessageTimeout, FALSE ) && params.result;
 }
 
 /*****************************************************************

--- a/dlls/win32u/message.c
+++ b/dlls/win32u/message.c
@@ -105,6 +105,7 @@ struct received_message_info
     UINT  type;
     MSG   msg;
     UINT  flags;  /* InSendMessageEx return flags */
+    UINT  dcomp_ime_authorization;
     struct received_message_info *prev;
 };
 
@@ -2341,8 +2342,20 @@ BOOL WINAPI NtUserGetGUIThreadInfo( DWORD id, GUITHREADINFO *info )
  *
  * Call a window procedure and the corresponding hooks.
  */
+static UINT validate_dcomp_ime_message(void)
+{
+    UINT authorization = 0;
+
+    SERVER_START_REQ( validate_dcomp_ime_message )
+    {
+        if (!wine_server_call( req )) authorization = reply->authorization;
+    }
+    SERVER_END_REQ;
+    return authorization;
+}
+
 static LRESULT call_window_proc( HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam,
-                                 enum message_type type, BOOL same_thread,
+                                 enum message_type type, BOOL same_thread, UINT dcomp_ime_authorization,
                                  enum wm_char_mapping mapping, BOOL ansi_dst )
 {
     struct user_thread_info *thread_info = get_user_thread_info();
@@ -2366,15 +2379,28 @@ static LRESULT call_window_proc( HWND hwnd, UINT msg, WPARAM wparam, LPARAM lpar
     prev_source = thread_info->client_info->msg_source;
     thread_info->client_info->msg_source = msg_source_unavailable;
 
-    packed_size = user_message_size( hwnd, msg, wparam, lparam, type == MSG_OTHER_PROCESS, ansi, &reply_size );
-
-    /* first the WH_CALLWNDPROC hook */
     cwp.lParam  = lparam;
     cwp.wParam  = wparam;
     cwp.message = msg;
     cwp.hwnd    = hwnd = get_full_window_handle( hwnd );
+    packed_size = user_message_size( hwnd, msg, wparam, lparam, type == MSG_OTHER_PROCESS, ansi, &reply_size );
+
+    /* first the WH_CALLWNDPROC hook */
     call_message_hooks( WH_CALLWNDPROC, HC_ACTION, same_thread, (LPARAM)&cwp, sizeof(cwp),
                         packed_size, ansi );
+
+    if (msg == WM_COPYDATA)
+    {
+        COPYDATASTRUCT *copydata = (COPYDATASTRUCT *)lparam;
+
+        if (!same_thread && dcomp_ime_authorization) dcomp_ime_authorization = validate_dcomp_ime_message();
+        if ((dcomp_ime_authorization & DCOMP_IME_AUTHORIZE_UPDATE) &&
+            process_ime_update( hwnd, copydata, &result ))
+            goto callwndprocret;
+        if ((dcomp_ime_authorization & DCOMP_IME_AUTHORIZE_SET_RECT) &&
+            process_ime_set_rect( hwnd, copydata, &result ))
+            goto callwndprocret;
+    }
 
     if (packed_size)
     {
@@ -2399,6 +2425,7 @@ static LRESULT call_window_proc( HWND hwnd, UINT msg, WPARAM wparam, LPARAM lpar
 
     copy_user_result( ret_ptr, min( ret_len, reply_size ), result, msg, wparam, lparam, ansi );
 
+callwndprocret:
     /* and finally the WH_CALLWNDPROCRET hook */
     cwpret.lResult = result;
     cwpret.lParam  = lparam;
@@ -3062,6 +3089,7 @@ static int peek_message( MSG *msg, const struct peek_message_filter *filter )
             {
                 size = wine_server_reply_size( reply );
                 info.type        = reply->type;
+                info.dcomp_ime_authorization = reply->dcomp_ime_authorization;
                 info.msg.hwnd    = wine_server_ptr_handle( reply->win );
                 info.msg.message = reply->msg;
                 info.msg.wParam  = reply->wparam;
@@ -3300,8 +3328,8 @@ static int peek_message( MSG *msg, const struct peek_message_filter *filter )
         info.prev = thread_info->receive_info;
         thread_info->receive_info = &info;
         result = call_window_proc( info.msg.hwnd, info.msg.message, info.msg.wParam,
-                                   info.msg.lParam, info.type, FALSE, WMCHAR_MAP_RECVMESSAGE,
-                                   info.type == MSG_ASCII );
+                                   info.msg.lParam, info.type, FALSE, info.dcomp_ime_authorization,
+                                   WMCHAR_MAP_RECVMESSAGE, info.type == MSG_ASCII );
         if (thread_info->receive_info == &info)
             reply_winproc_result( result, info.msg.hwnd, info.msg.message,
                                   info.msg.wParam, info.msg.lParam );
@@ -4514,7 +4542,7 @@ static BOOL process_message( struct send_message_info *info, DWORD_PTR *res_ptr,
     else
     {
         result = call_window_proc( info->hwnd, info->msg, info->wparam, info->lparam,
-                                   info->type, TRUE, info->wm_char, ansi );
+                                   info->type, TRUE, 0, info->wm_char, ansi );
         if (info->type == MSG_CALLBACK)
             call_sendmsg_callback( info->callback, info->hwnd, info->msg, info->data, result );
         ret = TRUE;

--- a/dlls/win32u/tests/win32u.c
+++ b/dlls/win32u/tests/win32u.c
@@ -2031,6 +2031,14 @@ static LRESULT WINAPI test_ipc_message_proc( HWND hwnd, UINT msg, WPARAM wparam,
             return (LRESULT)ipc_input;
         }
 
+    case WM_USER + 11:
+        ok( !GetPropW( ipc_root, dcomp_input_window_prop ), "root retained DComp input property\n" );
+        ok( !GetPropW( ipc_root, dcomp_keyboard_window_prop ), "root retained DComp keyboard property\n" );
+        ok( !GetPropW( ipc_input, direct_hardware_input_prop ), "input retained direct marker\n" );
+        ok( !GetPropW( ipc_input, direct_hardware_input_owner_prop ),
+            "input retained presentation owner\n" );
+        return 1;
+
     case WM_USER + 8:
         ok( start_dcomp_revoke_barrier(), "failed to start DComp revoke barrier\n" );
         return 1;
@@ -2404,8 +2412,8 @@ cleanup:
     if (mapping) CloseHandle( mapping );
     if (ipc_target) DestroyWindow( ipc_target );
     if (ipc_input) DestroyWindow( ipc_input );
-    if (ipc_old_target) DestroyWindow( ipc_old_target );
-    if (ipc_old_input) DestroyWindow( ipc_old_input );
+    if (ipc_old_target && ipc_old_target != ipc_target) DestroyWindow( ipc_old_target );
+    if (ipc_old_input && ipc_old_input != ipc_input) DestroyWindow( ipc_old_input );
     DestroyWindow( ipc_root );
     UnregisterClassW( L"TestIPCClass", NULL );
 }
@@ -2571,6 +2579,12 @@ static void test_ime_browser_child( HWND presentation, HANDLE mapping, BOOL repa
     token = MapViewOfFile( mapping, FILE_MAP_READ, 0, 0, sizeof(*token) );
     ok( !!token, "browser MapViewOfFile failed, error %lu\n", GetLastError() );
     if (!token) return;
+    if (!p_wine_server_call)
+    {
+        win_skip( "wine_server_call is unavailable\n" );
+        UnmapViewOfFile( token );
+        return;
+    }
 
     cls.lpfnWndProc = test_ipc_message_proc;
     cls.lpszClassName = L"TestIPCBrowserClass";
@@ -2834,6 +2848,7 @@ static void stop_dcomp_cross_process_helper( struct dcomp_cross_process_helper *
     if (helper->info.hProcess)
     {
         if (helper->window) PostMessageW( helper->window, WM_CLOSE, 0, 0 );
+        else TerminateProcess( helper->info.hProcess, 0 );
         wait_child_process_with_messages( &helper->info );
     }
     if (helper->ready) CloseHandle( helper->ready );
@@ -3172,10 +3187,7 @@ static void test_inter_process_child( const char *argv0, HWND hwnd, HANDLE mappi
     ok( SendMessageW( hwnd, WM_USER + 5, 3, 0 ) == 1, "replacement first key check failed\n" );
 
     DestroyWindow( presentation );
-    ok( !GetPropW( ipc_root, dcomp_input_window_prop ), "root retained DComp input property\n" );
-    ok( !GetPropW( ipc_root, dcomp_keyboard_window_prop ), "root retained DComp keyboard property\n" );
-    ok( !GetPropW( ipc_input, direct_hardware_input_prop ), "input retained direct marker\n" );
-    ok( !GetPropW( ipc_input, direct_hardware_input_owner_prop ), "input retained presentation owner\n" );
+    ok( SendMessageW( hwnd, WM_USER + 11, 0, 0 ) == 1, "presentation teardown check failed\n" );
     presentation = CreateWindowExW( 0, L"TestIPCPresentationClass", NULL, 0, 0, 0, 0, 0,
                                     HWND_MESSAGE, 0, 0, NULL );
     ok( !!presentation, "shared presentation CreateWindowExW failed, error %lu\n", GetLastError() );
@@ -4502,7 +4514,8 @@ static void test_keyboard_repeat_hook(void)
     ok( repeat_keydown_count >= 2, "received %ld non-key-up key-downs\n", repeat_keydown_count );
     ok( repeat_keydown.vkCode == 'A', "key-down vkey is %#lx\n", repeat_keydown.vkCode );
     ok( repeat_keydown.scanCode == 0x1e, "key-down scan is %#lx\n", repeat_keydown.scanCode );
-    ok( repeat_keydown.flags == LLKHF_EXTENDED, "key-down flags are %#lx\n", repeat_keydown.flags );
+    ok( (repeat_keydown.flags & (LLKHF_EXTENDED | LLKHF_UP)) == LLKHF_EXTENDED,
+        "key-down flags are %#lx\n", repeat_keydown.flags );
     ok( repeat_keydown.time == input.ki.time, "key-down time is %#lx\n", repeat_keydown.time );
     ok( repeat_keydown.dwExtraInfo == repeat_signature, "key-down extra info is %Ix\n",
         repeat_keydown.dwExtraInfo );
@@ -4510,8 +4523,8 @@ static void test_keyboard_repeat_hook(void)
         repeat_keydown_repeat.vkCode );
     ok( repeat_keydown_repeat.scanCode == 0x1e, "repeat key-down scan is %#lx\n",
         repeat_keydown_repeat.scanCode );
-    ok( repeat_keydown_repeat.flags == LLKHF_EXTENDED, "repeat key-down flags are %#lx\n",
-        repeat_keydown_repeat.flags );
+    ok( (repeat_keydown_repeat.flags & (LLKHF_EXTENDED | LLKHF_UP)) == LLKHF_EXTENDED,
+        "repeat key-down flags are %#lx\n", repeat_keydown_repeat.flags );
     ok( repeat_keydown_repeat.time != input.ki.time, "repeat key-down reused input time %#lx\n",
         repeat_keydown_repeat.time );
     ok( repeat_keydown_repeat.time - start < 2000, "repeat key-down time is %#lx, start %#lx\n",
@@ -4535,7 +4548,7 @@ static void test_keyboard_repeat_hook(void)
     ok( repeat_keyup_captured, "key-up hook was not captured\n" );
     ok( repeat_keyup.vkCode == 'A', "key-up vkey is %#lx\n", repeat_keyup.vkCode );
     ok( repeat_keyup.scanCode == 0x1e, "key-up scan is %#lx\n", repeat_keyup.scanCode );
-    ok( repeat_keyup.flags == (LLKHF_EXTENDED | LLKHF_UP),
+    ok( (repeat_keyup.flags & (LLKHF_EXTENDED | LLKHF_UP)) == (LLKHF_EXTENDED | LLKHF_UP),
         "key-up flags are %#lx\n", repeat_keyup.flags );
     ok( repeat_keyup.time == input.ki.time, "key-up time is %#lx\n", repeat_keyup.time );
     ok( repeat_keyup.dwExtraInfo == repeat_signature, "key-up extra info is %Ix\n",

--- a/dlls/win32u/tests/win32u.c
+++ b/dlls/win32u/tests/win32u.c
@@ -23,6 +23,8 @@
 
 #include "winbase.h"
 #include "ntuser.h"
+#include "wine/dcomp.h"
+#include "wine/server.h"
 
 #define MAX_ATOM_LEN  255
 
@@ -1706,10 +1708,392 @@ static void test_NtUserDisplayConfigGetDeviceInfo(void)
     ok(status == STATUS_UNSUCCESSFUL || status == STATUS_NOT_SUPPORTED, "got %#lx.\n", status);
 }
 
+static LONG private_copydata_calls, dcomp_presentation_process_id;
+static LONG ipc_old_key_down, ipc_old_key_up, ipc_new_key_down, ipc_new_key_up;
+static HWND ipc_root, ipc_input, ipc_target, ipc_presentation;
+static HWND ipc_old_input, ipc_old_target;
+static struct wine_dcomp_ime_token ipc_browser_token;
+static struct wine_dcomp_ime_token *ipc_shared_token;
+static unsigned int (CDECL *p_wine_server_call)( void * );
+static HANDLE dcomp_barrier_enter, dcomp_barrier_release;
+static HANDLE dcomp_barrier_thread, dcomp_barrier_hook;
+static NTSTATUS dcomp_barrier_revoke_status;
+static LONG dcomp_barrier_before_calls;
+static volatile LONG dcomp_barrier_active;
+
+static NTSTATUS create_dcomp_ime_offer( HWND presentation, struct wine_dcomp_ime_token *token )
+{
+    NTSTATUS status;
+
+    token->low = token->high = 0;
+    SERVER_START_REQ( create_dcomp_ime_offer )
+    {
+        req->presentation = wine_server_user_handle( presentation );
+        if (!(status = p_wine_server_call( req )))
+        {
+            token->low = reply->token_low;
+            token->high = reply->token_high;
+        }
+    }
+    SERVER_END_REQ;
+    return status;
+}
+
+static NTSTATUS set_dcomp_ime_relationship( const struct wine_dcomp_ime_token *token, HWND target )
+{
+    NTSTATUS status;
+
+    SERVER_START_REQ( set_dcomp_ime_relationship )
+    {
+        req->token_low = token->low;
+        req->token_high = token->high;
+        req->target = wine_server_user_handle( target );
+        status = p_wine_server_call( req );
+    }
+    SERVER_END_REQ;
+    return status;
+}
+
+static NTSTATUS revoke_dcomp_ime_offer( const struct wine_dcomp_ime_token *token )
+{
+    NTSTATUS status;
+
+    SERVER_START_REQ( revoke_dcomp_ime_offer )
+    {
+        req->token_low = token->low;
+        req->token_high = token->high;
+        status = p_wine_server_call( req );
+    }
+    SERVER_END_REQ;
+    return status;
+}
+
+static NTSTATUS update_dcomp_task_delegate( const struct wine_dcomp_ime_token *token,
+                                             HWND presentation, HWND target, unsigned int flags )
+{
+    NTSTATUS status;
+
+    SERVER_START_REQ( update_dcomp_task_delegate )
+    {
+        req->token_low = token->low;
+        req->token_high = token->high;
+        req->presentation = wine_server_user_handle( presentation );
+        req->target = wine_server_user_handle( target );
+        req->flags = flags;
+        status = p_wine_server_call( req );
+    }
+    SERVER_END_REQ;
+    return status;
+}
+static const WCHAR dcomp_detached_window_prop[] = {'_','_','w','i','n','e','_','d','c','o','m','p','_',
+        'd','e','t','a','c','h','e','d','_','w','i','n','d','o','w',0};
+static const WCHAR dcomp_base_presentation_prop[] = {'_','_','w','i','n','e','_','d','c','o','m','p','_',
+        'b','a','s','e','_','p','r','e','s','e','n','t','a','t','i','o','n',0};
+static const WCHAR dcomp_input_window_prop[] = {'_','_','w','i','n','e','_','d','c','o','m','p','_',
+        'i','n','p','u','t','_','w','i','n','d','o','w',0};
+static const WCHAR dcomp_keyboard_window_prop[] = {'_','_','w','i','n','e','_','d','c','o','m','p','_',
+        'k','e','y','b','o','a','r','d','_','w','i','n','d','o','w',0};
+static const WCHAR direct_hardware_input_prop[] = {'_','_','w','i','n','e','_','d','i','r','e','c','t','_',
+        'h','a','r','d','w','a','r','e','_','i','n','p','u','t',0};
+static const WCHAR dcomp_task_delegated_prop[] = {'_','_','w','i','n','e','_','d','c','o','m','p','_',
+        't','a','s','k','_','d','e','l','e','g','a','t','e','d',0};
+static const WCHAR dcomp_task_delegated_target_prop[] = {'_','_','w','i','n','e','_','d','c','o','m','p','_',
+        't','a','s','k','_','d','e','l','e','g','a','t','e','d','_','t','a','r','g','e','t',0};
+static const WCHAR direct_hardware_input_owner_prop[] = {'_','_','w','i','n','e','_','d','i','r','e','c','t','_',
+        'h','a','r','d','w','a','r','e','_','i','n','p','u','t','_','o','w','n','e','r',0};
+
+struct dcomp_presentation_process_state
+{
+    HWND presentation;
+    struct wine_dcomp_ime_token token;
+    NTSTATUS status;
+};
+
+static struct dcomp_presentation_process_state *dcomp_presentation_state;
+
+static LRESULT WINAPI dcomp_presentation_proc( HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam )
+{
+    return DefWindowProcW( hwnd, msg, wparam, lparam );
+}
+
+struct dcomp_presentation_process
+{
+    PROCESS_INFORMATION info;
+    HANDLE mapping;
+    HANDLE ready;
+    HANDLE stop;
+    char stop_name[64];
+    struct dcomp_presentation_process_state *state;
+};
+
+struct dcomp_victim_thread
+{
+    HANDLE ready;
+    HANDLE stop;
+    HANDLE thread;
+    DWORD tid;
+};
+
+static struct dcomp_victim_thread ipc_victim;
+
+static void stop_dcomp_victim_thread(void);
+static void stop_dcomp_revoke_barrier(void);
+
+static DWORD WINAPI dcomp_victim_thread_proc( void *arg )
+{
+    struct dcomp_victim_thread *victim = arg;
+    MSG msg;
+
+    PeekMessageW( &msg, NULL, 0, 0, PM_NOREMOVE );
+    SetEvent( victim->ready );
+    WaitForSingleObject( victim->stop, INFINITE );
+    return 0;
+}
+
+static BOOL start_dcomp_victim_thread(void)
+{
+    memset( &ipc_victim, 0, sizeof(ipc_victim) );
+    ipc_victim.ready = CreateEventW( NULL, TRUE, FALSE, NULL );
+    ipc_victim.stop = CreateEventW( NULL, TRUE, FALSE, NULL );
+    if (!ipc_victim.ready || !ipc_victim.stop) return FALSE;
+    ipc_victim.thread = CreateThread( NULL, 0, dcomp_victim_thread_proc, &ipc_victim, 0, &ipc_victim.tid );
+    if (!ipc_victim.thread || WaitForSingleObject( ipc_victim.ready, 5000 ) != WAIT_OBJECT_0)
+    {
+        stop_dcomp_victim_thread();
+        return FALSE;
+    }
+    return TRUE;
+}
+
+static void stop_dcomp_victim_thread(void)
+{
+    if (ipc_victim.stop) SetEvent( ipc_victim.stop );
+    if (ipc_victim.thread) WaitForSingleObject( ipc_victim.thread, 5000 );
+    if (ipc_victim.thread) CloseHandle( ipc_victim.thread );
+    if (ipc_victim.ready) CloseHandle( ipc_victim.ready );
+    if (ipc_victim.stop) CloseHandle( ipc_victim.stop );
+    memset( &ipc_victim, 0, sizeof(ipc_victim) );
+}
+
+static DWORD WINAPI dcomp_barrier_revoke_proc( void *arg )
+{
+    HANDLE events[2] = { dcomp_barrier_enter, dcomp_barrier_release };
+    DWORD wait;
+
+    wait = WaitForMultipleObjects( ARRAY_SIZE(events), events, FALSE, INFINITE );
+    if (wait == WAIT_OBJECT_0)
+    {
+        dcomp_barrier_revoke_status = set_dcomp_ime_relationship( &ipc_browser_token, NULL );
+        SetEvent( dcomp_barrier_release );
+    }
+    return 0;
+}
+
+static LRESULT WINAPI dcomp_barrier_hook_proc( INT code, WPARAM wparam, LPARAM lparam )
+{
+    CWPSTRUCT *cwp = (CWPSTRUCT *)lparam;
+
+    if (code == HC_ACTION && InterlockedCompareExchange( &dcomp_barrier_active, 0, 0 ) &&
+        cwp->message == WM_COPYDATA && cwp->hwnd == ipc_input && cwp->lParam)
+    {
+        COPYDATASTRUCT *copydata = (COPYDATASTRUCT *)cwp->lParam;
+        if (copydata->dwData == WINE_IME_UPDATE_COPYDATA)
+        {
+            SetEvent( dcomp_barrier_enter );
+            WaitForSingleObject( dcomp_barrier_release, INFINITE );
+        }
+    }
+    return CallNextHookEx( NULL, code, wparam, lparam );
+}
+
+static void stop_dcomp_revoke_barrier(void);
+
+static BOOL start_dcomp_revoke_barrier(void)
+{
+    stop_dcomp_revoke_barrier();
+    dcomp_barrier_enter = CreateEventW( NULL, TRUE, FALSE, NULL );
+    dcomp_barrier_release = CreateEventW( NULL, TRUE, FALSE, NULL );
+    dcomp_barrier_revoke_status = STATUS_UNSUCCESSFUL;
+    dcomp_barrier_before_calls = private_copydata_calls;
+    if (!dcomp_barrier_enter || !dcomp_barrier_release) goto failed;
+    dcomp_barrier_thread = CreateThread( NULL, 0, dcomp_barrier_revoke_proc, NULL, 0, NULL );
+    if (!dcomp_barrier_thread) goto failed;
+    dcomp_barrier_hook = SetWindowsHookExW( WH_CALLWNDPROC, dcomp_barrier_hook_proc, NULL,
+                                            GetCurrentThreadId() );
+    if (!dcomp_barrier_hook) goto failed;
+    dcomp_barrier_active = TRUE;
+    return TRUE;
+
+failed:
+    stop_dcomp_revoke_barrier();
+    return FALSE;
+}
+
+static void stop_dcomp_revoke_barrier(void)
+{
+    dcomp_barrier_active = FALSE;
+    if (dcomp_barrier_release) SetEvent( dcomp_barrier_release );
+    if (dcomp_barrier_hook)
+    {
+        UnhookWindowsHookEx( dcomp_barrier_hook );
+        dcomp_barrier_hook = NULL;
+    }
+    if (dcomp_barrier_thread)
+    {
+        WaitForSingleObject( dcomp_barrier_thread, 5000 );
+        CloseHandle( dcomp_barrier_thread );
+        dcomp_barrier_thread = NULL;
+    }
+    if (dcomp_barrier_enter) CloseHandle( dcomp_barrier_enter );
+    if (dcomp_barrier_release) CloseHandle( dcomp_barrier_release );
+    dcomp_barrier_enter = NULL;
+    dcomp_barrier_release = NULL;
+}
+
+struct packed_test_copydata
+{
+    ULONGLONG dwData;
+    DWORD cbData;
+    ULONGLONG lpData;
+};
+
+static NTSTATUS raw_dcomp_send( HWND source, HWND destination, DWORD receiver_tid,
+                                const COPYDATASTRUCT *copydata )
+{
+    struct packed_test_copydata packed;
+    NTSTATUS status;
+
+    packed.dwData = (ULONGLONG)copydata->dwData;
+    packed.cbData = copydata->cbData;
+    packed.lpData = copydata->lpData ? 1 : 0;
+    SERVER_START_REQ( send_message )
+    {
+        req->id = receiver_tid;
+        req->type = MSG_OTHER_PROCESS;
+        req->win = wine_server_user_handle( destination );
+        req->msg = WM_COPYDATA;
+        req->wparam = (lparam_t)(ULONG_PTR)source;
+        req->timeout = TIMEOUT_INFINITE;
+        wine_server_add_data( req, &packed, sizeof(packed) );
+        if (copydata->lpData) wine_server_add_data( req, copydata->lpData, copydata->cbData );
+        status = p_wine_server_call( req );
+    }
+    SERVER_END_REQ;
+    return status;
+}
+
+static void wait_child_process_with_messages( PROCESS_INFORMATION *info );
+static BOOL start_dcomp_presentation_process( const char *argv0,
+                                               struct dcomp_presentation_process *process );
+static void stop_dcomp_presentation_process( struct dcomp_presentation_process *process );
+static void test_dcomp_presentation_process_child( HANDLE mapping, HANDLE ready,
+                                                       const char *stop_name );
+
 static LRESULT WINAPI test_ipc_message_proc( HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam )
 {
     switch (msg)
     {
+    case WM_KEYDOWN:
+    case WM_SYSKEYDOWN:
+        if (hwnd == ipc_old_input) InterlockedIncrement( &ipc_old_key_down );
+        else if (hwnd == ipc_input) InterlockedIncrement( &ipc_new_key_down );
+        break;
+
+    case WM_KEYUP:
+    case WM_SYSKEYUP:
+        if (hwnd == ipc_old_input) InterlockedIncrement( &ipc_old_key_up );
+        else if (hwnd == ipc_input) InterlockedIncrement( &ipc_new_key_up );
+        break;
+
+    case WM_USER + 3:
+        flush_events();
+        return 1;
+
+    case WM_USER + 4:
+        {
+            NTSTATUS status;
+
+            ipc_old_input = ipc_input;
+            ipc_old_target = ipc_target;
+            ipc_input = CreateWindowExW( 0, L"TestIPCClass", NULL, WS_CHILD,
+                                         0, 0, 0, 0, HWND_MESSAGE, 0, 0, NULL );
+            ipc_target = CreateWindowExW( 0, L"TestIPCClass", NULL, WS_CHILD,
+                                          0, 0, 0, 0, HWND_MESSAGE, 0, 0, NULL );
+            if (ipc_input) NtUserSetParent( ipc_input, ipc_root );
+            if (ipc_target) NtUserSetParent( ipc_target, ipc_input );
+            ok( !!ipc_input && !!ipc_target, "failed to create replacement browser topology\n" );
+            status = set_dcomp_ime_relationship( &ipc_browser_token, ipc_target );
+            ok( !status, "replacement relationship returned %#lx\n", status );
+            ok( GetPropW( ipc_presentation, dcomp_keyboard_window_prop ) == ipc_input,
+                "replacement keyboard property was not published\n" );
+            ok( !GetPropW( ipc_old_input, direct_hardware_input_prop ),
+                "old input retained direct input property\n" );
+            return (LRESULT)ipc_input;
+        }
+
+    case WM_USER + 8:
+        ok( start_dcomp_revoke_barrier(), "failed to start DComp revoke barrier\n" );
+        return 1;
+
+    case WM_USER + 7:
+        ok( dcomp_barrier_revoke_status == STATUS_SUCCESS,
+            "post-dequeue DComp revoke returned %#lx\n", dcomp_barrier_revoke_status );
+        ok( private_copydata_calls == dcomp_barrier_before_calls + 1,
+            "revoked update did not reach ordinary WM_COPYDATA handler (%ld, expected %ld)\n",
+            private_copydata_calls, dcomp_barrier_before_calls + 1 );
+        dcomp_barrier_revoke_status = set_dcomp_ime_relationship( &ipc_browser_token, ipc_target );
+        ok( !dcomp_barrier_revoke_status, "post-barrier relationship restore returned %#lx\n",
+            dcomp_barrier_revoke_status );
+        stop_dcomp_revoke_barrier();
+        return 1;
+
+    case WM_USER + 9:
+        {
+            const unsigned int flags = DCOMP_TASK_DELEGATE_BASE | DCOMP_TASK_DELEGATE_TASK;
+            struct wine_dcomp_ime_token token = *ipc_shared_token;
+            NTSTATUS status;
+
+            ipc_presentation = (HWND)wparam;
+            status = update_dcomp_task_delegate( &token, ipc_presentation, ipc_target, flags );
+            ok( !status, "shared task relationship returned %#lx\n", status );
+            ok( GetPropW( ipc_target, dcomp_base_presentation_prop ) == ipc_presentation,
+                "shared base presentation was not published\n" );
+            ok( GetPropW( ipc_root, dcomp_task_delegated_prop ) == ipc_presentation,
+                "shared task delegate was not published\n" );
+            return 1;
+        }
+
+    case WM_USER + 10:
+        ok( !GetPropW( ipc_target, dcomp_base_presentation_prop ),
+            "revoked offer retained base presentation\n" );
+        ok( !GetPropW( ipc_root, dcomp_task_delegated_prop ),
+            "revoked offer retained task delegate\n" );
+        ok( !GetPropW( ipc_root, dcomp_task_delegated_target_prop ),
+            "revoked offer retained task target\n" );
+        return 1;
+
+    case WM_USER + 5:
+        if (wparam == 1)
+        {
+            ok( ipc_old_key_down == 2 && !ipc_old_key_up,
+                "old input counts after down are %ld/%ld\n", ipc_old_key_down, ipc_old_key_up );
+            ok( !ipc_new_key_down && !ipc_new_key_up,
+                "new input received early keys %ld/%ld\n", ipc_new_key_down, ipc_new_key_up );
+        }
+        else if (wparam == 2)
+        {
+            ok( ipc_old_key_down == 2 && ipc_old_key_up == 2,
+                "old input counts after release are %ld/%ld\n", ipc_old_key_down, ipc_old_key_up );
+            ok( !ipc_new_key_down && !ipc_new_key_up,
+                "new input received old releases %ld/%ld\n", ipc_new_key_down, ipc_new_key_up );
+        }
+        else
+        {
+            ok( ipc_new_key_down == 1 && ipc_new_key_up == 1,
+                "new input first key counts are %ld/%ld\n", ipc_new_key_down, ipc_new_key_up );
+        }
+        return 1;
+
     case WM_SETTEXT:
     case CB_FINDSTRING:
         ok( !wcscmp( (const WCHAR *)lparam, L"test" ),
@@ -1729,6 +2113,124 @@ static LRESULT WINAPI test_ipc_message_proc( HWND hwnd, UINT msg, WPARAM wparam,
 
     case WM_GETTEXTLENGTH:
         return 99;
+
+    case WM_COPYDATA:
+        if (((COPYDATASTRUCT *)lparam)->dwData == WINE_IME_UPDATE_COPYDATA ||
+            ((COPYDATASTRUCT *)lparam)->dwData == WINE_IME_SET_RECT_COPYDATA)
+            InterlockedIncrement( &private_copydata_calls );
+        return 7;
+
+    case WM_USER + 1:
+        {
+            RECT rect = {1, 2, 3, 4};
+            COPYDATASTRUCT copydata = { WINE_IME_SET_RECT_COPYDATA, sizeof(rect), &rect };
+            int res;
+
+            ipc_presentation = (HWND)wparam;
+            SetPropW( ipc_presentation, dcomp_detached_window_prop, ipc_target );
+            SetLastError( 0xdeadbeef );
+            ok( !SetPropW( ipc_target, dcomp_base_presentation_prop, ipc_presentation ) &&
+                GetLastError() == ERROR_ACCESS_DENIED,
+                "reserved base presentation set returned error %lu\n", GetLastError() );
+            SetLastError( 0xdeadbeef );
+            ok( !SetPropW( ipc_root, dcomp_task_delegated_prop, ipc_presentation ) &&
+                GetLastError() == ERROR_ACCESS_DENIED,
+                "reserved task delegate set returned error %lu\n", GetLastError() );
+            SetLastError( 0xdeadbeef );
+            ok( !SetPropW( ipc_root, dcomp_task_delegated_target_prop, ipc_target ) &&
+                GetLastError() == ERROR_ACCESS_DENIED,
+                "reserved task target set returned error %lu\n", GetLastError() );
+
+            res = SendMessageW( ipc_presentation, WM_COPYDATA, (WPARAM)ipc_root, (LPARAM)&copydata );
+            ok( res == 7, "property-only IME rect returned %d\n", res );
+            return 1;
+        }
+
+    case WM_USER + 2:
+        {
+            struct wine_dcomp_ime_token token = *ipc_shared_token;
+            RECT rect = {1, 2, 3, 4};
+            COPYDATASTRUCT copydata = { WINE_IME_SET_RECT_COPYDATA, sizeof(rect), &rect };
+            NTSTATUS status;
+            ATOM atom;
+            int res;
+
+            status = create_dcomp_ime_offer( ipc_presentation, &token );
+            ok( status == STATUS_ACCESS_DENIED, "foreign presentation offer returned %#lx\n", status );
+            token = *ipc_shared_token;
+            status = set_dcomp_ime_relationship( &token, ipc_presentation );
+            ok( status == STATUS_ACCESS_DENIED, "foreign target relationship returned %#lx\n", status );
+            status = set_dcomp_ime_relationship( &token, ipc_target );
+            ok( !status, "valid relationship returned %#lx\n", status );
+            ipc_browser_token = token;
+            SecureZeroMemory( ipc_shared_token, sizeof(*ipc_shared_token) );
+            ok( GetPropW( ipc_presentation, dcomp_input_window_prop ) == ipc_input,
+                "presentation input property was not published\n" );
+            ok( GetPropW( ipc_presentation, dcomp_keyboard_window_prop ) == ipc_input,
+                "presentation keyboard property was not published\n" );
+            ok( GetPropW( ipc_root, dcomp_input_window_prop ) == ipc_input,
+                "root input property was not published\n" );
+            ok( GetPropW( ipc_root, dcomp_keyboard_window_prop ) == ipc_input,
+                "root keyboard property was not published\n" );
+            ok( GetPropW( ipc_input, direct_hardware_input_prop ) == ULongToHandle( 0x57444952 ),
+                "direct input property was not published\n" );
+            ok( GetPropW( ipc_input, direct_hardware_input_owner_prop ) == ipc_presentation,
+                "direct input owner was not published\n" );
+            SetLastError( 0xdeadbeef );
+            ok( !RemovePropW( ipc_presentation, dcomp_keyboard_window_prop ) &&
+                GetLastError() == ERROR_ACCESS_DENIED,
+                "reserved property removal returned error %lu\n", GetLastError() );
+            ok( SetPropW( ipc_presentation, L"unreserved-test-property", ULongToHandle( 1 ) ),
+                "unreserved property set failed, error %lu\n", GetLastError() );
+            ok( RemovePropW( ipc_presentation, L"unreserved-test-property" ) == ULongToHandle( 1 ),
+                "unreserved property removal failed, error %lu\n", GetLastError() );
+
+            if (start_dcomp_victim_thread())
+            {
+                DWORD owner_tid = GetWindowThreadProcessId( ipc_presentation, NULL );
+                status = raw_dcomp_send( ipc_root, ipc_presentation, owner_tid, &copydata );
+                ok( !status, "owner TID SET_RECT send returned %#lx\n", status );
+                status = raw_dcomp_send( ipc_root, ipc_presentation, ipc_victim.tid, &copydata );
+                ok( status == STATUS_INVALID_PARAMETER,
+                    "mismatched victim TID SET_RECT returned %#lx\n", status );
+                stop_dcomp_victim_thread();
+            }
+            res = SendMessageW( ipc_presentation, WM_COPYDATA, (WPARAM)ipc_root, (LPARAM)&copydata );
+            ok( !res, "authorized IME rect returned %d\n", res );
+
+            status = set_dcomp_ime_relationship( &token, NULL );
+            ok( !status, "relationship deactivation returned %#lx\n", status );
+            ok( !GetPropW( ipc_presentation, dcomp_input_window_prop ),
+                "deactivated presentation retained input property\n" );
+            ok( !GetPropW( ipc_root, dcomp_keyboard_window_prop ),
+                "deactivated root retained keyboard property\n" );
+            SetLastError( 0xdeadbeef );
+            ok( !SetPropW( ipc_presentation, dcomp_input_window_prop, ipc_input ) &&
+                GetLastError() == ERROR_ACCESS_DENIED,
+                "reserved string property set returned error %lu\n", GetLastError() );
+            atom = GlobalAddAtomW( direct_hardware_input_prop );
+            ok( !!atom, "reserved property GlobalAddAtomW failed, error %lu\n", GetLastError() );
+            SetLastError( 0xdeadbeef );
+            ok( atom && !SetPropW( ipc_input, (LPCWSTR)MAKEINTATOM( atom ),
+                                   ULongToHandle( 0x57444952 ) ) &&
+                GetLastError() == ERROR_ACCESS_DENIED,
+                "reserved atom property set returned error %lu\n", GetLastError() );
+            if (atom) GlobalDeleteAtom( atom );
+            res = SendMessageW( ipc_presentation, WM_COPYDATA, (WPARAM)ipc_root, (LPARAM)&copydata );
+            ok( res == 7, "deactivated IME rect returned %d\n", res );
+
+            status = set_dcomp_ime_relationship( &token, ipc_target );
+            ok( !status, "relationship rebind returned %#lx\n", status );
+            ok( GetPropW( ipc_presentation, dcomp_input_window_prop ) == ipc_input,
+                "rebound presentation input property was not restored\n" );
+            ok( GetPropW( ipc_root, dcomp_keyboard_window_prop ) == ipc_input,
+                "rebound root keyboard property was not restored\n" );
+            ok( GetPropW( ipc_input, direct_hardware_input_prop ) == ULongToHandle( 0x57444952 ),
+                "rebound direct input property was not restored\n" );
+            res = SendMessageW( ipc_presentation, WM_COPYDATA, (WPARAM)ipc_root, (LPARAM)&copydata );
+            ok( !res, "rebound IME rect returned %d\n", res );
+            return 1;
+        }
 
     case WM_MDICREATE:
         {
@@ -1751,43 +2253,796 @@ static void test_inter_process_messages( const char *argv0 )
     char path[MAX_PATH];
     PROCESS_INFORMATION pi;
     STARTUPINFOA startup;
-    MSG msg;
+    HANDLE mapping = NULL;
     HWND hwnd;
     BOOL ret;
 
+    private_copydata_calls = 0;
+    ipc_old_key_down = ipc_old_key_up = ipc_new_key_down = ipc_new_key_up = 0;
+    ipc_old_input = ipc_old_target = NULL;
+    SecureZeroMemory( &ipc_browser_token, sizeof(ipc_browser_token) );
+    ipc_presentation = NULL;
     cls.lpfnWndProc = test_ipc_message_proc;
     cls.lpszClassName = L"TestIPCClass";
     RegisterClassW( &cls );
 
-    hwnd = CreateWindowExW( 0, L"TestIPCClass", NULL, WS_POPUP | CBS_HASSTRINGS, 0,0,0,0,0,0,0, NULL );
+    ipc_root = CreateWindowExW( 0, L"TestIPCClass", NULL, 0, 0, 0, 0, 0, HWND_MESSAGE, 0, 0, NULL );
+    ipc_input = CreateWindowExW( 0, L"TestIPCClass", NULL, WS_CHILD, 0, 0, 0, 0, HWND_MESSAGE, 0, 0, NULL );
+    ipc_target = CreateWindowExW( 0, L"TestIPCClass", NULL, WS_CHILD, 0, 0, 0, 0, HWND_MESSAGE, 0, 0, NULL );
+    if (ipc_root && ipc_input) NtUserSetParent( ipc_input, ipc_root );
+    if (ipc_input && ipc_target) NtUserSetParent( ipc_target, ipc_input );
+    ok( !!ipc_root && !!ipc_input && !!ipc_target &&
+        NtUserGetAncestor( ipc_target, GA_ROOT ) == ipc_root &&
+        NtUserGetAncestor( ipc_target, GA_PARENT ) == ipc_input,
+        "failed to create DComp topology windows root %p input %p target %p, error %lu\n",
+        ipc_root, ipc_input, ipc_target, GetLastError() );
+    if (!ipc_root || !ipc_input || !ipc_target ||
+        NtUserGetAncestor( ipc_target, GA_ROOT ) != ipc_root ||
+        NtUserGetAncestor( ipc_target, GA_PARENT ) != ipc_input)
+    {
+        if (ipc_target) DestroyWindow( ipc_target );
+        if (ipc_input) DestroyWindow( ipc_input );
+        if (ipc_root) DestroyWindow( ipc_root );
+        UnregisterClassW( L"TestIPCClass", NULL );
+        return;
+    }
+    hwnd = ipc_input;
+    ipc_old_input = ipc_input;
+    mapping = CreateFileMappingW( INVALID_HANDLE_VALUE, NULL, PAGE_READWRITE, 0,
+                                  sizeof(*ipc_shared_token), NULL );
+    ok( !!mapping, "CreateFileMappingW failed, error %lu\n", GetLastError() );
+    if (!mapping) goto cleanup;
+    ret = SetHandleInformation( mapping, HANDLE_FLAG_INHERIT, HANDLE_FLAG_INHERIT );
+    ok( ret, "SetHandleInformation failed, error %lu\n", GetLastError() );
+    if (!ret) goto cleanup;
+    ipc_shared_token = MapViewOfFile( mapping, FILE_MAP_ALL_ACCESS, 0, 0, sizeof(*ipc_shared_token) );
+    ok( !!ipc_shared_token, "MapViewOfFile failed, error %lu\n", GetLastError() );
+    if (!ipc_shared_token) goto cleanup;
 
     memset( &startup, 0, sizeof(startup) );
     startup.cb = sizeof(startup);
     startup.dwFlags = STARTF_USESHOWWINDOW;
     startup.wShowWindow = SW_SHOWNORMAL;
-    sprintf( path, "%s win32u ipcmsg %Ix", argv0, (INT_PTR)hwnd );
+    sprintf( path, "%s win32u ipcmsg %Ix %Ix", argv0, (INT_PTR)hwnd, (INT_PTR)mapping );
     ret = CreateProcessA( NULL, path, NULL, NULL, TRUE, 0, NULL, NULL, &startup, &pi );
     ok( ret, "CreateProcess '%s' failed err %lu.\n", path, GetLastError() );
+    if (!ret) goto cleanup;
 
-    do
+    wait_child_process_with_messages( &pi );
+    ok( private_copydata_calls == (p_wine_server_call ? 4 : 2),
+        "application received %ld private-marker messages\n", private_copydata_calls );
+    SecureZeroMemory( ipc_shared_token, sizeof(*ipc_shared_token) );
+
+    if (p_wine_server_call)
     {
-        GetMessageW( &msg, NULL, 0, 0 );
-        TranslateMessage( &msg );
-        DispatchMessageW( &msg );
-    } while (msg.message != WM_USER);
+        struct dcomp_presentation_process first = {0}, replacement = {0}, newest = {0};
+        HWND first_presentation = NULL, replacement_presentation = NULL, newest_presentation = NULL;
+        const unsigned int flags = DCOMP_TASK_DELEGATE_BASE | DCOMP_TASK_DELEGATE_TASK;
+        NTSTATUS status;
 
-    wait_child_process( &pi );
+        if (start_dcomp_presentation_process( argv0, &first ))
+        {
+            first_presentation = first.state->presentation;
+            status = update_dcomp_task_delegate( &first.state->token, first_presentation,
+                                                 ipc_target, flags );
+            ok( !status, "first presentation relationship returned %#lx\n", status );
+        }
+        if (first_presentation &&
+            start_dcomp_presentation_process( argv0, &replacement ))
+        {
+            replacement_presentation = replacement.state->presentation;
+            status = update_dcomp_task_delegate( &replacement.state->token, replacement_presentation,
+                                                 ipc_target, flags );
+            ok( !status, "replacement presentation relationship returned %#lx\n", status );
+            ok( GetPropW( ipc_target, dcomp_base_presentation_prop ) == replacement_presentation,
+                "replacement base presentation was not published\n" );
+            ok( GetPropW( ipc_root, dcomp_task_delegated_prop ) == replacement_presentation,
+                "replacement task delegate was not published\n" );
 
-    DestroyWindow( hwnd );
+            status = update_dcomp_task_delegate( &first.state->token, first_presentation,
+                                                 ipc_target, flags );
+            ok( !status, "refreshed first presentation relationship returned %#lx\n", status );
+            ok( GetPropW( ipc_target, dcomp_base_presentation_prop ) == first_presentation,
+                "refreshed first presentation did not become base winner\n" );
+            status = update_dcomp_task_delegate( &replacement.state->token, replacement_presentation,
+                                                 ipc_target, flags );
+            ok( !status, "refreshed replacement relationship returned %#lx\n", status );
+            ok( GetPropW( ipc_target, dcomp_base_presentation_prop ) == replacement_presentation,
+                "refreshed replacement did not become base winner\n" );
+
+            stop_dcomp_presentation_process( &first );
+            ok( GetPropW( ipc_target, dcomp_base_presentation_prop ) == replacement_presentation,
+                "old presentation teardown removed replacement base presentation\n" );
+            ok( GetPropW( ipc_root, dcomp_task_delegated_prop ) == replacement_presentation,
+                "old presentation teardown removed replacement task delegate\n" );
+            ok( GetPropW( ipc_root, dcomp_task_delegated_target_prop ) == ipc_target,
+                "old presentation teardown removed replacement task target\n" );
+            ok( GetPropW( ipc_root, dcomp_input_window_prop ) == ipc_input,
+                "old presentation teardown removed replacement input property\n" );
+            ok( GetPropW( ipc_input, direct_hardware_input_owner_prop ) == replacement_presentation,
+                "old presentation teardown removed replacement input owner\n" );
+
+            if (start_dcomp_presentation_process( argv0, &newest ))
+            {
+                newest_presentation = newest.state->presentation;
+                status = update_dcomp_task_delegate( &newest.state->token, newest_presentation,
+                                                     ipc_target, flags );
+                ok( !status, "newest presentation relationship returned %#lx\n", status );
+                ok( GetPropW( ipc_target, dcomp_base_presentation_prop ) == newest_presentation,
+                    "newest base presentation was not published\n" );
+                stop_dcomp_presentation_process( &newest );
+                ok( GetPropW( ipc_target, dcomp_base_presentation_prop ) == replacement_presentation,
+                    "newest teardown did not restore replacement base presentation\n" );
+                ok( GetPropW( ipc_root, dcomp_task_delegated_prop ) == replacement_presentation,
+                    "newest teardown did not restore replacement task delegate\n" );
+                ok( GetPropW( ipc_input, direct_hardware_input_owner_prop ) == replacement_presentation,
+                    "newest teardown did not restore replacement input owner\n" );
+            }
+
+            stop_dcomp_presentation_process( &replacement );
+            ok( !GetPropW( ipc_target, dcomp_base_presentation_prop ),
+                "replacement teardown retained base presentation\n" );
+            ok( !GetPropW( ipc_root, dcomp_task_delegated_prop ),
+                "replacement teardown retained task delegate\n" );
+            ok( !GetPropW( ipc_root, dcomp_task_delegated_target_prop ),
+                "replacement teardown retained task target\n" );
+            ok( !GetPropW( ipc_root, dcomp_input_window_prop ),
+                "replacement teardown retained input property\n" );
+            ok( !GetPropW( ipc_input, direct_hardware_input_owner_prop ),
+                "replacement teardown retained input owner\n" );
+        }
+        else
+        {
+            stop_dcomp_presentation_process( &first );
+            stop_dcomp_presentation_process( &replacement );
+            stop_dcomp_presentation_process( &newest );
+        }
+    }
+
+cleanup:
+    if (ipc_shared_token) UnmapViewOfFile( ipc_shared_token );
+    if (mapping) CloseHandle( mapping );
+    if (ipc_target) DestroyWindow( ipc_target );
+    if (ipc_input) DestroyWindow( ipc_input );
+    if (ipc_old_target) DestroyWindow( ipc_old_target );
+    if (ipc_old_input) DestroyWindow( ipc_old_input );
+    DestroyWindow( ipc_root );
     UnregisterClassW( L"TestIPCClass", NULL );
 }
 
-static void test_inter_process_child( HWND hwnd )
+static void wait_child_process_with_messages( PROCESS_INFORMATION *info )
+{
+    DWORD start = GetTickCount();
+    HANDLE process = info->hProcess;
+    MSG msg;
+
+    for (;;)
+    {
+        DWORD elapsed = GetTickCount() - start;
+        DWORD timeout = elapsed >= 30000 ? 0 : 30000 - elapsed;
+        DWORD ret = MsgWaitForMultipleObjects( 1, &process, FALSE, timeout, QS_ALLINPUT );
+
+        if (ret == WAIT_OBJECT_0) break;
+        if (ret == WAIT_OBJECT_0 + 1)
+        {
+            while (PeekMessageW( &msg, NULL, 0, 0, PM_REMOVE ))
+            {
+                TranslateMessage( &msg );
+                DispatchMessageW( &msg );
+            }
+            continue;
+        }
+        if (ret == WAIT_TIMEOUT)
+            ok( 0, "timed out waiting for browser helper\n" );
+        else
+            ok( 0, "browser helper wait returned %#lx, error %lu\n", ret, GetLastError() );
+        break;
+    }
+    wait_child_process( info );
+}
+
+static BOOL start_dcomp_presentation_process( const char *argv0,
+                                               struct dcomp_presentation_process *process )
+{
+    STARTUPINFOA startup = { .cb = sizeof(startup) };
+    char path[MAX_PATH];
+    BOOL ret;
+
+    memset( process, 0, sizeof(*process) );
+    sprintf( process->stop_name, "WineDCompPresentationStop-%lu-%ld", GetCurrentProcessId(),
+             InterlockedIncrement( &dcomp_presentation_process_id ) );
+    process->mapping = CreateFileMappingW( INVALID_HANDLE_VALUE, NULL, PAGE_READWRITE, 0,
+                                           sizeof(*process->state), NULL );
+    process->ready = CreateEventW( NULL, TRUE, FALSE, NULL );
+    process->stop = CreateEventA( NULL, TRUE, FALSE, process->stop_name );
+    ok( !!process->mapping && !!process->ready && !!process->stop,
+        "failed to create presentation process synchronization, error %lu\n", GetLastError() );
+    if (!process->mapping || !process->ready || !process->stop) goto failed;
+    ret = SetHandleInformation( process->mapping, HANDLE_FLAG_INHERIT, HANDLE_FLAG_INHERIT ) &&
+          SetHandleInformation( process->ready, HANDLE_FLAG_INHERIT, HANDLE_FLAG_INHERIT );
+    ok( ret, "failed to make presentation synchronization inheritable, error %lu\n", GetLastError() );
+    if (!ret) goto failed;
+    process->state = MapViewOfFile( process->mapping, FILE_MAP_ALL_ACCESS, 0, 0,
+                                    sizeof(*process->state) );
+    ok( !!process->state, "presentation state MapViewOfFile failed, error %lu\n", GetLastError() );
+    if (!process->state) goto failed;
+    memset( process->state, 0, sizeof(*process->state) );
+
+    sprintf( path, "%s win32u dcomp_presentation %Ix %Ix %s", argv0,
+             (INT_PTR)process->mapping, (INT_PTR)process->ready, process->stop_name );
+    ret = CreateProcessA( NULL, path, NULL, NULL, TRUE, 0, NULL, NULL, &startup, &process->info );
+    ok( ret, "CreateProcess '%s' failed, error %lu\n", path, GetLastError() );
+    if (!ret) goto failed;
+    ret = WaitForSingleObject( process->ready, 30000 ) == WAIT_OBJECT_0;
+    ok( ret, "timed out waiting for presentation helper\n" );
+    ok( ret && !process->state->status && process->state->presentation &&
+        (process->state->token.low || process->state->token.high),
+        "presentation helper returned %#lx, window %p, empty token %d\n",
+        process->state->status, process->state->presentation,
+        !process->state->token.low && !process->state->token.high );
+    if (ret && !process->state->status && process->state->presentation &&
+        (process->state->token.low || process->state->token.high))
+        return TRUE;
+
+failed:
+    stop_dcomp_presentation_process( process );
+    return FALSE;
+}
+
+static void stop_dcomp_presentation_process( struct dcomp_presentation_process *process )
+{
+    if (process->info.hProcess)
+    {
+        DWORD ret;
+
+        if (process->stop) SetEvent( process->stop );
+        ret = WaitForSingleObject( process->info.hProcess, 30000 );
+        ok( ret == WAIT_OBJECT_0, "presentation process wait returned %#lx\n", ret );
+        CloseHandle( process->info.hThread );
+        CloseHandle( process->info.hProcess );
+    }
+    if (process->state) UnmapViewOfFile( process->state );
+    if (process->stop) CloseHandle( process->stop );
+    if (process->ready) CloseHandle( process->ready );
+    if (process->mapping) CloseHandle( process->mapping );
+    memset( process, 0, sizeof(*process) );
+}
+
+static void run_ime_browser_helper( const char *argv0, HWND presentation, HANDLE mapping,
+                                    BOOL reparent, BOOL expect_success )
+{
+    PROCESS_INFORMATION info;
+    STARTUPINFOA startup = { .cb = sizeof(startup) };
+    char path[MAX_PATH];
+    BOOL ret;
+
+    sprintf( path, "%s win32u ime_browser %Ix %Ix %u %u", argv0, (INT_PTR)presentation,
+             (INT_PTR)mapping, reparent, expect_success );
+    ret = CreateProcessA( NULL, path, NULL, NULL, TRUE, 0, NULL, NULL, &startup, &info );
+    ok( ret, "CreateProcess '%s' failed, error %lu\n", path, GetLastError() );
+    if (!ret) return;
+    wait_child_process_with_messages( &info );
+}
+
+static void test_dcomp_presentation_process_child( HANDLE mapping, HANDLE ready,
+                                                       const char *stop_name )
+{
+    struct dcomp_presentation_process_state *state;
+    WNDCLASSW cls = { .lpfnWndProc = DefWindowProcW,
+                      .lpszClassName = L"TestDCompPresentationProcessClass" };
+    HANDLE stop;
+
+    stop = OpenEventA( SYNCHRONIZE, FALSE, stop_name );
+    state = MapViewOfFile( mapping, FILE_MAP_ALL_ACCESS, 0, 0, sizeof(*state) );
+    if (!stop || !state)
+    {
+        if (state) state->status = STATUS_UNSUCCESSFUL;
+        SetEvent( ready );
+        return;
+    }
+    cls.lpfnWndProc = dcomp_presentation_proc;
+    RegisterClassW( &cls );
+    dcomp_presentation_state = state;
+    state->presentation = CreateWindowExW( 0, cls.lpszClassName, NULL, 0, 0, 0, 0, 0,
+                                           HWND_MESSAGE, 0, 0, NULL );
+    if (!state->presentation)
+        state->status = STATUS_UNSUCCESSFUL;
+    else if (!p_wine_server_call)
+        state->status = STATUS_NOT_IMPLEMENTED;
+    else
+        state->status = create_dcomp_ime_offer( state->presentation, &state->token );
+    SetEvent( ready );
+    WaitForSingleObject( stop, INFINITE );
+    dcomp_presentation_state = NULL;
+    ExitProcess( 0 );
+}
+
+static void test_ime_browser_child( HWND presentation, HANDLE mapping, BOOL reparent,
+                                    BOOL expect_success )
+{
+    struct wine_dcomp_ime_token *token;
+    RECT rect = {1, 2, 3, 4};
+    COPYDATASTRUCT copydata = { WINE_IME_SET_RECT_COPYDATA, sizeof(rect), &rect };
+    WNDCLASSW cls = {0};
+    HWND root, input, target, other_root = NULL;
+    NTSTATUS status;
+    int res;
+
+    token = MapViewOfFile( mapping, FILE_MAP_READ, 0, 0, sizeof(*token) );
+    ok( !!token, "browser MapViewOfFile failed, error %lu\n", GetLastError() );
+    if (!token) return;
+
+    cls.lpfnWndProc = test_ipc_message_proc;
+    cls.lpszClassName = L"TestIPCBrowserClass";
+    RegisterClassW( &cls );
+    root = CreateWindowExW( 0, cls.lpszClassName, NULL, 0, 0, 0, 0, 0, HWND_MESSAGE, 0, 0, NULL );
+    input = CreateWindowExW( 0, cls.lpszClassName, NULL, WS_CHILD, 0, 0, 0, 0, HWND_MESSAGE, 0, 0, NULL );
+    target = CreateWindowExW( 0, cls.lpszClassName, NULL, WS_CHILD, 0, 0, 0, 0, HWND_MESSAGE, 0, 0, NULL );
+    if (root && input) NtUserSetParent( input, root );
+    if (input && target) NtUserSetParent( target, input );
+    ok( !!root && !!input && !!target, "failed to create browser topology, error %lu\n", GetLastError() );
+    if (!root || !input || !target) goto done;
+
+    status = set_dcomp_ime_relationship( token, target );
+    if (!expect_success)
+    {
+        ok( status == STATUS_NOT_FOUND, "revoked browser relationship returned %#lx\n", status );
+        goto done;
+    }
+    ok( !status, "browser relationship returned %#lx\n", status );
+    status = update_dcomp_task_delegate( token, presentation, target,
+                                         DCOMP_TASK_DELEGATE_BASE | DCOMP_TASK_DELEGATE_TASK );
+    ok( !status, "browser task relationship returned %#lx\n", status );
+    ok( GetPropW( target, dcomp_base_presentation_prop ) == presentation,
+        "browser base presentation was not published\n" );
+    ok( GetPropW( root, dcomp_task_delegated_prop ) == presentation,
+        "browser task delegate was not published\n" );
+    res = SendMessageW( presentation, WM_COPYDATA, (WPARAM)root, (LPARAM)&copydata );
+    ok( !res, "browser IME rect returned %d\n", res );
+
+    if (reparent)
+    {
+        other_root = CreateWindowExW( 0, cls.lpszClassName, NULL, 0, 0, 0, 0, 0,
+                                      HWND_MESSAGE, 0, 0, NULL );
+        ok( !!other_root, "failed to create replacement browser root, error %lu\n", GetLastError() );
+        if (other_root)
+        {
+            NtUserSetParent( input, other_root );
+            ok( !GetPropW( target, dcomp_base_presentation_prop ),
+                "reparented target retained base presentation\n" );
+            ok( !GetPropW( root, dcomp_task_delegated_prop ),
+                "reparented root retained task delegate\n" );
+            ok( !GetPropW( root, dcomp_task_delegated_target_prop ),
+                "reparented root retained task target\n" );
+            res = SendMessageW( presentation, WM_COPYDATA, (WPARAM)root, (LPARAM)&copydata );
+            ok( res == 7, "reparented IME rect returned %d\n", res );
+            NtUserSetParent( input, root );
+            status = set_dcomp_ime_relationship( token, target );
+            ok( !status, "reparented relationship returned %#lx\n", status );
+            status = update_dcomp_task_delegate( token, presentation, target,
+                                                 DCOMP_TASK_DELEGATE_BASE | DCOMP_TASK_DELEGATE_TASK );
+            ok( !status, "reparented task relationship returned %#lx\n", status );
+            res = SendMessageW( presentation, WM_COPYDATA, (WPARAM)root, (LPARAM)&copydata );
+            ok( !res, "rebound reparented IME rect returned %d\n", res );
+        }
+    }
+
+done:
+    if (target) DestroyWindow( target );
+    if (input) DestroyWindow( input );
+    if (other_root) DestroyWindow( other_root );
+    if (root) DestroyWindow( root );
+    UnregisterClassW( cls.lpszClassName, NULL );
+    UnmapViewOfFile( token );
+}
+
+enum dcomp_cross_process_message
+{
+    WM_DCOMP_CROSS_BROWSER_PARENT_TARGET = WM_APP + 0x300,
+    WM_DCOMP_CROSS_BROWSER_PARENT_INPUT,
+    WM_DCOMP_CROSS_GPU_PARENT_TARGET,
+    WM_DCOMP_CROSS_GPU_PARENT_BAD_TARGET,
+    WM_DCOMP_CROSS_GPU_UPDATE_TARGET,
+    WM_DCOMP_CROSS_GPU_UPDATE_BAD_TARGET,
+    WM_DCOMP_CROSS_GPU_CLEAR,
+};
+
+struct dcomp_cross_process_state
+{
+    HWND input;
+    HWND presentation;
+    HWND target;
+    HWND bad_target;
+    struct wine_dcomp_ime_token token;
+    NTSTATUS browser_status;
+    NTSTATUS gpu_status;
+};
+
+struct dcomp_cross_process_helper
+{
+    PROCESS_INFORMATION info;
+    HANDLE ready;
+    HWND window;
+};
+
+static struct dcomp_cross_process_state *dcomp_cross_process_state;
+
+static LRESULT WINAPI dcomp_cross_browser_proc( HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam )
+{
+    switch (msg)
+    {
+    case WM_DCOMP_CROSS_BROWSER_PARENT_TARGET:
+        NtUserSetParent( dcomp_cross_process_state->target, dcomp_cross_process_state->input );
+        return NtUserGetAncestor( dcomp_cross_process_state->target, GA_PARENT ) ==
+               dcomp_cross_process_state->input;
+
+    case WM_DCOMP_CROSS_BROWSER_PARENT_INPUT:
+        NtUserSetParent( dcomp_cross_process_state->input, (HWND)wparam );
+        return NtUserGetAncestor( dcomp_cross_process_state->input, GA_PARENT ) == (HWND)wparam;
+
+    case WM_CLOSE:
+        DestroyWindow( hwnd );
+        PostQuitMessage( 0 );
+        return 0;
+    }
+    return DefWindowProcW( hwnd, msg, wparam, lparam );
+}
+
+static LRESULT WINAPI dcomp_cross_gpu_proc( HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam )
+{
+    const unsigned int flags = DCOMP_TASK_DELEGATE_BASE | DCOMP_TASK_DELEGATE_TASK;
+
+    switch (msg)
+    {
+    case WM_DCOMP_CROSS_GPU_PARENT_TARGET:
+        NtUserSetParent( dcomp_cross_process_state->target, dcomp_cross_process_state->input );
+        return NtUserGetAncestor( dcomp_cross_process_state->target, GA_PARENT ) ==
+               dcomp_cross_process_state->input;
+
+    case WM_DCOMP_CROSS_GPU_PARENT_BAD_TARGET:
+        NtUserSetParent( dcomp_cross_process_state->bad_target, dcomp_cross_process_state->input );
+        return NtUserGetAncestor( dcomp_cross_process_state->bad_target, GA_PARENT ) ==
+               dcomp_cross_process_state->input;
+
+    case WM_DCOMP_CROSS_GPU_UPDATE_TARGET:
+        dcomp_cross_process_state->gpu_status = update_dcomp_task_delegate(
+                &dcomp_cross_process_state->token, dcomp_cross_process_state->presentation,
+                dcomp_cross_process_state->target, flags );
+        return 1;
+
+    case WM_DCOMP_CROSS_GPU_UPDATE_BAD_TARGET:
+        dcomp_cross_process_state->gpu_status = update_dcomp_task_delegate(
+                &dcomp_cross_process_state->token, dcomp_cross_process_state->presentation,
+                dcomp_cross_process_state->bad_target, flags );
+        return 1;
+
+    case WM_DCOMP_CROSS_GPU_CLEAR:
+        dcomp_cross_process_state->gpu_status = update_dcomp_task_delegate(
+                &dcomp_cross_process_state->token, dcomp_cross_process_state->presentation,
+                NULL, 0 );
+        return 1;
+
+    case WM_CLOSE:
+        DestroyWindow( hwnd );
+        PostQuitMessage( 0 );
+        return 0;
+    }
+    return DefWindowProcW( hwnd, msg, wparam, lparam );
+}
+
+static void test_dcomp_cross_process_child( const char *role, HANDLE mapping, HANDLE ready )
+{
+    struct dcomp_cross_process_state *state;
+    WNDCLASSW cls = {0};
+    MSG msg;
+
+    state = MapViewOfFile( mapping, FILE_MAP_ALL_ACCESS, 0, 0, sizeof(*state) );
+    if (!state)
+    {
+        SetEvent( ready );
+        return;
+    }
+    dcomp_cross_process_state = state;
+
+    if (!strcmp( role, "browser" ))
+    {
+        cls.lpfnWndProc = dcomp_cross_browser_proc;
+        cls.lpszClassName = L"TestDCompCrossBrowserClass";
+        RegisterClassW( &cls );
+        state->input = CreateWindowExW( 0, cls.lpszClassName, NULL, WS_CHILD,
+                                        0, 0, 0, 0, HWND_MESSAGE, 0, 0, NULL );
+        state->browser_status = state->input ? STATUS_SUCCESS : STATUS_UNSUCCESSFUL;
+    }
+    else
+    {
+        cls.lpfnWndProc = dcomp_cross_gpu_proc;
+        cls.lpszClassName = L"TestDCompCrossGpuClass";
+        RegisterClassW( &cls );
+        state->presentation = CreateWindowExW( 0, cls.lpszClassName, NULL, 0,
+                                               0, 0, 0, 0, HWND_MESSAGE, 0, 0, NULL );
+        state->target = CreateWindowExW( 0, cls.lpszClassName, NULL, WS_CHILD,
+                                        0, 0, 0, 0, HWND_MESSAGE, 0, 0, NULL );
+        state->bad_target = CreateWindowExW( 0, cls.lpszClassName, NULL, WS_CHILD,
+                                            0, 0, 0, 0, HWND_MESSAGE, 0, 0, NULL );
+        if (!state->presentation || !state->target || !state->bad_target)
+            state->gpu_status = STATUS_UNSUCCESSFUL;
+        else if (!p_wine_server_call)
+            state->gpu_status = STATUS_NOT_IMPLEMENTED;
+        else
+            state->gpu_status = create_dcomp_ime_offer( state->presentation, &state->token );
+    }
+    SetEvent( ready );
+
+    while (GetMessageW( &msg, NULL, 0, 0 ))
+    {
+        TranslateMessage( &msg );
+        DispatchMessageW( &msg );
+    }
+
+    if (!strcmp( role, "browser" ))
+    {
+        if (IsWindow( state->input )) DestroyWindow( state->input );
+    }
+    else
+    {
+        if (IsWindow( state->bad_target )) DestroyWindow( state->bad_target );
+        if (IsWindow( state->target )) DestroyWindow( state->target );
+        if (IsWindow( state->presentation )) DestroyWindow( state->presentation );
+    }
+    UnregisterClassW( cls.lpszClassName, NULL );
+    dcomp_cross_process_state = NULL;
+    UnmapViewOfFile( state );
+}
+
+static BOOL start_dcomp_cross_process_helper( const char *argv0, const char *role, HANDLE mapping,
+                                               struct dcomp_cross_process_helper *helper )
+{
+    STARTUPINFOA startup = { .cb = sizeof(startup) };
+    char path[MAX_PATH];
+    BOOL ret;
+
+    memset( helper, 0, sizeof(*helper) );
+    helper->ready = CreateEventW( NULL, TRUE, FALSE, NULL );
+    ok( !!helper->ready, "%s helper ready event creation failed, error %lu\n", role, GetLastError() );
+    if (!helper->ready) return FALSE;
+    ret = SetHandleInformation( helper->ready, HANDLE_FLAG_INHERIT, HANDLE_FLAG_INHERIT );
+    ok( ret, "%s helper ready inheritance failed, error %lu\n", role, GetLastError() );
+    if (!ret) goto failed;
+
+    sprintf( path, "%s win32u dcomp_cross %s %Ix %Ix", argv0, role,
+             (INT_PTR)mapping, (INT_PTR)helper->ready );
+    ret = CreateProcessA( NULL, path, NULL, NULL, TRUE, 0, NULL, NULL, &startup, &helper->info );
+    ok( ret, "CreateProcess '%s' failed, error %lu\n", path, GetLastError() );
+    if (!ret) goto failed;
+    ret = WaitForSingleObject( helper->ready, 30000 ) == WAIT_OBJECT_0;
+    ok( ret, "timed out waiting for %s helper\n", role );
+    if (ret) return TRUE;
+
+failed:
+    if (helper->info.hProcess)
+    {
+        TerminateProcess( helper->info.hProcess, 1 );
+        wait_child_process_with_messages( &helper->info );
+    }
+    if (helper->ready) CloseHandle( helper->ready );
+    memset( helper, 0, sizeof(*helper) );
+    return FALSE;
+}
+
+static void stop_dcomp_cross_process_helper( struct dcomp_cross_process_helper *helper )
+{
+    if (helper->info.hProcess)
+    {
+        if (helper->window) PostMessageW( helper->window, WM_CLOSE, 0, 0 );
+        wait_child_process_with_messages( &helper->info );
+    }
+    if (helper->ready) CloseHandle( helper->ready );
+    memset( helper, 0, sizeof(*helper) );
+}
+
+static void check_dcomp_cross_input_mapping( HWND presentation, HWND root, HWND input,
+                                             BOOL published )
+{
+    HWND expected_input = published ? input : NULL;
+    HWND expected_owner = published ? presentation : NULL;
+    HANDLE expected_direct = published ? ULongToHandle( 0x57444952 ) : NULL;
+
+    ok( GetPropW( presentation, dcomp_input_window_prop ) == expected_input,
+        "presentation input mapping is %p, expected %p\n",
+        GetPropW( presentation, dcomp_input_window_prop ), expected_input );
+    ok( GetPropW( presentation, dcomp_keyboard_window_prop ) == expected_input,
+        "presentation keyboard mapping is %p, expected %p\n",
+        GetPropW( presentation, dcomp_keyboard_window_prop ), expected_input );
+    ok( GetPropW( root, dcomp_input_window_prop ) == expected_input,
+        "root input mapping is %p, expected %p\n",
+        GetPropW( root, dcomp_input_window_prop ), expected_input );
+    ok( GetPropW( root, dcomp_keyboard_window_prop ) == expected_input,
+        "root keyboard mapping is %p, expected %p\n",
+        GetPropW( root, dcomp_keyboard_window_prop ), expected_input );
+    ok( GetPropW( input, direct_hardware_input_prop ) == expected_direct,
+        "direct input marker is %p, expected %p\n",
+        GetPropW( input, direct_hardware_input_prop ), expected_direct );
+    ok( GetPropW( input, direct_hardware_input_owner_prop ) == expected_owner,
+        "direct input owner is %p, expected %p\n",
+        GetPropW( input, direct_hardware_input_owner_prop ), expected_owner );
+}
+
+static void test_dcomp_cross_process_parenting( const char *argv0 )
+{
+    struct dcomp_cross_process_helper browser = {0}, gpu = {0};
+    struct dcomp_cross_process_state *state = NULL;
+    WNDCLASSW cls = { .lpfnWndProc = DefWindowProcW,
+                      .lpszClassName = L"TestDCompCrossRootClass" };
+    HANDLE mapping = NULL;
+    HWND root = NULL, unrelated_root = NULL;
+    LRESULT res;
+    BOOL ret;
+
+    mapping = CreateFileMappingW( INVALID_HANDLE_VALUE, NULL, PAGE_READWRITE, 0,
+                                  sizeof(*state), NULL );
+    ok( !!mapping, "cross-process mapping creation failed, error %lu\n", GetLastError() );
+    if (!mapping) return;
+    ret = SetHandleInformation( mapping, HANDLE_FLAG_INHERIT, HANDLE_FLAG_INHERIT );
+    ok( ret, "cross-process mapping inheritance failed, error %lu\n", GetLastError() );
+    if (!ret) goto done;
+    state = MapViewOfFile( mapping, FILE_MAP_ALL_ACCESS, 0, 0, sizeof(*state) );
+    ok( !!state, "cross-process state mapping failed, error %lu\n", GetLastError() );
+    if (!state) goto done;
+    memset( state, 0, sizeof(*state) );
+
+    RegisterClassW( &cls );
+    root = CreateWindowExW( 0, cls.lpszClassName, NULL, 0, 0, 0, 0, 0,
+                            HWND_MESSAGE, 0, 0, NULL );
+    unrelated_root = CreateWindowExW( 0, cls.lpszClassName, NULL, 0, 0, 0, 0, 0,
+                                      HWND_MESSAGE, 0, 0, NULL );
+    ok( !!root && !!unrelated_root, "cross-process roots creation failed, error %lu\n",
+        GetLastError() );
+    if (!root || !unrelated_root) goto done;
+
+    if (!start_dcomp_cross_process_helper( argv0, "browser", mapping, &browser )) goto done;
+    browser.window = state->input;
+    ok( !state->browser_status && state->input, "browser helper returned %#lx, input %p\n",
+        state->browser_status, state->input );
+    if (state->browser_status || !state->input) goto done;
+
+    if (!start_dcomp_cross_process_helper( argv0, "gpu", mapping, &gpu )) goto done;
+    gpu.window = state->target;
+    ok( !state->gpu_status && state->presentation && state->target && state->bad_target &&
+        (state->token.low || state->token.high),
+        "GPU helper returned %#lx, presentation %p, targets %p/%p, empty token %d\n",
+        state->gpu_status, state->presentation, state->target, state->bad_target,
+        !state->token.low && !state->token.high );
+    if (state->gpu_status || !state->presentation || !state->target || !state->bad_target ||
+        (!state->token.low && !state->token.high)) goto done;
+
+    NtUserSetParent( state->input, root );
+    ok( NtUserGetAncestor( state->input, GA_PARENT ) == root,
+        "root owner failed to parent browser input\n" );
+
+    res = SendMessageW( state->target, WM_DCOMP_CROSS_GPU_PARENT_TARGET, 0, 0 );
+    ok( res, "GPU failed to self-parent target\n" );
+    SendMessageW( state->target, WM_DCOMP_CROSS_GPU_UPDATE_TARGET, 0, 0 );
+    ok( state->gpu_status == STATUS_ACCESS_DENIED,
+        "unconsented target relationship returned %#lx\n", state->gpu_status );
+    ok( !GetPropW( state->target, dcomp_base_presentation_prop ),
+        "unconsented target published base presentation\n" );
+    ok( !GetPropW( root, dcomp_task_delegated_prop ),
+        "unconsented target published task delegate\n" );
+    check_dcomp_cross_input_mapping( state->presentation, root, state->input, FALSE );
+
+    res = SendMessageW( state->input, WM_DCOMP_CROSS_BROWSER_PARENT_TARGET, 0, 0 );
+    ok( res, "browser owner failed to parent GPU target\n" );
+    SendMessageW( state->target, WM_DCOMP_CROSS_GPU_UPDATE_TARGET, 0, 0 );
+    ok( !state->gpu_status, "consented cross-process relationship returned %#lx\n",
+        state->gpu_status );
+    ok( GetPropW( state->target, dcomp_base_presentation_prop ) == state->presentation,
+        "cross-process base presentation was not published\n" );
+    ok( GetPropW( root, dcomp_task_delegated_prop ) == state->presentation,
+        "cross-process task delegate was not published\n" );
+    ok( GetPropW( root, dcomp_task_delegated_target_prop ) == state->target,
+        "cross-process task target was not published\n" );
+    check_dcomp_cross_input_mapping( state->presentation, root, state->input, TRUE );
+
+    res = SendMessageW( state->target, WM_DCOMP_CROSS_GPU_PARENT_TARGET, 0, 0 );
+    ok( res, "GPU failed to repeat target parent\n" );
+    SendMessageW( state->target, WM_DCOMP_CROSS_GPU_UPDATE_TARGET, 0, 0 );
+    ok( !state->gpu_status, "repeated target parent lost consent, status %#lx\n",
+        state->gpu_status );
+    check_dcomp_cross_input_mapping( state->presentation, root, state->input, TRUE );
+
+    res = SendMessageW( state->bad_target, WM_DCOMP_CROSS_GPU_PARENT_BAD_TARGET, 0, 0 );
+    ok( res, "GPU failed to self-parent replacement target\n" );
+    SendMessageW( state->bad_target, WM_DCOMP_CROSS_GPU_UPDATE_BAD_TARGET, 0, 0 );
+    ok( state->gpu_status == STATUS_ACCESS_DENIED,
+        "unconsented replacement returned %#lx\n", state->gpu_status );
+    ok( GetPropW( state->target, dcomp_base_presentation_prop ) == state->presentation,
+        "failed replacement disturbed base winner\n" );
+    ok( GetPropW( root, dcomp_task_delegated_prop ) == state->presentation,
+        "failed replacement disturbed task winner\n" );
+    check_dcomp_cross_input_mapping( state->presentation, root, state->input, TRUE );
+
+    res = SendMessageW( state->input, WM_DCOMP_CROSS_BROWSER_PARENT_INPUT,
+                        (WPARAM)unrelated_root, 0 );
+    ok( res, "browser failed to reparent input under unrelated root\n" );
+    ok( !GetPropW( state->target, dcomp_base_presentation_prop ),
+        "reparented target retained base presentation\n" );
+    ok( !GetPropW( root, dcomp_task_delegated_prop ),
+        "old root retained task delegate\n" );
+    check_dcomp_cross_input_mapping( state->presentation, root, state->input, FALSE );
+    SendMessageW( state->target, WM_DCOMP_CROSS_GPU_UPDATE_TARGET, 0, 0 );
+    ok( state->gpu_status == STATUS_ACCESS_DENIED,
+        "unconsented unrelated root returned %#lx\n", state->gpu_status );
+    ok( !GetPropW( unrelated_root, dcomp_task_delegated_prop ),
+        "unrelated root received task delegate\n" );
+    check_dcomp_cross_input_mapping( state->presentation, unrelated_root, state->input, FALSE );
+
+    NtUserSetParent( state->input, root );
+    ok( NtUserGetAncestor( state->input, GA_PARENT ) == root,
+        "root owner failed to restore browser input\n" );
+    SendMessageW( state->target, WM_DCOMP_CROSS_GPU_UPDATE_TARGET, 0, 0 );
+    ok( !state->gpu_status, "restored cross-process relationship returned %#lx\n",
+        state->gpu_status );
+    ok( GetPropW( root, dcomp_task_delegated_prop ) == state->presentation,
+        "restored root task delegate was not published\n" );
+    check_dcomp_cross_input_mapping( state->presentation, root, state->input, TRUE );
+
+    SendMessageW( state->presentation, WM_DCOMP_CROSS_GPU_CLEAR, 0, 0 );
+    ok( !state->gpu_status, "presentation owner clear returned %#lx\n", state->gpu_status );
+    ok( !GetPropW( state->target, dcomp_base_presentation_prop ),
+        "presentation owner clear retained base presentation\n" );
+    ok( !GetPropW( root, dcomp_task_delegated_prop ),
+        "presentation owner clear retained task delegate\n" );
+    ok( !GetPropW( root, dcomp_task_delegated_target_prop ),
+        "presentation owner clear retained task target\n" );
+    check_dcomp_cross_input_mapping( state->presentation, root, state->input, FALSE );
+
+done:
+    stop_dcomp_cross_process_helper( &gpu );
+    stop_dcomp_cross_process_helper( &browser );
+    if (unrelated_root) DestroyWindow( unrelated_root );
+    if (root) DestroyWindow( root );
+    UnregisterClassW( cls.lpszClassName, NULL );
+    if (state) UnmapViewOfFile( state );
+    if (mapping) CloseHandle( mapping );
+}
+
+static void send_dcomp_test_key( HWND hwnd, WORD vkey, WORD scan, DWORD flags )
+{
+    INPUT input = {0};
+    NTSTATUS status;
+
+    input.type = INPUT_KEYBOARD;
+    input.ki.wVk = vkey;
+    input.ki.wScan = scan;
+    input.ki.dwFlags = flags;
+    status = NtUserSendHardwareInput( hwnd, 0, &input, 0 );
+    ok( !status, "NtUserSendHardwareInput returned %#lx\n", status );
+}
+
+static void test_inter_process_child( const char *argv0, HWND hwnd, HANDLE mapping )
 {
     MDICREATESTRUCTA mdi;
+    struct
+    {
+        UINT cursor_pos;
+        UINT comp_len;
+        UINT result_len;
+        WCHAR strings[9];
+    } ime_update = { .cursor_pos = MAKELONG( 1, 3 ), .comp_len = 5, .result_len = 4,
+                     .strings = {'c','o','m','p',0,'r','e','s',0} };
+    struct wine_dcomp_ime_token token, shared_offer, *shared_token;
+    unsigned int i;
+    COPYDATASTRUCT copydata;
+    WNDCLASSW cls = {0};
     WCHAR bufW[100];
+    HWND presentation, old_input, input;
+    NTSTATUS status;
     char buf[100];
     int res;
+
+    shared_token = MapViewOfFile( mapping, FILE_MAP_ALL_ACCESS, 0, 0, sizeof(*shared_token) );
+    ok( !!shared_token, "child MapViewOfFile failed, error %lu\n", GetLastError() );
+    if (!shared_token) return;
 
     res = SendMessageA( hwnd, WM_SETTEXT, 0, (LPARAM)"test" );
     ok( res == 6, "WM_SETTEXT returned %d\n", res );
@@ -1844,6 +3099,132 @@ static void test_inter_process_child( HWND hwnd )
     mdi.lParam = 0xdeadbeef;
     res = NtUserMessageCall( hwnd, WM_MDICREATE, 0, (LPARAM)&mdi, NULL, NtUserSendMessage, TRUE );
     ok( res == 0xdeadbeef, "res = %d\n", res );
+
+    copydata.dwData = WINE_IME_UPDATE_COPYDATA;
+    copydata.cbData = 0;
+    copydata.lpData = NULL;
+    res = SendMessageW( hwnd, WM_COPYDATA, 0, (LPARAM)&copydata );
+    ok( res == 7, "unrelated IME update marker returned %d\n", res );
+
+    cls.lpfnWndProc = test_ipc_message_proc;
+    cls.lpszClassName = L"TestIPCPresentationClass";
+    RegisterClassW( &cls );
+    presentation = CreateWindowExW( 0, L"TestIPCPresentationClass", NULL, 0, 0, 0, 0, 0,
+                                    HWND_MESSAGE, 0, 0, NULL );
+    ok( !!presentation, "CreateWindowExW failed, error %lu\n", GetLastError() );
+    res = SendMessageW( hwnd, WM_USER + 1, (WPARAM)presentation, 0 );
+    ok( res == 1, "DComp topology setup returned %d\n", res );
+
+    copydata.cbData = offsetof(struct wine_ime_update, strings);
+    res = SendMessageW( hwnd, WM_COPYDATA, (WPARAM)presentation, (LPARAM)&copydata );
+    ok( res == 7, "property-only IME update returned %d\n", res );
+    if (!p_wine_server_call) goto done;
+
+    status = create_dcomp_ime_offer( presentation, &token );
+    ok( !status && (token.low || token.high), "offer creation returned %#lx with empty token %d\n",
+        status, !token.low && !token.high );
+    status = set_dcomp_ime_relationship( &token, presentation );
+    ok( status == STATUS_ACCESS_DENIED, "same-process relationship returned %#lx\n", status );
+
+    *shared_token = token;
+    res = SendMessageW( hwnd, WM_USER + 2, 0, 0 );
+    ok( res == 1, "relationship setup returned %d\n", res );
+    SecureZeroMemory( &token, sizeof(token) );
+
+    copydata.dwData = WINE_IME_UPDATE_COPYDATA;
+    copydata.cbData = offsetof(struct wine_ime_update, strings) + sizeof(ime_update.strings);
+    copydata.lpData = &ime_update;
+    if (start_dcomp_victim_thread())
+    {
+        DWORD owner_tid = GetWindowThreadProcessId( hwnd, NULL );
+        status = raw_dcomp_send( presentation, hwnd, owner_tid, &copydata );
+        ok( !status, "owner TID UPDATE send returned %#lx\n", status );
+        status = raw_dcomp_send( presentation, hwnd, ipc_victim.tid, &copydata );
+        ok( status == STATUS_INVALID_PARAMETER,
+            "mismatched victim TID UPDATE returned %#lx\n", status );
+        stop_dcomp_victim_thread();
+    }
+
+    res = SendMessageW( hwnd, WM_USER + 8, 0, 0 );
+    ok( res == 1, "post-dequeue revoke barrier setup returned %d\n", res );
+    status = raw_dcomp_send( presentation, hwnd, GetWindowThreadProcessId( hwnd, NULL ), &copydata );
+    ok( !status, "post-dequeue revoke raw UPDATE returned %#lx\n", status );
+    res = SendMessageW( hwnd, WM_USER + 7, 0, 0 );
+    ok( res == 1, "post-dequeue revoke barrier check returned %d\n", res );
+
+    res = SendMessageW( hwnd, WM_COPYDATA, (WPARAM)presentation, (LPARAM)&copydata );
+    ok( res, "authorized IME update returned %d\n", res );
+
+    old_input = input = hwnd;
+    send_dcomp_test_key( old_input, 'A', 0x1e, 0 );
+    send_dcomp_test_key( old_input, VK_RCONTROL, 0x1d, KEYEVENTF_EXTENDEDKEY );
+    ok( SendMessageW( hwnd, WM_USER + 3, 0, 0 ) == 1, "old input drain failed\n" );
+    ok( SendMessageW( hwnd, WM_USER + 5, 1, 0 ) == 1, "old input down check failed\n" );
+    input = (HWND)SendMessageW( hwnd, WM_USER + 4, 0, 0 );
+    ok( !!input, "replacement input creation failed\n" );
+    send_dcomp_test_key( old_input, 'A', 0x1e, KEYEVENTF_KEYUP );
+    send_dcomp_test_key( old_input, VK_RCONTROL, 0x1d, KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP );
+    ok( SendMessageW( hwnd, WM_USER + 3, 0, 0 ) == 1, "replacement input drain failed\n" );
+    ok( SendMessageW( hwnd, WM_USER + 5, 2, 0 ) == 1, "old input release check failed\n" );
+    send_dcomp_test_key( input, 'B', 0x30, 0 );
+    send_dcomp_test_key( input, 'B', 0x30, KEYEVENTF_KEYUP );
+    ok( SendMessageW( input, WM_USER + 3, 0, 0 ) == 1, "first replacement key drain failed\n" );
+    ok( SendMessageW( hwnd, WM_USER + 5, 3, 0 ) == 1, "replacement first key check failed\n" );
+
+    DestroyWindow( presentation );
+    ok( !GetPropW( ipc_root, dcomp_input_window_prop ), "root retained DComp input property\n" );
+    ok( !GetPropW( ipc_root, dcomp_keyboard_window_prop ), "root retained DComp keyboard property\n" );
+    ok( !GetPropW( ipc_input, direct_hardware_input_prop ), "input retained direct marker\n" );
+    ok( !GetPropW( ipc_input, direct_hardware_input_owner_prop ), "input retained presentation owner\n" );
+    presentation = CreateWindowExW( 0, L"TestIPCPresentationClass", NULL, 0, 0, 0, 0, 0,
+                                    HWND_MESSAGE, 0, 0, NULL );
+    ok( !!presentation, "shared presentation CreateWindowExW failed, error %lu\n", GetLastError() );
+    if (!presentation) goto done;
+    status = create_dcomp_ime_offer( presentation, &shared_offer );
+    ok( !status && (shared_offer.low || shared_offer.high),
+        "shared offer creation returned %#lx with empty token %d\n",
+        status, !shared_offer.low && !shared_offer.high );
+    for (i = 1; i < 256; i++)
+    {
+        status = create_dcomp_ime_offer( presentation, &token );
+        ok( !status, "shared offer %u returned %#lx\n", i + 1, status );
+        ok( token.low == shared_offer.low && token.high == shared_offer.high,
+            "shared offer %u returned a different token\n", i + 1 );
+    }
+    status = create_dcomp_ime_offer( presentation, &token );
+    ok( status == STATUS_INSUFFICIENT_RESOURCES, "offer beyond cap returned %#lx\n", status );
+    for (i = 1; i < 256; i++)
+    {
+        status = revoke_dcomp_ime_offer( &shared_offer );
+        ok( !status, "shared revoke %u returned %#lx\n", i, status );
+    }
+
+    *shared_token = shared_offer;
+    run_ime_browser_helper( argv0, presentation, mapping, TRUE, TRUE );
+    run_ime_browser_helper( argv0, presentation, mapping, FALSE, TRUE );
+    res = SendMessageW( hwnd, WM_USER + 9, (WPARAM)presentation, 0 );
+    ok( res == 1, "shared task relationship setup returned %d\n", res );
+    status = revoke_dcomp_ime_offer( &shared_offer );
+    ok( !status, "final shared revoke returned %#lx\n", status );
+    res = SendMessageW( hwnd, WM_USER + 10, 0, 0 );
+    ok( res == 1, "shared task relationship cleanup check returned %d\n", res );
+    run_ime_browser_helper( argv0, presentation, mapping, FALSE, FALSE );
+    SecureZeroMemory( shared_token, sizeof(*shared_token) );
+    SecureZeroMemory( &shared_offer, sizeof(shared_offer) );
+
+    DestroyWindow( presentation );
+    presentation = CreateWindowExW( 0, L"TestIPCPresentationClass", NULL, 0, 0, 0, 0, 0,
+                                    HWND_MESSAGE, 0, 0, NULL );
+    ok( !!presentation, "replacement CreateWindowExW failed, error %lu\n", GetLastError() );
+    SetPropW( presentation, dcomp_detached_window_prop, hwnd );
+    res = SendMessageW( hwnd, WM_COPYDATA, (WPARAM)presentation, (LPARAM)&copydata );
+    ok( res == 7, "replacement presentation IME update returned %d\n", res );
+    DestroyWindow( presentation );
+
+done:
+    if (IsWindow( presentation )) DestroyWindow( presentation );
+    UnregisterClassW( L"TestIPCPresentationClass", NULL );
+    UnmapViewOfFile( shared_token );
 
     PostMessageA( hwnd, WM_USER, 0, 0 );
 }
@@ -3050,6 +4431,124 @@ void test_NtUserGetPointerDeviceRects( const char *arg )
         wine_dbgstr_rect( &display ), wine_dbgstr_rect( &screen ) );
 }
 
+static LONG repeat_signature_seed = 0x52455054;
+static LONG repeat_keydown_count, repeat_keyup_captured;
+static ULONG_PTR repeat_signature;
+static KBDLLHOOKSTRUCT repeat_keydown, repeat_keydown_repeat, repeat_keyup;
+
+static LRESULT CALLBACK repeat_keyboard_hook( int code, WPARAM wparam, LPARAM lparam )
+{
+    if (code == HC_ACTION)
+    {
+        const KBDLLHOOKSTRUCT *hook = (const KBDLLHOOKSTRUCT *)lparam;
+        LONG count;
+
+        if (hook->vkCode != 'A' || hook->scanCode != 0x1e || hook->dwExtraInfo != repeat_signature)
+            return CallNextHookEx( NULL, code, wparam, lparam );
+        if (hook->flags & LLKHF_UP)
+        {
+            repeat_keyup = *hook;
+            InterlockedExchange( &repeat_keyup_captured, TRUE );
+        }
+        else
+        {
+            count = InterlockedIncrement( &repeat_keydown_count );
+            if (count == 1) repeat_keydown = *hook;
+            else if (count == 2) repeat_keydown_repeat = *hook;
+        }
+    }
+    return CallNextHookEx( NULL, code, wparam, lparam );
+}
+
+static void test_keyboard_repeat_hook(void)
+{
+    INPUT input = {.type = INPUT_KEYBOARD, .ki = {.wVk = 'A', .wScan = 0x1e,
+                   .dwFlags = KEYEVENTF_EXTENDEDKEY, .time = 0x12345678}};
+    UINT old_delay, old_speed;
+    BOOL old_repeat;
+    HHOOK hook;
+    DWORD start;
+    NTSTATUS status;
+    MSG msg;
+
+    repeat_signature = (ULONG_PTR)InterlockedIncrement( &repeat_signature_seed );
+    input.ki.dwExtraInfo = repeat_signature;
+    SystemParametersInfoW( SPI_GETKEYBOARDDELAY, 0, &old_delay, 0 );
+    SystemParametersInfoW( SPI_GETKEYBOARDSPEED, 0, &old_speed, 0 );
+    SystemParametersInfoW( SPI_SETKEYBOARDDELAY, 0, NULL, 0 );
+    SystemParametersInfoW( SPI_SETKEYBOARDSPEED, 31, NULL, 0 );
+    old_repeat = NtUserCallOneParam( TRUE, NtUserCallOneParam_SetKeyboardAutoRepeat );
+
+    repeat_keydown_count = repeat_keyup_captured = 0;
+    memset( &repeat_keydown, 0, sizeof(repeat_keydown) );
+    memset( &repeat_keydown_repeat, 0, sizeof(repeat_keydown_repeat) );
+    memset( &repeat_keyup, 0, sizeof(repeat_keyup) );
+    hook = SetWindowsHookExW( WH_KEYBOARD_LL, repeat_keyboard_hook, GetModuleHandleW( NULL ), 0 );
+    ok( !!hook, "SetWindowsHookExW failed, error %lu\n", GetLastError() );
+    if (!hook) goto restore;
+
+    status = NtUserSendHardwareInput( NULL, 0, &input, 0 );
+    ok( !status, "physical key-down failed, status %#lx\n", status );
+    start = GetTickCount();
+    while (repeat_keydown_count < 2 && GetTickCount() - start < 2000)
+    {
+        MsgWaitForMultipleObjects( 0, NULL, FALSE, 100, QS_ALLINPUT );
+        while (PeekMessageW( &msg, NULL, 0, 0, PM_REMOVE ))
+        {
+            TranslateMessage( &msg );
+            DispatchMessageW( &msg );
+        }
+    }
+    ok( repeat_keydown_count >= 2, "received %ld non-key-up key-downs\n", repeat_keydown_count );
+    ok( repeat_keydown.vkCode == 'A', "key-down vkey is %#lx\n", repeat_keydown.vkCode );
+    ok( repeat_keydown.scanCode == 0x1e, "key-down scan is %#lx\n", repeat_keydown.scanCode );
+    ok( repeat_keydown.flags == LLKHF_EXTENDED, "key-down flags are %#lx\n", repeat_keydown.flags );
+    ok( repeat_keydown.time == input.ki.time, "key-down time is %#lx\n", repeat_keydown.time );
+    ok( repeat_keydown.dwExtraInfo == repeat_signature, "key-down extra info is %Ix\n",
+        repeat_keydown.dwExtraInfo );
+    ok( repeat_keydown_repeat.vkCode == 'A', "repeat key-down vkey is %#lx\n",
+        repeat_keydown_repeat.vkCode );
+    ok( repeat_keydown_repeat.scanCode == 0x1e, "repeat key-down scan is %#lx\n",
+        repeat_keydown_repeat.scanCode );
+    ok( repeat_keydown_repeat.flags == LLKHF_EXTENDED, "repeat key-down flags are %#lx\n",
+        repeat_keydown_repeat.flags );
+    ok( repeat_keydown_repeat.time != input.ki.time, "repeat key-down reused input time %#lx\n",
+        repeat_keydown_repeat.time );
+    ok( repeat_keydown_repeat.time - start < 2000, "repeat key-down time is %#lx, start %#lx\n",
+        repeat_keydown_repeat.time, start );
+    ok( repeat_keydown_repeat.dwExtraInfo == repeat_signature,
+        "repeat key-down extra info is %Ix\n", repeat_keydown_repeat.dwExtraInfo );
+
+    input.ki.dwFlags = KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP;
+    status = NtUserSendHardwareInput( NULL, 0, &input, 0 );
+    ok( !status, "physical key-up failed, status %#lx\n", status );
+    start = GetTickCount();
+    while (!repeat_keyup_captured && GetTickCount() - start < 2000)
+    {
+        MsgWaitForMultipleObjects( 0, NULL, FALSE, 100, QS_ALLINPUT );
+        while (PeekMessageW( &msg, NULL, 0, 0, PM_REMOVE ))
+        {
+            TranslateMessage( &msg );
+            DispatchMessageW( &msg );
+        }
+    }
+    ok( repeat_keyup_captured, "key-up hook was not captured\n" );
+    ok( repeat_keyup.vkCode == 'A', "key-up vkey is %#lx\n", repeat_keyup.vkCode );
+    ok( repeat_keyup.scanCode == 0x1e, "key-up scan is %#lx\n", repeat_keyup.scanCode );
+    ok( repeat_keyup.flags == (LLKHF_EXTENDED | LLKHF_UP),
+        "key-up flags are %#lx\n", repeat_keyup.flags );
+    ok( repeat_keyup.time == input.ki.time, "key-up time is %#lx\n", repeat_keyup.time );
+    ok( repeat_keyup.dwExtraInfo == repeat_signature, "key-up extra info is %Ix\n",
+        repeat_keyup.dwExtraInfo );
+    ok( !!GetDesktopWindow(), "wineserver stopped responding after repeat timer\n" );
+    UnhookWindowsHookEx( hook );
+
+restore:
+    SystemParametersInfoW( SPI_SETKEYBOARDDELAY, old_delay, NULL, 0 );
+    SystemParametersInfoW( SPI_SETKEYBOARDSPEED, old_speed, NULL, 0 );
+    NtUserCallOneParam( old_repeat, NtUserCallOneParam_SetKeyboardAutoRepeat );
+}
+
 START_TEST(win32u)
 {
     char **argv;
@@ -3059,9 +4558,57 @@ START_TEST(win32u)
     GetDesktopWindow();
 
     argc = winetest_get_mainargs( &argv );
-    if (argc > 3 && !strcmp( argv[2], "ipcmsg" ))
+    p_wine_server_call = (void *)GetProcAddress( GetModuleHandleA( "ntdll.dll" ), "wine_server_call" );
+    if (argc > 2 && !strcmp( argv[2], "dcomp_cross_main" ))
     {
-        test_inter_process_child( LongToHandle( strtol( argv[3], NULL, 16 )));
+        if (!p_wine_server_call)
+            win_skip( "wine_server_call is unavailable\n" );
+        else
+            test_dcomp_cross_process_parenting( argv[0] );
+        return;
+    }
+
+    if (argc > 5 && !strcmp( argv[2], "dcomp_cross" ))
+    {
+        test_dcomp_cross_process_child( argv[3], LongToHandle( strtol( argv[4], NULL, 16 )),
+                                       LongToHandle( strtol( argv[5], NULL, 16 )) );
+        return;
+    }
+
+    if (argc > 6 && !strcmp( argv[2], "ime_browser" ))
+    {
+        test_ime_browser_child( LongToHandle( strtol( argv[3], NULL, 16 )),
+                                LongToHandle( strtol( argv[4], NULL, 16 )), atoi( argv[5] ),
+                                atoi( argv[6] ) );
+        return;
+    }
+
+    if (argc > 5 && !strcmp( argv[2], "dcomp_presentation" ))
+    {
+        test_dcomp_presentation_process_child( LongToHandle( strtol( argv[3], NULL, 16 )),
+                                               LongToHandle( strtol( argv[4], NULL, 16 )), argv[5] );
+        return;
+    }
+
+    if (argc > 4 && !strcmp( argv[2], "ipcmsg" ))
+    {
+        test_inter_process_child( argv[0], LongToHandle( strtol( argv[3], NULL, 16 )),
+                                  LongToHandle( strtol( argv[4], NULL, 16 )) );
+        return;
+    }
+
+    if (argc > 2 && !strcmp( argv[2], "ime_relay" ))
+    {
+        if (!p_wine_server_call)
+            win_skip( "wine_server_call is unavailable\n" );
+        else
+            test_inter_process_messages( argv[0] );
+        return;
+    }
+
+    if (argc > 2 && !strcmp( argv[2], "repeat_hook" ))
+    {
+        test_keyboard_repeat_hook();
         return;
     }
 
@@ -3102,6 +4649,7 @@ START_TEST(win32u)
     test_message_filter();
     test_timer();
     test_inter_process_messages( argv[0] );
+    if (p_wine_server_call) test_dcomp_cross_process_parenting( argv[0] );
     test_wndproc_hook();
 
     test_NtUserCloseWindowStation();

--- a/dlls/win32u/win32u_private.h
+++ b/dlls/win32u/win32u_private.h
@@ -88,6 +88,7 @@ extern void cleanup_imm_thread(void);
 extern HWND get_default_ime_window( HWND hwnd );
 extern HIMC get_default_input_context(void);
 extern HIMC get_window_input_context( HWND hwnd );
+extern BOOL process_ime_update( HWND hwnd, const COPYDATASTRUCT *copydata, LRESULT *result );
 extern BOOL register_imm_window( HWND hwnd );
 extern void unregister_imm_window( HWND hwnd );
 
@@ -101,6 +102,7 @@ extern HWND get_focus(void);
 extern DWORD get_input_state(void);
 extern DWORD get_last_input_time(void);
 extern BOOL get_async_keyboard_state( BYTE state[256] );
+extern BOOL process_ime_set_rect( HWND hwnd, const COPYDATASTRUCT *copydata, LRESULT *result );
 extern BOOL set_capture_window( HWND hwnd, UINT gui_flags, HWND *prev_ret );
 extern BOOL set_foreground_window( HWND hwnd, BOOL mouse, BOOL force );
 extern BOOL set_active_window( HWND hwnd, HWND *prev, BOOL mouse, BOOL focus, DWORD new_active_thread_id );
@@ -127,6 +129,9 @@ extern UINT get_menu_state( HMENU handle, UINT item_id, UINT flags );
 extern HMENU get_window_sys_sub_menu( HWND hwnd );
 extern BOOL is_menu( HMENU handle );
 extern HWND is_menu_active(void);
+
+/* window.c */
+extern BOOL is_dcomp_ime_relationship( HWND presentation, HWND root, HWND input );
 extern LRESULT popup_menu_window_proc( HWND hwnd, UINT message, WPARAM wparam, LPARAM lparam, BOOL ansi );
 extern BOOL set_window_menu( HWND hwnd, HMENU handle );
 extern void track_keyboard_menu_bar( HWND hwnd, UINT wparam, WCHAR ch );

--- a/dlls/win32u/window.c
+++ b/dlls/win32u/window.c
@@ -6771,7 +6771,7 @@ BOOL is_dcomp_ime_relationship( HWND presentation, HWND root, HWND input )
             't','a','s','k','_','d','e','l','e','g','a','t','e','d','_','t','a','r','g','e','t',0};
     static const WCHAR direct_owner_prop[] = {'_','_','w','i','n','e','_','d','i','r','e','c','t','_',
             'h','a','r','d','w','a','r','e','_','i','n','p','u','t','_','o','w','n','e','r',0};
-    DWORD presentation_pid, root_pid, input_pid, target_pid;
+    DWORD presentation_pid = 0, root_pid = 0, input_pid = 0, target_pid = 0;
     HWND target;
 
     if (!NtUserIsWindow( presentation ) || !NtUserIsWindow( root ) || !NtUserIsWindow( input ) ||
@@ -6784,11 +6784,10 @@ BOOL is_dcomp_ime_relationship( HWND presentation, HWND root, HWND input )
         NtUserGetProp( input, direct_owner_prop ) != presentation)
         return FALSE;
 
-    get_window_thread( presentation, &presentation_pid );
-    get_window_thread( root, &root_pid );
-    get_window_thread( input, &input_pid );
-    get_window_thread( target, &target_pid );
-    return presentation_pid && root_pid && presentation_pid != root_pid &&
+    if (!get_window_thread( presentation, &presentation_pid ) ||
+        !get_window_thread( root, &root_pid ) || !get_window_thread( input, &input_pid ) ||
+        !get_window_thread( target, &target_pid )) return FALSE;
+    return presentation_pid != root_pid &&
            root_pid == input_pid && root_pid == target_pid;
 }
 

--- a/dlls/win32u/window.c
+++ b/dlls/win32u/window.c
@@ -6757,6 +6757,41 @@ HWND get_shell_window(void)
     return hwnd;
 }
 
+BOOL is_dcomp_ime_relationship( HWND presentation, HWND root, HWND input )
+{
+    static const WCHAR detached_prop[] = {'_','_','w','i','n','e','_','d','c','o','m','p','_',
+            'd','e','t','a','c','h','e','d','_','w','i','n','d','o','w',0};
+    static const WCHAR base_prop[] = {'_','_','w','i','n','e','_','d','c','o','m','p','_',
+            'b','a','s','e','_','p','r','e','s','e','n','t','a','t','i','o','n',0};
+    static const WCHAR input_prop[] = {'_','_','w','i','n','e','_','d','c','o','m','p','_',
+            'i','n','p','u','t','_','w','i','n','d','o','w',0};
+    static const WCHAR delegated_prop[] = {'_','_','w','i','n','e','_','d','c','o','m','p','_',
+            't','a','s','k','_','d','e','l','e','g','a','t','e','d',0};
+    static const WCHAR delegated_target_prop[] = {'_','_','w','i','n','e','_','d','c','o','m','p','_',
+            't','a','s','k','_','d','e','l','e','g','a','t','e','d','_','t','a','r','g','e','t',0};
+    static const WCHAR direct_owner_prop[] = {'_','_','w','i','n','e','_','d','i','r','e','c','t','_',
+            'h','a','r','d','w','a','r','e','_','i','n','p','u','t','_','o','w','n','e','r',0};
+    DWORD presentation_pid, root_pid, input_pid, target_pid;
+    HWND target;
+
+    if (!NtUserIsWindow( presentation ) || !NtUserIsWindow( root ) || !NtUserIsWindow( input ) ||
+        !(target = NtUserGetProp( presentation, detached_prop )) || !NtUserIsWindow( target ) ||
+        NtUserGetProp( target, base_prop ) != presentation ||
+        NtUserGetAncestor( target, GA_ROOT ) != root || NtUserGetAncestor( target, GA_PARENT ) != input ||
+        NtUserGetProp( presentation, input_prop ) != input || NtUserGetProp( root, input_prop ) != input ||
+        NtUserGetProp( root, delegated_prop ) != presentation ||
+        NtUserGetProp( root, delegated_target_prop ) != target ||
+        NtUserGetProp( input, direct_owner_prop ) != presentation)
+        return FALSE;
+
+    get_window_thread( presentation, &presentation_pid );
+    get_window_thread( root, &root_pid );
+    get_window_thread( input, &input_pid );
+    get_window_thread( target, &target_pid );
+    return presentation_pid && root_pid && presentation_pid != root_pid &&
+           root_pid == input_pid && root_pid == target_pid;
+}
+
 /*******************************************************************
  *           NtUserQueryWindow (win32u.@)
  */

--- a/dlls/wow64win/user.c
+++ b/dlls/wow64win/user.c
@@ -1703,10 +1703,35 @@ NTSTATUS WINAPI wow64_NtUserCallHwndParam( UINT *args )
                 ULONG input;
                 ULONG lparam;
             } *params32 = UlongToPtr( param );
+            INPUT32 *input32 = UlongToPtr( params32->input );
             struct send_hardware_input_params params;
+            INPUT input = {0};
+
+            input.type = input32->type;
+            switch (input.type)
+            {
+            case INPUT_MOUSE:
+                input.mi.dx          = input32->mi.dx;
+                input.mi.dy          = input32->mi.dy;
+                input.mi.mouseData   = input32->mi.mouseData;
+                input.mi.dwFlags     = input32->mi.dwFlags;
+                input.mi.time        = input32->mi.time;
+                input.mi.dwExtraInfo = input32->mi.dwExtraInfo;
+                break;
+            case INPUT_KEYBOARD:
+                input.ki.wVk         = input32->ki.wVk;
+                input.ki.wScan       = input32->ki.wScan;
+                input.ki.dwFlags     = input32->ki.dwFlags;
+                input.ki.time        = input32->ki.time;
+                input.ki.dwExtraInfo = input32->ki.dwExtraInfo;
+                break;
+            case INPUT_HARDWARE:
+                input.hi = input32->hi;
+                break;
+            }
 
             params.flags = params32->flags;
-            params.input = UlongToPtr( params32->input );
+            params.input = &input;
             params.lparam = params32->lparam;
             return NtUserCallHwndParam( hwnd, (UINT_PTR)&params, code );
         }

--- a/include/ntuser.h
+++ b/include/ntuser.h
@@ -658,6 +658,18 @@ enum wine_internal_message
 #define IMN_WINE_SET_OPEN_STATUS  0x000f
 #define IMN_WINE_SET_COMP_STRING  0x0010
 
+#define WINE_IME_UPDATE_COPYDATA   0x57494d45
+#define WINE_IME_SET_RECT_COPYDATA 0x57494d52
+#define WINE_IME_UPDATE_MAX_CHARS  4096
+
+struct wine_ime_update
+{
+    UINT cursor_pos;
+    UINT comp_len;
+    UINT result_len;
+    WCHAR strings[];
+};
+
 /* not compatible with Windows */
 #define MAKE_FNID(index) ((WORD)(0x8000 | (index)))
 

--- a/include/ntuser.h
+++ b/include/ntuser.h
@@ -1632,7 +1632,7 @@ struct send_hardware_input_params
     };
 };
 
-static inline BOOL NtUserSendHardwareInput( HWND hwnd, UINT flags, const INPUT *input, LPARAM lparam )
+static inline NTSTATUS NtUserSendHardwareInput( HWND hwnd, UINT flags, const INPUT *input, LPARAM lparam )
 {
     struct send_hardware_input_params params = {.flags = flags, .input = input, .lparam = lparam};
     return NtUserCallHwndParam( hwnd, (UINT_PTR)&params, NtUserCallHwndParam_SendHardwareInput );

--- a/include/wine/dcomp.h
+++ b/include/wine/dcomp.h
@@ -17,6 +17,15 @@
 #define WINE_DCOMP_VISUAL_RENDERER_ACTIVE 0x00000008
 #define WINE_DCOMP_VISUAL_TRANSFORM_ABSOLUTE 0x00000010
 
+struct wine_dcomp_ime_token
+{
+    UINT64 low;
+    UINT64 high;
+};
+
+static const GUID WINE_DCOMP_IME_TOKEN_GUID =
+    {0xdfe53f32, 0x7c4d, 0x4f25, {0xb8, 0x2c, 0xa4, 0x84, 0x65, 0x88, 0xe9, 0xb6}};
+
 struct wine_dcomp_visual_desc
 {
     UINT version;

--- a/include/wine/server_protocol.h
+++ b/include/wine/server_protocol.h
@@ -31,6 +31,7 @@ typedef unsigned __int64 file_pos_t;
 typedef unsigned __int64 client_ptr_t;
 typedef unsigned __int64 affinity_t;
 typedef unsigned __int64 object_id_t;
+typedef unsigned __int64 capability_t;
 typedef client_ptr_t mod_handle_t;
 
 struct request_header
@@ -3269,12 +3270,12 @@ struct get_message_reply
     lparam_t        wparam;
     lparam_t        lparam;
     int             type;
+    unsigned int    dcomp_ime_authorization;
     int             x;
     int             y;
     unsigned int    time;
     data_size_t     total;
     /* VARARG(data,message_data); */
-    char __pad_52[4];
 };
 
 
@@ -3315,6 +3316,20 @@ struct get_message_reply_reply
     struct reply_header __header;
     lparam_t        result;
     /* VARARG(data,bytes); */
+};
+
+
+
+struct validate_dcomp_ime_message_request
+{
+    struct request_header __header;
+    char __pad_12[4];
+};
+struct validate_dcomp_ime_message_reply
+{
+    struct reply_header __header;
+    unsigned int    authorization;
+    char __pad_12[4];
 };
 
 
@@ -3620,6 +3635,70 @@ struct destroy_window_reply
 {
     struct reply_header __header;
 };
+
+
+struct create_dcomp_ime_offer_request
+{
+    struct request_header __header;
+    user_handle_t  presentation;
+};
+struct create_dcomp_ime_offer_reply
+{
+    struct reply_header __header;
+    capability_t token_low;
+    capability_t token_high;
+};
+
+
+struct set_dcomp_ime_relationship_request
+{
+    struct request_header __header;
+    char __pad_12[4];
+    capability_t token_low;
+    capability_t token_high;
+    user_handle_t  target;
+    char __pad_36[4];
+};
+struct set_dcomp_ime_relationship_reply
+{
+    struct reply_header __header;
+};
+
+
+struct revoke_dcomp_ime_offer_request
+{
+    struct request_header __header;
+    char __pad_12[4];
+    capability_t token_low;
+    capability_t token_high;
+};
+struct revoke_dcomp_ime_offer_reply
+{
+    struct reply_header __header;
+};
+
+
+struct update_dcomp_task_delegate_request
+{
+    struct request_header __header;
+    char __pad_12[4];
+    capability_t token_low;
+    capability_t token_high;
+    user_handle_t presentation;
+    user_handle_t target;
+    unsigned int flags;
+    char __pad_44[4];
+};
+struct update_dcomp_task_delegate_reply
+{
+    struct reply_header __header;
+};
+
+#define DCOMP_TASK_DELEGATE_BASE 0x01
+#define DCOMP_TASK_DELEGATE_TASK 0x02
+
+#define DCOMP_IME_AUTHORIZE_UPDATE   0x01
+#define DCOMP_IME_AUTHORIZE_SET_RECT 0x02
 
 
 struct update_window_broadcast_exclusion_request
@@ -6575,6 +6654,7 @@ enum request
     REQ_reply_message,
     REQ_accept_hardware_message,
     REQ_get_message_reply,
+    REQ_validate_dcomp_ime_message,
     REQ_set_win_timer,
     REQ_kill_win_timer,
     REQ_is_window_hung,
@@ -6593,6 +6673,10 @@ enum request
     REQ_set_named_pipe_info,
     REQ_create_window,
     REQ_destroy_window,
+    REQ_create_dcomp_ime_offer,
+    REQ_set_dcomp_ime_relationship,
+    REQ_revoke_dcomp_ime_offer,
+    REQ_update_dcomp_task_delegate,
     REQ_update_window_broadcast_exclusion,
     REQ_get_window_broadcast_exclusion,
     REQ_get_desktop_window,
@@ -6903,6 +6987,7 @@ union generic_request
     struct reply_message_request reply_message_request;
     struct accept_hardware_message_request accept_hardware_message_request;
     struct get_message_reply_request get_message_reply_request;
+    struct validate_dcomp_ime_message_request validate_dcomp_ime_message_request;
     struct set_win_timer_request set_win_timer_request;
     struct kill_win_timer_request kill_win_timer_request;
     struct is_window_hung_request is_window_hung_request;
@@ -6921,6 +7006,10 @@ union generic_request
     struct set_named_pipe_info_request set_named_pipe_info_request;
     struct create_window_request create_window_request;
     struct destroy_window_request destroy_window_request;
+    struct create_dcomp_ime_offer_request create_dcomp_ime_offer_request;
+    struct set_dcomp_ime_relationship_request set_dcomp_ime_relationship_request;
+    struct revoke_dcomp_ime_offer_request revoke_dcomp_ime_offer_request;
+    struct update_dcomp_task_delegate_request update_dcomp_task_delegate_request;
     struct update_window_broadcast_exclusion_request update_window_broadcast_exclusion_request;
     struct get_window_broadcast_exclusion_request get_window_broadcast_exclusion_request;
     struct get_desktop_window_request get_desktop_window_request;
@@ -7229,6 +7318,7 @@ union generic_reply
     struct reply_message_reply reply_message_reply;
     struct accept_hardware_message_reply accept_hardware_message_reply;
     struct get_message_reply_reply get_message_reply_reply;
+    struct validate_dcomp_ime_message_reply validate_dcomp_ime_message_reply;
     struct set_win_timer_reply set_win_timer_reply;
     struct kill_win_timer_reply kill_win_timer_reply;
     struct is_window_hung_reply is_window_hung_reply;
@@ -7247,6 +7337,10 @@ union generic_reply
     struct set_named_pipe_info_reply set_named_pipe_info_reply;
     struct create_window_reply create_window_reply;
     struct destroy_window_reply destroy_window_reply;
+    struct create_dcomp_ime_offer_reply create_dcomp_ime_offer_reply;
+    struct set_dcomp_ime_relationship_reply set_dcomp_ime_relationship_reply;
+    struct revoke_dcomp_ime_offer_reply revoke_dcomp_ime_offer_reply;
+    struct update_dcomp_task_delegate_reply update_dcomp_task_delegate_reply;
     struct update_window_broadcast_exclusion_reply update_window_broadcast_exclusion_reply;
     struct get_window_broadcast_exclusion_reply get_window_broadcast_exclusion_reply;
     struct get_desktop_window_reply get_desktop_window_reply;
@@ -7422,6 +7516,6 @@ union generic_reply
     struct alpc_create_port_reply alpc_create_port_reply;
 };
 
-#define SERVER_PROTOCOL_VERSION 964
+#define SERVER_PROTOCOL_VERSION 970
 
 #endif /* __WINE_WINE_SERVER_PROTOCOL_H */

--- a/server/process.c
+++ b/server/process.c
@@ -961,6 +961,8 @@ static void process_killed( struct process *process )
 
     destroy_process_classes( process );
     free_mapped_views( process );
+    cleanup_message_results_process( process );
+    cleanup_dcomp_ime_process( process );
     free_process_user_handles( process );
     remove_process_locks( process );
     set_process_startup_state( process, STARTUP_ABORTED );

--- a/server/protocol.def
+++ b/server/protocol.def
@@ -47,6 +47,7 @@ typedef unsigned __int64 file_pos_t;
 typedef unsigned __int64 client_ptr_t;
 typedef unsigned __int64 affinity_t;
 typedef unsigned __int64 object_id_t;
+typedef unsigned __int64 capability_t;
 typedef client_ptr_t mod_handle_t;
 
 struct request_header
@@ -2499,6 +2500,7 @@ enum message_type
     lparam_t        wparam;    /* parameters */
     lparam_t        lparam;    /* parameters */
     int             type;      /* message type */
+    unsigned int    dcomp_ime_authorization; /* private DComp IME direction */
     int             x;         /* message x position */
     int             y;         /* message y position */
     unsigned int    time;      /* message time */
@@ -2527,6 +2529,13 @@ enum message_type
 @REPLY
     lparam_t        result;    /* message result */
     VARARG(data,bytes);        /* message data for sent messages */
+@END
+
+
+/* Revalidate private DComp authorization for the current sent message */
+@REQ(validate_dcomp_ime_message)
+@REPLY
+    unsigned int    authorization;
 @END
 
 
@@ -2719,6 +2728,42 @@ enum message_type
 @REQ(destroy_window)
     user_handle_t  handle;      /* handle to the window */
 @END
+
+/* Create an IME authorization offer for a DirectComposition presentation window */
+@REQ(create_dcomp_ime_offer)
+    user_handle_t  presentation; /* presentation window owned by the caller */
+@REPLY
+    capability_t token_low;
+    capability_t token_high;
+@END
+
+/* Accept or deactivate a DirectComposition IME authorization offer */
+@REQ(set_dcomp_ime_relationship)
+    capability_t token_low;
+    capability_t token_high;
+    user_handle_t  target;       /* browser target window, zero to deactivate */
+@END
+
+/* Revoke a DirectComposition IME authorization offer */
+@REQ(revoke_dcomp_ime_offer)
+    capability_t token_low;
+    capability_t token_high;
+@END
+
+/* Atomically update a DirectComposition presentation binding. */
+@REQ(update_dcomp_task_delegate)
+    capability_t token_low;
+    capability_t token_high;
+    user_handle_t presentation;
+    user_handle_t target;
+    unsigned int flags;
+@END
+
+#define DCOMP_TASK_DELEGATE_BASE 0x01
+#define DCOMP_TASK_DELEGATE_TASK 0x02
+
+#define DCOMP_IME_AUTHORIZE_UPDATE   0x01
+#define DCOMP_IME_AUTHORIZE_SET_RECT 0x02
 
 /* Update the broadcast exclusion owned by a window */
 @REQ(update_window_broadcast_exclusion)

--- a/server/queue.c
+++ b/server/queue.c
@@ -1965,6 +1965,8 @@ void clear_dcomp_key_owners( struct desktop *desktop, user_handle_t presentation
     for (i = 0; i < ARRAY_SIZE(desktop->dcomp_keys); i++)
         if (desktop->dcomp_keys[i].presentation == presentation)
             memset( &desktop->dcomp_keys[i], 0, sizeof(desktop->dcomp_keys[i]) );
+    if (desktop->key_repeat.dcomp_presentation == presentation)
+        desktop->key_repeat.dcomp_presentation = 0;
 }
 
 /* queue a hardware message into a given thread input */
@@ -3348,21 +3350,6 @@ DECL_HANDLER(send_message)
         msg->result    = NULL;
         msg->data      = NULL;
         msg->data_size = get_req_data_size();
-
-        if (msg->msg == WM_COPYDATA && msg->win)
-        {
-            struct thread *window_thread = get_window_thread( msg->win );
-            if (window_thread != thread && get_dcomp_ime_message_authorization(
-                    (user_handle_t)msg->wparam, msg->win, current->process ))
-            {
-                if (window_thread) release_object( window_thread );
-                set_error( STATUS_INVALID_PARAMETER );
-                free( msg );
-                release_object( thread );
-                return;
-            }
-            if (window_thread) release_object( window_thread );
-        }
 
         get_message_defaults( recv_queue, &msg->x, &msg->y, &msg->time );
 

--- a/server/queue.c
+++ b/server/queue.c
@@ -57,14 +57,22 @@ enum message_kind { SEND_MESSAGE, POST_MESSAGE };
 
 /* list of processes registered for rawinput in the input desktop */
 static struct list rawinput_processes = LIST_INIT(rawinput_processes);
+static struct list message_results = LIST_INIT(message_results);
 
 struct message_result
 {
+    struct list            entry;         /* entry in global result list */
     struct list            sender_entry;  /* entry in sender list */
     struct message        *msg;           /* message the result is for */
     struct message_result *recv_next;     /* next in receiver list */
     struct msg_queue      *sender;        /* sender queue */
     struct msg_queue      *receiver;      /* receiver queue */
+    struct process        *sender_process;/* non-owning sender process */
+    user_handle_t          dcomp_source;  /* DComp source window */
+    user_handle_t          dcomp_destination; /* DComp destination window */
+    unsigned int           dcomp_message; /* message code */
+    user_handle_t          set_parent_child; /* WM_WINE_SETPARENT destination */
+    user_handle_t          set_parent_parent; /* WM_WINE_SETPARENT parent */
     int                    replied;       /* has it been replied to? */
     unsigned int           error;         /* error code to pass back to sender */
     lparam_t               result;        /* reply result */
@@ -90,6 +98,10 @@ struct message
     void                  *data;      /* message data for sent messages */
     unsigned int           data_size; /* size of message data */
     unsigned int           unique_id; /* unique id for nested hw message waits */
+    user_handle_t          dcomp_presentation; /* authorized keyboard presentation */
+    unsigned short         dcomp_scan; /* authorized physical keyboard scan */
+    unsigned int           dcomp_generation; /* pending key-owner generation */
+    unsigned char          dcomp_keyup; /* consumes a prior authorized key-down */
     struct message_result *result;    /* result in sender queue */
 };
 
@@ -188,6 +200,7 @@ static struct cursor_pos cursor_history[64];
 static unsigned int cursor_history_latest;
 
 static void queue_hardware_message( struct desktop *desktop, struct message *msg, int always_queue );
+static void cancel_dcomp_key_owner( struct desktop *desktop, struct message *msg );
 static void free_message( struct message *msg );
 
 /* set the caret window in a given thread input, requires write lock on the thread input shared member */
@@ -895,6 +908,7 @@ static int merge_message( struct thread_input *input, const struct message *msg 
 /* free a result structure */
 static void free_result( struct message_result *result )
 {
+    list_remove( &result->entry );
     if (result->timeout) remove_timeout_user( result->timeout );
     free( result->data );
     if (result->callback_msg) free_message( result->callback_msg );
@@ -928,7 +942,10 @@ static void store_message_result( struct message_result *res, lparam_t result, u
     if (res->hardware_msg)
     {
         if (!error && result)  /* rejected by the hook */
+        {
+            cancel_dcomp_key_owner( res->desktop, res->hardware_msg );
             free_message( res->hardware_msg );
+        }
         else
             queue_hardware_message( res->desktop, res->hardware_msg, 0 );
 
@@ -1023,6 +1040,12 @@ static struct message_result *alloc_message_result( struct msg_queue *send_queue
         result->msg          = msg;
         result->sender       = send_queue;
         result->receiver     = recv_queue;
+        result->sender_process = current ? current->process : NULL;
+        result->dcomp_source = 0;
+        result->dcomp_destination = 0;
+        result->dcomp_message = 0;
+        result->set_parent_child = 0;
+        result->set_parent_parent = 0;
         result->replied      = 0;
         result->data         = NULL;
         result->data_size    = 0;
@@ -1062,10 +1085,40 @@ static struct message_result *alloc_message_result( struct msg_queue *send_queue
             clear_queue_bits( send_queue, QS_SMRESULT );
         }
 
+        if (msg->msg == WM_COPYDATA)
+        {
+            result->dcomp_source = (user_handle_t)msg->wparam;
+            result->dcomp_destination = msg->win;
+            result->dcomp_message = msg->msg;
+        }
+        else if (msg->msg == WM_WINE_SETPARENT)
+        {
+            result->set_parent_child = msg->win;
+            result->set_parent_parent = (user_handle_t)msg->wparam;
+        }
         if (timeout != TIMEOUT_INFINITE)
             result->timeout = add_timeout_user( timeout, result_timeout, result );
+        list_add_tail( &message_results, &result->entry );
     }
     return result;
+}
+
+void cleanup_message_results_process( struct process *process )
+{
+    struct message_result *result;
+
+    LIST_FOR_EACH_ENTRY( result, &message_results, struct message_result, entry )
+        if (result->sender_process == process) result->sender_process = NULL;
+}
+
+int is_current_set_parent_message( user_handle_t child, user_handle_t parent,
+                                   struct process *sender )
+{
+    struct message_result *result;
+
+    if (!current->queue || !(result = current->queue->recv_result)) return 0;
+    return result->sender_process == sender && result->set_parent_child == child &&
+           result->set_parent_parent == parent;
 }
 
 /* receive a message, removing it from the sent queue */
@@ -1081,6 +1134,15 @@ static void receive_message( struct msg_queue *queue, struct message *msg,
         return;
     }
     reply->type   = msg->type;
+    reply->dcomp_ime_authorization = 0;
+    if (result)
+    {
+        struct thread *window_thread = get_window_thread( msg->win );
+        if (window_thread && window_thread->queue == queue)
+            reply->dcomp_ime_authorization = get_dcomp_ime_message_authorization(
+                    (user_handle_t)msg->wparam, msg->win, result->sender_process );
+        if (window_thread) release_object( window_thread );
+    }
     reply->win    = msg->win;
     reply->msg    = msg->msg;
     reply->wparam = msg->wparam;
@@ -1795,7 +1857,12 @@ static user_handle_t find_hardware_message_window( struct desktop *desktop, stru
         if (!(win = msg->win) && input) win = input_shm->focus;
         break;
     case QS_KEY:
-        if (input && !(win = input_shm->focus))
+        if (msg->dcomp_presentation &&
+            (is_dcomp_keyboard_input( msg->dcomp_presentation, msg->win ) ||
+             (msg->dcomp_keyup && msg->dcomp_generation &&
+              is_dcomp_presentation_active( msg->dcomp_presentation ))))
+            win = msg->win;
+        else if (input && !(win = input_shm->focus))
         {
             win = input_shm->active;
             if (*msg_code < WM_SYSKEYDOWN) *msg_code += WM_SYSKEYDOWN - WM_KEYDOWN;
@@ -1858,6 +1925,48 @@ static unsigned int get_rawinput_device_flags( struct process *process, struct m
     return 0;
 }
 
+static struct dcomp_key_owner *get_dcomp_key_owner( struct desktop *desktop, unsigned short scan )
+{
+    if (scan >= DCOMP_KEY_COUNT) return NULL;
+    return &desktop->dcomp_keys[scan];
+}
+
+static unsigned short get_dcomp_key_scan( const union hw_input *input )
+{
+    return input->kbd.scan | ((input->kbd.flags & KEYEVENTF_EXTENDEDKEY) ? 0x100 : 0);
+}
+
+static unsigned int reserve_dcomp_key_owner( struct desktop *desktop, unsigned short scan,
+                                             user_handle_t win, user_handle_t presentation )
+{
+    struct dcomp_key_owner *owner = get_dcomp_key_owner( desktop, scan );
+
+    if (!owner) return 0;
+    if (!++owner->generation) owner->generation++;
+    owner->win = get_user_full_handle( win );
+    owner->presentation = get_user_full_handle( presentation );
+    return owner->generation;
+}
+
+static void cancel_dcomp_key_owner( struct desktop *desktop, struct message *msg )
+{
+    struct dcomp_key_owner *owner;
+
+    if (msg->dcomp_keyup || !msg->dcomp_generation ||
+        !(owner = get_dcomp_key_owner( desktop, msg->dcomp_scan ))) return;
+    if (owner->generation == msg->dcomp_generation) memset( owner, 0, sizeof(*owner) );
+}
+
+void clear_dcomp_key_owners( struct desktop *desktop, user_handle_t presentation )
+{
+    unsigned int i;
+
+    presentation = get_user_full_handle( presentation );
+    for (i = 0; i < ARRAY_SIZE(desktop->dcomp_keys); i++)
+        if (desktop->dcomp_keys[i].presentation == presentation)
+            memset( &desktop->dcomp_keys[i], 0, sizeof(desktop->dcomp_keys[i]) );
+}
+
 /* queue a hardware message into a given thread input */
 static void queue_hardware_message( struct desktop *desktop, struct message *msg, int always_queue )
 {
@@ -1867,6 +1976,7 @@ static void queue_hardware_message( struct desktop *desktop, struct message *msg
     struct thread_input *input;
     struct hardware_msg_data *msg_data = msg->data;
     unsigned int msg_code;
+    int dcomp_authorized = 0;
     int flags, msg_bit;
 
     update_desktop_key_state( desktop, msg->msg, msg->wparam );
@@ -1876,7 +1986,15 @@ static void queue_hardware_message( struct desktop *desktop, struct message *msg
     switch ((msg_bit = get_hardware_msg_bit( msg->msg )))
     {
     case QS_KEY:
-        if (queue_hotkey_message( desktop, msg )) return;
+        dcomp_authorized = msg->dcomp_presentation &&
+                (is_dcomp_keyboard_input( msg->dcomp_presentation, msg->win ) ||
+                 (msg->dcomp_keyup && msg->dcomp_generation &&
+                  is_dcomp_presentation_active( msg->dcomp_presentation )));
+        if (queue_hotkey_message( desktop, msg ))
+        {
+            cancel_dcomp_key_owner( desktop, msg );
+            return;
+        }
         if (desktop_shm->keystate[VK_MENU] & 0x80) msg->lparam |= KF_ALTDOWN << 16;
         if (msg->wparam == VK_SHIFT || msg->wparam == VK_LSHIFT || msg->wparam == VK_RSHIFT)
             msg->lparam &= ~(KF_EXTENDED << 16);
@@ -1906,6 +2024,7 @@ static void queue_hardware_message( struct desktop *desktop, struct message *msg
     else input = desktop->foreground_input;
 
     win = find_hardware_message_window( desktop, input, msg, &msg_code, &thread );
+    if (msg_bit == QS_KEY && !dcomp_authorized) cancel_dcomp_key_owner( desktop, msg );
     flags = thread ? get_rawinput_device_flags( thread->process, msg ) : 0;
     if (thread) input = thread->queue->input;
     if (input && (get_hardware_msg_bit( msg->msg ) & (QS_KEY | QS_MOUSEBUTTON)))
@@ -1913,6 +2032,7 @@ static void queue_hardware_message( struct desktop *desktop, struct message *msg
 
     if (!win || !thread || (flags & RIDEV_NOLEGACY))
     {
+        if (msg_bit == QS_KEY) cancel_dcomp_key_owner( desktop, msg );
         if (input && !(flags & RIDEV_NOLEGACY)) update_thread_input_key_state( input, msg->msg, msg->wparam );
         free_message( msg );
         if (thread) release_object( thread );
@@ -2320,14 +2440,16 @@ static int queue_mouse_message( struct desktop *desktop, user_handle_t win, cons
 }
 
 static int queue_keyboard_message( struct desktop *desktop, user_handle_t win, const union hw_input *input,
-                                   unsigned int origin, struct msg_queue *sender, int repeat );
+                                   unsigned int origin, struct msg_queue *sender, int repeat,
+                                   user_handle_t dcomp_presentation );
 
 static void key_repeat_timeout( void *private )
 {
     struct desktop *desktop = private;
 
     desktop->key_repeat.timeout = NULL;
-    queue_keyboard_message( desktop, desktop->key_repeat.win, &desktop->key_repeat.input, IMO_HARDWARE, NULL, 1 );
+    queue_keyboard_message( desktop, desktop->key_repeat.win, &desktop->key_repeat.input,
+                            IMO_HARDWARE, NULL, 1, desktop->key_repeat.dcomp_presentation );
 }
 
 static void stop_key_repeat( struct desktop *desktop )
@@ -2335,12 +2457,14 @@ static void stop_key_repeat( struct desktop *desktop )
     if (desktop->key_repeat.timeout) remove_timeout_user( desktop->key_repeat.timeout );
     desktop->key_repeat.timeout = NULL;
     desktop->key_repeat.win = 0;
+    desktop->key_repeat.dcomp_presentation = 0;
     memset( &desktop->key_repeat.input, 0, sizeof(desktop->key_repeat.input) );
 }
 
 /* queue a hardware message for a keyboard event */
 static int queue_keyboard_message( struct desktop *desktop, user_handle_t win, const union hw_input *input,
-                                   unsigned int origin, struct msg_queue *sender, int repeat )
+                                   unsigned int origin, struct msg_queue *sender, int repeat,
+                                   user_handle_t dcomp_presentation )
 {
     desktop_shm_t *desktop_shm = desktop->shared;
     struct hw_msg_source source = { IMDT_KEYBOARD, origin };
@@ -2352,7 +2476,30 @@ static int queue_keyboard_message( struct desktop *desktop, user_handle_t win, c
     lparam_t lparam = input->kbd.scan << 16;
     unsigned int flags = 0;
     BOOL unicode = input->kbd.flags & KEYEVENTF_UNICODE;
+    struct dcomp_key_owner *key_owner = NULL;
+    unsigned short dcomp_scan = 0;
+    unsigned int dcomp_generation = 0;
+    int dcomp_keyup = 0;
     int wait;
+
+    if (origin == IMO_HARDWARE && !repeat && !unicode)
+    {
+        dcomp_scan = get_dcomp_key_scan( input );
+        key_owner = get_dcomp_key_owner( desktop, dcomp_scan );
+        if (input->kbd.flags & KEYEVENTF_KEYUP)
+        {
+            if (key_owner && key_owner->win == get_user_full_handle( win ) &&
+                is_dcomp_presentation_owner( key_owner->presentation, current->process ))
+            {
+                dcomp_presentation = key_owner->presentation;
+                dcomp_generation = key_owner->generation;
+                dcomp_keyup = 1;
+                memset( key_owner, 0, sizeof(*key_owner) );
+            }
+        }
+        else if (dcomp_presentation)
+            dcomp_generation = reserve_dcomp_key_owner( desktop, dcomp_scan, win, dcomp_presentation );
+    }
 
     if (!(time = input->kbd.time)) time = get_tick_count();
 
@@ -2458,6 +2605,7 @@ static int queue_keyboard_message( struct desktop *desktop, user_handle_t win, c
             desktop->key_repeat.input = *input;
             desktop->key_repeat.input.kbd.time = 0;
             desktop->key_repeat.win = win;
+            desktop->key_repeat.dcomp_presentation = dcomp_presentation;
             if (desktop->key_repeat.timeout) remove_timeout_user( desktop->key_repeat.timeout );
             desktop->key_repeat.timeout = add_timeout_user( timeout, key_repeat_timeout, desktop );
         }
@@ -2478,11 +2626,21 @@ static int queue_keyboard_message( struct desktop *desktop, user_handle_t win, c
         release_object( foreground );
     }
 
-    if (!(msg = alloc_hardware_message( input->kbd.info, source, time, 0 ))) return 0;
+    if (!(msg = alloc_hardware_message( input->kbd.info, source, time, 0 )))
+    {
+        if (dcomp_generation && !dcomp_keyup && key_owner &&
+            key_owner->generation == dcomp_generation)
+            memset( key_owner, 0, sizeof(*key_owner) );
+        return 0;
+    }
     msg_data = msg->data;
 
-    msg->win       = get_user_full_handle( win );
-    msg->msg       = message_code;
+    msg->win = get_user_full_handle( win );
+    msg->dcomp_presentation = dcomp_presentation;
+    msg->dcomp_scan = dcomp_scan;
+    msg->dcomp_generation = dcomp_generation;
+    msg->dcomp_keyup = dcomp_keyup;
+    msg->msg = message_code;
     if (origin == IMO_INJECTED) msg_data->flags = LLKHF_INJECTED;
 
     if (!unicode || input->kbd.vkey)
@@ -3191,6 +3349,21 @@ DECL_HANDLER(send_message)
         msg->data      = NULL;
         msg->data_size = get_req_data_size();
 
+        if (msg->msg == WM_COPYDATA && msg->win)
+        {
+            struct thread *window_thread = get_window_thread( msg->win );
+            if (window_thread != thread && get_dcomp_ime_message_authorization(
+                    (user_handle_t)msg->wparam, msg->win, current->process ))
+            {
+                if (window_thread) release_object( window_thread );
+                set_error( STATUS_INVALID_PARAMETER );
+                free( msg );
+                release_object( thread );
+                return;
+            }
+            if (window_thread) release_object( window_thread );
+        }
+
         get_message_defaults( recv_queue, &msg->x, &msg->y, &msg->time );
 
         if (msg->data_size && !(msg->data = memdup( get_req_data(), msg->data_size )))
@@ -3237,6 +3410,19 @@ DECL_HANDLER(send_message)
     release_object( thread );
 }
 
+/* Revalidate authorization at dispatch time, after relationship changes. */
+DECL_HANDLER(validate_dcomp_ime_message)
+{
+    struct message_result *result;
+    struct thread *receiver = current;
+
+    reply->authorization = 0;
+    if (!current->queue || !(result = current->queue->recv_result)) return;
+    if (result->dcomp_message == WM_COPYDATA)
+        reply->authorization = validate_dcomp_ime_message( result->dcomp_source,
+                result->dcomp_destination, result->sender_process, receiver );
+}
+
 /* send a hardware message to a thread queue */
 DECL_HANDLER(send_hardware_message)
 {
@@ -3266,7 +3452,8 @@ DECL_HANDLER(send_hardware_message)
         wait = queue_mouse_message( desktop, req->win, &req->input, origin, sender, rawinput );
         break;
     case INPUT_KEYBOARD:
-        wait = queue_keyboard_message( desktop, req->win, &req->input, origin, sender, 0 );
+        wait = queue_keyboard_message( desktop, req->win, &req->input, origin, sender, 0,
+                origin == IMO_HARDWARE ? get_dcomp_keyboard_presentation( req->win, current->process ) : 0 );
         break;
     case INPUT_HARDWARE:
         queue_custom_hardware_message( desktop, req->win, origin, &req->input );
@@ -3311,6 +3498,7 @@ DECL_HANDLER(get_message)
     }
 
     if (!queue) return;
+    reply->dcomp_ime_authorization = 0;
     queue_shm = queue->shared;
 
     /* check for any hardware internal message */

--- a/server/request_handlers.h
+++ b/server/request_handlers.h
@@ -137,6 +137,7 @@ DECL_HANDLER(get_message);
 DECL_HANDLER(reply_message);
 DECL_HANDLER(accept_hardware_message);
 DECL_HANDLER(get_message_reply);
+DECL_HANDLER(validate_dcomp_ime_message);
 DECL_HANDLER(set_win_timer);
 DECL_HANDLER(kill_win_timer);
 DECL_HANDLER(is_window_hung);
@@ -155,6 +156,10 @@ DECL_HANDLER(create_named_pipe);
 DECL_HANDLER(set_named_pipe_info);
 DECL_HANDLER(create_window);
 DECL_HANDLER(destroy_window);
+DECL_HANDLER(create_dcomp_ime_offer);
+DECL_HANDLER(set_dcomp_ime_relationship);
+DECL_HANDLER(revoke_dcomp_ime_offer);
+DECL_HANDLER(update_dcomp_task_delegate);
 DECL_HANDLER(update_window_broadcast_exclusion);
 DECL_HANDLER(get_window_broadcast_exclusion);
 DECL_HANDLER(get_desktop_window);
@@ -462,6 +467,7 @@ static const req_handler req_handlers[REQ_NB_REQUESTS] =
     (req_handler)req_reply_message,
     (req_handler)req_accept_hardware_message,
     (req_handler)req_get_message_reply,
+    (req_handler)req_validate_dcomp_ime_message,
     (req_handler)req_set_win_timer,
     (req_handler)req_kill_win_timer,
     (req_handler)req_is_window_hung,
@@ -480,6 +486,10 @@ static const req_handler req_handlers[REQ_NB_REQUESTS] =
     (req_handler)req_set_named_pipe_info,
     (req_handler)req_create_window,
     (req_handler)req_destroy_window,
+    (req_handler)req_create_dcomp_ime_offer,
+    (req_handler)req_set_dcomp_ime_relationship,
+    (req_handler)req_revoke_dcomp_ime_offer,
+    (req_handler)req_update_dcomp_task_delegate,
     (req_handler)req_update_window_broadcast_exclusion,
     (req_handler)req_get_window_broadcast_exclusion,
     (req_handler)req_get_desktop_window,
@@ -659,6 +669,7 @@ C_ASSERT( sizeof(abstime_t) == 8 );
 C_ASSERT( sizeof(affinity_t) == 8 );
 C_ASSERT( sizeof(apc_param_t) == 8 );
 C_ASSERT( sizeof(atom_t) == 4 );
+C_ASSERT( sizeof(capability_t) == 8 );
 C_ASSERT( sizeof(char) == 1 );
 C_ASSERT( sizeof(client_ptr_t) == 8 );
 C_ASSERT( sizeof(d3dkmt_handle_t) == 4 );
@@ -1432,10 +1443,11 @@ C_ASSERT( offsetof(struct get_message_reply, msg) == 12 );
 C_ASSERT( offsetof(struct get_message_reply, wparam) == 16 );
 C_ASSERT( offsetof(struct get_message_reply, lparam) == 24 );
 C_ASSERT( offsetof(struct get_message_reply, type) == 32 );
-C_ASSERT( offsetof(struct get_message_reply, x) == 36 );
-C_ASSERT( offsetof(struct get_message_reply, y) == 40 );
-C_ASSERT( offsetof(struct get_message_reply, time) == 44 );
-C_ASSERT( offsetof(struct get_message_reply, total) == 48 );
+C_ASSERT( offsetof(struct get_message_reply, dcomp_ime_authorization) == 36 );
+C_ASSERT( offsetof(struct get_message_reply, x) == 40 );
+C_ASSERT( offsetof(struct get_message_reply, y) == 44 );
+C_ASSERT( offsetof(struct get_message_reply, time) == 48 );
+C_ASSERT( offsetof(struct get_message_reply, total) == 52 );
 C_ASSERT( sizeof(struct get_message_reply) == 56 );
 C_ASSERT( offsetof(struct reply_message_request, remove) == 12 );
 C_ASSERT( offsetof(struct reply_message_request, result) == 16 );
@@ -1446,6 +1458,9 @@ C_ASSERT( offsetof(struct get_message_reply_request, cancel) == 12 );
 C_ASSERT( sizeof(struct get_message_reply_request) == 16 );
 C_ASSERT( offsetof(struct get_message_reply_reply, result) == 8 );
 C_ASSERT( sizeof(struct get_message_reply_reply) == 16 );
+C_ASSERT( sizeof(struct validate_dcomp_ime_message_request) == 16 );
+C_ASSERT( offsetof(struct validate_dcomp_ime_message_reply, authorization) == 8 );
+C_ASSERT( sizeof(struct validate_dcomp_ime_message_reply) == 16 );
 C_ASSERT( offsetof(struct set_win_timer_request, win) == 12 );
 C_ASSERT( offsetof(struct set_win_timer_request, msg) == 16 );
 C_ASSERT( offsetof(struct set_win_timer_request, rate) == 20 );
@@ -1551,6 +1566,24 @@ C_ASSERT( offsetof(struct create_window_reply, class_ptr) == 24 );
 C_ASSERT( sizeof(struct create_window_reply) == 32 );
 C_ASSERT( offsetof(struct destroy_window_request, handle) == 12 );
 C_ASSERT( sizeof(struct destroy_window_request) == 16 );
+C_ASSERT( offsetof(struct create_dcomp_ime_offer_request, presentation) == 12 );
+C_ASSERT( sizeof(struct create_dcomp_ime_offer_request) == 16 );
+C_ASSERT( offsetof(struct create_dcomp_ime_offer_reply, token_low) == 8 );
+C_ASSERT( offsetof(struct create_dcomp_ime_offer_reply, token_high) == 16 );
+C_ASSERT( sizeof(struct create_dcomp_ime_offer_reply) == 24 );
+C_ASSERT( offsetof(struct set_dcomp_ime_relationship_request, token_low) == 16 );
+C_ASSERT( offsetof(struct set_dcomp_ime_relationship_request, token_high) == 24 );
+C_ASSERT( offsetof(struct set_dcomp_ime_relationship_request, target) == 32 );
+C_ASSERT( sizeof(struct set_dcomp_ime_relationship_request) == 40 );
+C_ASSERT( offsetof(struct revoke_dcomp_ime_offer_request, token_low) == 16 );
+C_ASSERT( offsetof(struct revoke_dcomp_ime_offer_request, token_high) == 24 );
+C_ASSERT( sizeof(struct revoke_dcomp_ime_offer_request) == 32 );
+C_ASSERT( offsetof(struct update_dcomp_task_delegate_request, token_low) == 16 );
+C_ASSERT( offsetof(struct update_dcomp_task_delegate_request, token_high) == 24 );
+C_ASSERT( offsetof(struct update_dcomp_task_delegate_request, presentation) == 32 );
+C_ASSERT( offsetof(struct update_dcomp_task_delegate_request, target) == 36 );
+C_ASSERT( offsetof(struct update_dcomp_task_delegate_request, flags) == 40 );
+C_ASSERT( sizeof(struct update_dcomp_task_delegate_request) == 48 );
 C_ASSERT( offsetof(struct update_window_broadcast_exclusion_request, window) == 12 );
 C_ASSERT( offsetof(struct update_window_broadcast_exclusion_request, target) == 16 );
 C_ASSERT( offsetof(struct update_window_broadcast_exclusion_request, flags) == 20 );

--- a/server/request_trace.h
+++ b/server/request_trace.h
@@ -1529,6 +1529,7 @@ static void dump_get_message_reply( const struct get_message_reply *req )
     dump_uint64( ", wparam=", &req->wparam );
     dump_uint64( ", lparam=", &req->lparam );
     fprintf( stderr, ", type=%d", req->type );
+    fprintf( stderr, ", dcomp_ime_authorization=%08x", req->dcomp_ime_authorization );
     fprintf( stderr, ", x=%d", req->x );
     fprintf( stderr, ", y=%d", req->y );
     fprintf( stderr, ", time=%08x", req->time );
@@ -1557,6 +1558,15 @@ static void dump_get_message_reply_reply( const struct get_message_reply_reply *
 {
     dump_uint64( " result=", &req->result );
     dump_varargs_bytes( ", data=", cur_size );
+}
+
+static void dump_validate_dcomp_ime_message_request( const struct validate_dcomp_ime_message_request *req )
+{
+}
+
+static void dump_validate_dcomp_ime_message_reply( const struct validate_dcomp_ime_message_reply *req )
+{
+    fprintf( stderr, " authorization=%08x", req->authorization );
 }
 
 static void dump_set_win_timer_request( const struct set_win_timer_request *req )
@@ -1757,6 +1767,39 @@ static void dump_create_window_reply( const struct create_window_reply *req )
 static void dump_destroy_window_request( const struct destroy_window_request *req )
 {
     fprintf( stderr, " handle=%08x", req->handle );
+}
+
+static void dump_create_dcomp_ime_offer_request( const struct create_dcomp_ime_offer_request *req )
+{
+    fprintf( stderr, " presentation=%08x", req->presentation );
+}
+
+static void dump_create_dcomp_ime_offer_reply( const struct create_dcomp_ime_offer_reply *req )
+{
+    fprintf( stderr, " token_low=<redacted>" );
+    fprintf( stderr, ", token_high=<redacted>" );
+}
+
+static void dump_set_dcomp_ime_relationship_request( const struct set_dcomp_ime_relationship_request *req )
+{
+    fprintf( stderr, " token_low=<redacted>" );
+    fprintf( stderr, ", token_high=<redacted>" );
+    fprintf( stderr, ", target=%08x", req->target );
+}
+
+static void dump_revoke_dcomp_ime_offer_request( const struct revoke_dcomp_ime_offer_request *req )
+{
+    fprintf( stderr, " token_low=<redacted>" );
+    fprintf( stderr, ", token_high=<redacted>" );
+}
+
+static void dump_update_dcomp_task_delegate_request( const struct update_dcomp_task_delegate_request *req )
+{
+    fprintf( stderr, " token_low=<redacted>" );
+    fprintf( stderr, ", token_high=<redacted>" );
+    fprintf( stderr, ", presentation=%08x", req->presentation );
+    fprintf( stderr, ", target=%08x", req->target );
+    fprintf( stderr, ", flags=%08x", req->flags );
 }
 
 static void dump_update_window_broadcast_exclusion_request( const struct update_window_broadcast_exclusion_request *req )
@@ -3814,6 +3857,7 @@ static const dump_func req_dumpers[REQ_NB_REQUESTS] =
     (dump_func)dump_reply_message_request,
     (dump_func)dump_accept_hardware_message_request,
     (dump_func)dump_get_message_reply_request,
+    (dump_func)dump_validate_dcomp_ime_message_request,
     (dump_func)dump_set_win_timer_request,
     (dump_func)dump_kill_win_timer_request,
     (dump_func)dump_is_window_hung_request,
@@ -3832,6 +3876,10 @@ static const dump_func req_dumpers[REQ_NB_REQUESTS] =
     (dump_func)dump_set_named_pipe_info_request,
     (dump_func)dump_create_window_request,
     (dump_func)dump_destroy_window_request,
+    (dump_func)dump_create_dcomp_ime_offer_request,
+    (dump_func)dump_set_dcomp_ime_relationship_request,
+    (dump_func)dump_revoke_dcomp_ime_offer_request,
+    (dump_func)dump_update_dcomp_task_delegate_request,
     (dump_func)dump_update_window_broadcast_exclusion_request,
     (dump_func)dump_get_window_broadcast_exclusion_request,
     (dump_func)dump_get_desktop_window_request,
@@ -4139,6 +4187,7 @@ static const dump_func reply_dumpers[REQ_NB_REQUESTS] =
     NULL,
     NULL,
     (dump_func)dump_get_message_reply_reply,
+    (dump_func)dump_validate_dcomp_ime_message_reply,
     (dump_func)dump_set_win_timer_reply,
     NULL,
     (dump_func)dump_is_window_hung_reply,
@@ -4156,6 +4205,10 @@ static const dump_func reply_dumpers[REQ_NB_REQUESTS] =
     (dump_func)dump_create_named_pipe_reply,
     NULL,
     (dump_func)dump_create_window_reply,
+    NULL,
+    (dump_func)dump_create_dcomp_ime_offer_reply,
+    NULL,
+    NULL,
     NULL,
     (dump_func)dump_update_window_broadcast_exclusion_reply,
     (dump_func)dump_get_window_broadcast_exclusion_reply,
@@ -4464,6 +4517,7 @@ static const char * const req_names[REQ_NB_REQUESTS] =
     "reply_message",
     "accept_hardware_message",
     "get_message_reply",
+    "validate_dcomp_ime_message",
     "set_win_timer",
     "kill_win_timer",
     "is_window_hung",
@@ -4482,6 +4536,10 @@ static const char * const req_names[REQ_NB_REQUESTS] =
     "set_named_pipe_info",
     "create_window",
     "destroy_window",
+    "create_dcomp_ime_offer",
+    "set_dcomp_ime_relationship",
+    "revoke_dcomp_ime_offer",
+    "update_dcomp_task_delegate",
     "update_window_broadcast_exclusion",
     "get_window_broadcast_exclusion",
     "get_desktop_window",

--- a/server/user.h
+++ b/server/user.h
@@ -58,7 +58,17 @@ struct key_repeat
     timeout_t            period;           /* auto-repeat period */
     union hw_input       input;            /* the input to repeat */
     user_handle_t        win;              /* target window for input event */
+    user_handle_t        dcomp_presentation; /* authorized DComp presentation */
     struct timeout_user *timeout;          /* timeout for repeat */
+};
+
+#define DCOMP_KEY_COUNT 0x200
+
+struct dcomp_key_owner
+{
+    user_handle_t win;
+    user_handle_t presentation;
+    unsigned int generation;
 };
 
 struct desktop
@@ -83,6 +93,7 @@ struct desktop
     unsigned int         users;            /* processes and threads using this desktop */
     unsigned char        alt_pressed;      /* last key press was Alt (used to determine msg on release) */
     struct key_repeat    key_repeat;       /* key auto-repeat */
+    struct dcomp_key_owner dcomp_keys[DCOMP_KEY_COUNT]; /* authorized DComp key destinations */
     unsigned int         clip_flags;       /* last cursor clip flags */
     user_handle_t        cursor_win;       /* window that contains the cursor */
     desktop_shm_t       *shared;           /* desktop session shared memory */
@@ -136,6 +147,7 @@ extern void post_win_event( struct thread *thread, unsigned int event,
 extern void free_hotkeys( struct desktop *desktop, user_handle_t window );
 extern void free_pointers( struct desktop *desktop );
 extern void set_rawinput_process( struct process *process, int enable );
+extern void clear_dcomp_key_owners( struct desktop *desktop, user_handle_t presentation );
 
 /* region functions */
 
@@ -183,6 +195,22 @@ extern struct thread *get_window_thread( user_handle_t handle );
 extern user_handle_t shallow_window_from_point( struct desktop *desktop, int x, int y );
 extern struct thread *window_thread_from_point( user_handle_t scope, int x, int y );
 extern int is_direct_hardware_input_window( user_handle_t handle );
+extern user_handle_t get_dcomp_keyboard_presentation( user_handle_t destination,
+                                                      struct process *sender );
+extern int is_dcomp_presentation_owner( user_handle_t presentation, struct process *sender );
+extern int is_dcomp_presentation_active( user_handle_t presentation );
+extern int is_dcomp_keyboard_input( user_handle_t presentation, user_handle_t destination );
+extern unsigned int get_dcomp_ime_message_authorization( user_handle_t source,
+                                                         user_handle_t destination,
+                                                         struct process *sender );
+extern unsigned int validate_dcomp_ime_message( user_handle_t source,
+                                               user_handle_t destination,
+                                               struct process *sender,
+                                               struct thread *receiver );
+extern void cleanup_dcomp_ime_process( struct process *process );
+extern void cleanup_message_results_process( struct process *process );
+extern int is_current_set_parent_message( user_handle_t child, user_handle_t parent,
+                                          struct process *sender );
 extern user_handle_t find_window_to_repaint( user_handle_t parent, struct thread *thread );
 extern struct window_class *get_window_class( user_handle_t window );
 extern void set_window_rect_visible( user_handle_t window, struct rectangle rect );

--- a/server/window.c
+++ b/server/window.c
@@ -1025,7 +1025,7 @@ static void set_reserved_dcomp_property( struct window *win, enum dcomp_property
 
     if (free_slot == -1)
     {
-        assert( win->prop_inuse < win->prop_alloc );
+        if (!reserve_dcomp_properties( win, &id, 1 )) return;
         free_slot = win->prop_inuse++;
     }
     grab_atom( table, atom );

--- a/server/window.c
+++ b/server/window.c
@@ -21,7 +21,13 @@
 #include "config.h"
 
 #include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
 #include <stdarg.h>
+#include <unistd.h>
+#ifdef HAVE_SYS_RANDOM_H
+#include <sys/random.h>
+#endif
 
 #include "ntstatus.h"
 #include "windef.h"
@@ -57,6 +63,48 @@ enum property_type
 };
 
 
+#define MAX_DCOMP_IME_OFFERS 256
+
+struct dcomp_ime_relationship
+{
+    struct list      entry;
+    unsigned __int64 token_low;
+    unsigned __int64 token_high;
+    unsigned __int64 generation;
+    unsigned int     offer_refcount;
+    struct process  *presentation_process;
+    struct process  *browser_process;
+    struct window   *presentation;
+    struct window   *root;
+    struct window   *input;
+    struct window   *target;
+    user_handle_t    presentation_root;
+    user_handle_t    presentation_target;
+};
+
+struct dcomp_task_relationship
+{
+    struct list      entry;
+    unsigned __int64 generation;
+    unsigned int     flags;
+    struct window   *presentation;
+    struct window   *root;
+    struct window   *target;
+};
+
+static struct list dcomp_ime_relationships = LIST_INIT( dcomp_ime_relationships );
+static struct list dcomp_task_relationships = LIST_INIT( dcomp_task_relationships );
+static unsigned __int64 dcomp_ime_generation;
+static unsigned __int64 dcomp_task_generation;
+
+static void clear_dcomp_ime_properties( struct dcomp_ime_relationship *relationship );
+static void republish_dcomp_ime_root( struct window *root );
+static void republish_dcomp_ime_input( struct window *input );
+static void republish_dcomp_ime_presentation( struct window *presentation );
+static void republish_dcomp_task_root( struct window *root );
+static void republish_dcomp_task_target( struct window *target );
+static void cleanup_dcomp_task_relationships( struct window *win );
+
 struct window
 {
     struct object    obj;             /* object header */
@@ -86,6 +134,7 @@ struct window
     unsigned int     is_layered : 1;  /* has layered info been set? */
     unsigned int     is_orphan : 1;   /* is window orphaned */
     unsigned int     set_foreground : 1;/* has window been foreground once */
+    unsigned int     parent_owner_authorized : 1; /* parent owner established this edge */
     unsigned int     color_key;       /* color key for a layered window */
     unsigned int     alpha;           /* alpha value for a layered window */
     unsigned int     layered_flags;   /* flags for a layered window */
@@ -172,6 +221,308 @@ static inline struct window *get_window( user_handle_t handle )
     struct window *ret = get_user_object( handle, NTUSER_OBJ_WINDOW );
     if (!ret) set_win32_error( ERROR_INVALID_WINDOW_HANDLE );
     return ret;
+}
+
+static int fill_random_bytes( void *buffer, size_t size )
+{
+    unsigned char *ptr = buffer;
+    int fd;
+
+#ifdef HAVE_GETRANDOM
+    while (size)
+    {
+        ssize_t ret;
+
+        do ret = getrandom( ptr, size, 0 );
+        while (ret == -1 && errno == EINTR);
+        if (ret == -1)
+        {
+            if (errno == ENOSYS) break;
+            return 0;
+        }
+        if (!ret) return 0;
+        ptr += ret;
+        size -= ret;
+    }
+    if (!size) return 1;
+#endif
+
+    if ((fd = open( "/dev/urandom", O_RDONLY | O_CLOEXEC )) == -1) return 0;
+    while (size)
+    {
+        ssize_t ret;
+
+        do ret = read( fd, ptr, size );
+        while (ret == -1 && errno == EINTR);
+        if (ret <= 0)
+        {
+            close( fd );
+            return 0;
+        }
+        ptr += ret;
+        size -= ret;
+    }
+    close( fd );
+    return 1;
+}
+
+static struct dcomp_ime_relationship *find_dcomp_ime_relationship( unsigned __int64 token_low,
+                                                                  unsigned __int64 token_high )
+{
+    struct dcomp_ime_relationship *relationship;
+
+    if (!token_low && !token_high) return NULL;
+    LIST_FOR_EACH_ENTRY( relationship, &dcomp_ime_relationships, struct dcomp_ime_relationship, entry )
+        if (relationship->token_low == token_low && relationship->token_high == token_high)
+            return relationship;
+    return NULL;
+}
+
+static int generate_dcomp_ime_token( struct dcomp_ime_relationship *relationship )
+{
+    struct dcomp_ime_relationship *collision;
+
+    do
+    {
+        if (!fill_random_bytes( &relationship->token_low,
+                                sizeof(relationship->token_low) + sizeof(relationship->token_high) ))
+        {
+            relationship->token_low = relationship->token_high = 0;
+            set_error( STATUS_UNSUCCESSFUL );
+            return 0;
+        }
+        collision = find_dcomp_ime_relationship( relationship->token_low, relationship->token_high );
+    }
+    while ((!relationship->token_low && !relationship->token_high) ||
+           (collision && collision != relationship));
+    return 1;
+}
+
+static struct dcomp_ime_relationship *find_dcomp_ime_presentation( struct window *presentation )
+{
+    struct dcomp_ime_relationship *relationship;
+
+    LIST_FOR_EACH_ENTRY( relationship, &dcomp_ime_relationships, struct dcomp_ime_relationship, entry )
+        if (relationship->presentation == presentation) return relationship;
+    return NULL;
+}
+
+static void deactivate_dcomp_ime_relationship( struct dcomp_ime_relationship *relationship )
+{
+    struct window *root = relationship->root, *input = relationship->input;
+
+    clear_dcomp_ime_properties( relationship );
+    relationship->root = NULL;
+    relationship->input = NULL;
+    relationship->target = NULL;
+    relationship->presentation_root = 0;
+    relationship->presentation_target = 0;
+    relationship->generation = 0;
+    if (root) republish_dcomp_ime_root( root );
+    if (input) republish_dcomp_ime_input( input );
+    republish_dcomp_ime_presentation( relationship->presentation );
+}
+
+static void release_dcomp_ime_browser( struct dcomp_ime_relationship *relationship )
+{
+    deactivate_dcomp_ime_relationship( relationship );
+    if (!relationship->browser_process) return;
+    release_object( relationship->browser_process );
+    relationship->browser_process = NULL;
+}
+
+static void free_dcomp_ime_relationship( struct dcomp_ime_relationship *relationship )
+{
+    release_dcomp_ime_browser( relationship );
+    list_remove( &relationship->entry );
+    release_object( relationship->presentation_process );
+    free( relationship );
+}
+
+static int window_is_dcomp_ime_ancestor( struct window *win,
+                                        struct dcomp_ime_relationship *relationship )
+{
+    struct window *ancestor;
+
+    for (ancestor = relationship->input; ancestor; ancestor = ancestor->parent)
+    {
+        if (ancestor == win) return 1;
+        if (ancestor == relationship->root) break;
+    }
+    return 0;
+}
+
+static void invalidate_dcomp_ime_relationships( struct window *win )
+{
+    struct dcomp_ime_relationship *relationship;
+
+    LIST_FOR_EACH_ENTRY( relationship, &dcomp_ime_relationships, struct dcomp_ime_relationship, entry )
+        if (relationship->target == win || window_is_dcomp_ime_ancestor( win, relationship ))
+            deactivate_dcomp_ime_relationship( relationship );
+}
+
+static int window_is_dcomp_task_ancestor( struct window *win,
+                                          struct dcomp_task_relationship *relationship )
+{
+    struct window *ancestor;
+
+    for (ancestor = relationship->target; ancestor; ancestor = ancestor->parent)
+    {
+        if (ancestor == win) return 1;
+        if (ancestor == relationship->root) break;
+    }
+    return 0;
+}
+
+static void remove_dcomp_task_relationship( struct dcomp_task_relationship *relationship )
+{
+    struct window *root = relationship->root, *target = relationship->target;
+
+    list_remove( &relationship->entry );
+    free( relationship );
+    republish_dcomp_task_target( target );
+    republish_dcomp_task_root( root );
+}
+
+static void invalidate_dcomp_task_relationships( struct window *win )
+{
+    struct dcomp_task_relationship *relationship, *next;
+
+    LIST_FOR_EACH_ENTRY_SAFE( relationship, next, &dcomp_task_relationships,
+                              struct dcomp_task_relationship, entry )
+        if (window_is_dcomp_task_ancestor( win, relationship ))
+            remove_dcomp_task_relationship( relationship );
+}
+
+static void cleanup_dcomp_task_presentation( struct window *presentation )
+{
+    struct dcomp_task_relationship *relationship, *next;
+
+    LIST_FOR_EACH_ENTRY_SAFE( relationship, next, &dcomp_task_relationships,
+                              struct dcomp_task_relationship, entry )
+        if (relationship->presentation == presentation)
+            remove_dcomp_task_relationship( relationship );
+}
+
+static void cleanup_dcomp_ime_relationships( struct window *win )
+{
+    struct dcomp_ime_relationship *relationship, *next;
+
+    LIST_FOR_EACH_ENTRY_SAFE( relationship, next, &dcomp_ime_relationships,
+                              struct dcomp_ime_relationship, entry )
+    {
+        if (relationship->presentation == win)
+        {
+            clear_dcomp_key_owners( win->desktop, win->handle );
+            free_dcomp_ime_relationship( relationship );
+        }
+        else if (relationship->target == win || window_is_dcomp_ime_ancestor( win, relationship ))
+            deactivate_dcomp_ime_relationship( relationship );
+    }
+}
+
+void cleanup_dcomp_ime_process( struct process *process )
+{
+    struct dcomp_ime_relationship *relationship, *next;
+
+    LIST_FOR_EACH_ENTRY_SAFE( relationship, next, &dcomp_ime_relationships,
+                              struct dcomp_ime_relationship, entry )
+    {
+        if (relationship->presentation_process == process)
+        {
+            clear_dcomp_key_owners( relationship->presentation->desktop,
+                                    relationship->presentation->handle );
+            free_dcomp_ime_relationship( relationship );
+        }
+        else if (relationship->browser_process == process)
+            release_dcomp_ime_browser( relationship );
+    }
+}
+
+user_handle_t get_dcomp_keyboard_presentation( user_handle_t destination_handle,
+                                                struct process *sender )
+{
+    struct dcomp_ime_relationship *relationship;
+    struct window *destination = get_user_object( destination_handle, NTUSER_OBJ_WINDOW );
+
+    if (!destination || !sender) return 0;
+    LIST_FOR_EACH_ENTRY( relationship, &dcomp_ime_relationships, struct dcomp_ime_relationship, entry )
+        if (relationship->input == destination && relationship->presentation_process == sender)
+            return relationship->presentation->handle;
+    return 0;
+}
+
+int is_dcomp_presentation_owner( user_handle_t presentation_handle, struct process *sender )
+{
+    struct dcomp_ime_relationship *relationship;
+    struct window *presentation = get_user_object( presentation_handle, NTUSER_OBJ_WINDOW );
+
+    if (!presentation || !sender) return 0;
+    LIST_FOR_EACH_ENTRY( relationship, &dcomp_ime_relationships, struct dcomp_ime_relationship, entry )
+        if (relationship->presentation == presentation && relationship->presentation_process == sender)
+            return 1;
+    return 0;
+}
+
+int is_dcomp_presentation_active( user_handle_t presentation_handle )
+{
+    struct dcomp_ime_relationship *relationship;
+    struct window *presentation = get_user_object( presentation_handle, NTUSER_OBJ_WINDOW );
+
+    if (!presentation) return 0;
+    LIST_FOR_EACH_ENTRY( relationship, &dcomp_ime_relationships, struct dcomp_ime_relationship, entry )
+        if (relationship->presentation == presentation && relationship->offer_refcount) return 1;
+    return 0;
+}
+
+int is_dcomp_keyboard_input( user_handle_t presentation_handle, user_handle_t destination_handle )
+{
+    struct dcomp_ime_relationship *relationship;
+    struct window *presentation = get_user_object( presentation_handle, NTUSER_OBJ_WINDOW );
+    struct window *destination = get_user_object( destination_handle, NTUSER_OBJ_WINDOW );
+
+    if (!presentation || !destination) return 0;
+    LIST_FOR_EACH_ENTRY( relationship, &dcomp_ime_relationships, struct dcomp_ime_relationship, entry )
+        if (relationship->presentation == presentation && relationship->input == destination)
+            return 1;
+    return 0;
+}
+
+unsigned int get_dcomp_ime_message_authorization( user_handle_t source_handle,
+                                                   user_handle_t destination_handle,
+                                                   struct process *sender )
+{
+    struct dcomp_ime_relationship *relationship;
+    struct window *source = get_user_object( source_handle, NTUSER_OBJ_WINDOW );
+    struct window *destination = get_user_object( destination_handle, NTUSER_OBJ_WINDOW );
+
+    if (!source || !destination || !sender) return 0;
+    LIST_FOR_EACH_ENTRY( relationship, &dcomp_ime_relationships, struct dcomp_ime_relationship, entry )
+    {
+        if (!relationship->browser_process) continue;
+        if (relationship->presentation == source && relationship->input == destination &&
+            relationship->presentation_process == sender)
+            return DCOMP_IME_AUTHORIZE_UPDATE;
+        if (relationship->root == source && relationship->presentation == destination &&
+            relationship->browser_process == sender)
+            return DCOMP_IME_AUTHORIZE_SET_RECT;
+    }
+    return 0;
+}
+
+unsigned int validate_dcomp_ime_message( user_handle_t source_handle,
+                                         user_handle_t destination_handle,
+                                         struct process *sender,
+                                         struct thread *receiver )
+{
+    struct thread *window_thread;
+    unsigned int authorization;
+
+    if (!receiver || !(window_thread = get_window_thread( destination_handle ))) return 0;
+    authorization = window_thread == receiver ?
+            get_dcomp_ime_message_authorization( source_handle, destination_handle, sender ) : 0;
+    release_object( window_thread );
+    return authorization;
 }
 
 /* check if window is the desktop */
@@ -411,6 +762,9 @@ static int set_parent_window( struct window *win, struct window *parent )
         }
     }
 
+    invalidate_dcomp_ime_relationships( win );
+    invalidate_dcomp_task_relationships( win );
+
     if (parent)
     {
         if (win->parent) release_object( win->parent );
@@ -547,6 +901,472 @@ static lparam_t get_property( struct window *win, atom_t atom )
     return 0;
 }
 
+static const WCHAR dcomp_inputW[] = {'_','_','w','i','n','e','_','d','c','o','m','p','_',
+                                     'i','n','p','u','t','_','w','i','n','d','o','w'};
+static const WCHAR dcomp_keyboardW[] = {'_','_','w','i','n','e','_','d','c','o','m','p','_',
+                                        'k','e','y','b','o','a','r','d','_','w','i','n','d','o','w'};
+static const WCHAR direct_inputW[] = {'_','_','w','i','n','e','_','d','i','r','e','c','t','_',
+                                      'h','a','r','d','w','a','r','e','_','i','n','p','u','t'};
+static const WCHAR direct_ownerW[] = {'_','_','w','i','n','e','_','d','i','r','e','c','t','_',
+                                      'h','a','r','d','w','a','r','e','_','i','n','p','u','t','_',
+                                      'o','w','n','e','r'};
+static const WCHAR base_presentationW[] = {'_','_','w','i','n','e','_','d','c','o','m','p','_',
+                                           'b','a','s','e','_','p','r','e','s','e','n','t','a','t','i','o','n'};
+static const WCHAR task_delegatedW[] = {'_','_','w','i','n','e','_','d','c','o','m','p','_',
+                                        't','a','s','k','_','d','e','l','e','g','a','t','e','d'};
+static const WCHAR task_targetW[] = {'_','_','w','i','n','e','_','d','c','o','m','p','_',
+                                     't','a','s','k','_','d','e','l','e','g','a','t','e','d','_',
+                                     't','a','r','g','e','t'};
+
+enum dcomp_property_id
+{
+    DCOMP_PROPERTY_INPUT,
+    DCOMP_PROPERTY_KEYBOARD,
+    DCOMP_PROPERTY_DIRECT_INPUT,
+    DCOMP_PROPERTY_DIRECT_OWNER,
+    DCOMP_PROPERTY_BASE_PRESENTATION,
+    DCOMP_PROPERTY_TASK_DELEGATED,
+    DCOMP_PROPERTY_TASK_TARGET,
+    DCOMP_PROPERTY_COUNT,
+};
+
+static const struct
+{
+    const WCHAR *name;
+    data_size_t size;
+} dcomp_property_names[DCOMP_PROPERTY_COUNT] =
+{
+    {dcomp_inputW, sizeof(dcomp_inputW)},
+    {dcomp_keyboardW, sizeof(dcomp_keyboardW)},
+    {direct_inputW, sizeof(direct_inputW)},
+    {direct_ownerW, sizeof(direct_ownerW)},
+    {base_presentationW, sizeof(base_presentationW)},
+    {task_delegatedW, sizeof(task_delegatedW)},
+    {task_targetW, sizeof(task_targetW)},
+};
+
+static atom_t dcomp_property_atoms[DCOMP_PROPERTY_COUNT];
+
+static atom_t get_dcomp_property_atom( const WCHAR *name, data_size_t size, int create )
+{
+    const struct unicode_str str = {name, size};
+    struct atom_table *table = get_global_atom_table();
+
+    return create ? add_atom( table, &str ) : find_atom( table, &str );
+}
+
+static int init_dcomp_property_atoms(void)
+{
+    unsigned int i;
+
+    for (i = 0; i < DCOMP_PROPERTY_COUNT; i++)
+    {
+        if (dcomp_property_atoms[i]) continue;
+        if (!(dcomp_property_atoms[i] = get_dcomp_property_atom( dcomp_property_names[i].name,
+                                                                 dcomp_property_names[i].size, 1 )))
+            return 0;
+    }
+    return 1;
+}
+
+static int reserve_dcomp_properties( struct window *win, const enum dcomp_property_id *ids,
+                                     unsigned int count )
+{
+    struct property *new_properties;
+    unsigned int active = 0, missing = 0, i, j;
+    int new_alloc;
+
+    for (i = 0; i < win->prop_inuse; i++)
+        if (win->properties[i].type != PROP_TYPE_FREE) active++;
+
+    for (i = 0; i < count; i++)
+    {
+        for (j = 0; j < win->prop_inuse; j++)
+            if (win->properties[j].type != PROP_TYPE_FREE &&
+                win->properties[j].atom == dcomp_property_atoms[ids[i]]) break;
+        if (j == win->prop_inuse) missing++;
+    }
+    if (active + missing <= win->prop_alloc) return 1;
+
+    new_alloc = win->prop_alloc;
+    while (active + missing > new_alloc) new_alloc += 16;
+    if (!(new_properties = realloc( win->properties, sizeof(*new_properties) * new_alloc )))
+    {
+        set_error( STATUS_NO_MEMORY );
+        return 0;
+    }
+    win->properties = new_properties;
+    win->prop_alloc = new_alloc;
+    return 1;
+}
+
+static void set_reserved_dcomp_property( struct window *win, enum dcomp_property_id id,
+                                         lparam_t value )
+{
+    struct atom_table *table = get_global_atom_table();
+    atom_t atom = dcomp_property_atoms[id];
+    int free_slot = -1, i;
+
+    for (i = 0; i < win->prop_inuse; i++)
+    {
+        struct property *property = win->properties + i;
+
+        if (property->type == PROP_TYPE_FREE)
+        {
+            if (free_slot == -1) free_slot = i;
+            continue;
+        }
+        if (property->atom != atom) continue;
+        if (property->type != PROP_TYPE_STRING) grab_atom( table, atom );
+        property->type = PROP_TYPE_STRING;
+        property->data = value;
+        return;
+    }
+
+    if (free_slot == -1)
+    {
+        assert( win->prop_inuse < win->prop_alloc );
+        free_slot = win->prop_inuse++;
+    }
+    grab_atom( table, atom );
+    win->properties[free_slot].atom = atom;
+    win->properties[free_slot].type = PROP_TYPE_STRING;
+    win->properties[free_slot].data = value;
+}
+
+static void remove_reserved_dcomp_property( struct window *win, enum dcomp_property_id id )
+{
+    atom_t atom = dcomp_property_atoms[id];
+
+    if (win && atom) remove_property( win, atom );
+}
+
+static lparam_t get_dcomp_property( struct window *win, const WCHAR *name, data_size_t size )
+{
+    atom_t atom;
+    lparam_t value = 0;
+
+    if (win && (atom = get_dcomp_property_atom( name, size, 0 ))) value = get_property( win, atom );
+    clear_error();
+    return value;
+}
+
+static void remove_dcomp_property( struct window *win, const WCHAR *name, data_size_t size,
+                                   lparam_t value )
+{
+    atom_t atom;
+
+    if (win && (atom = get_dcomp_property_atom( name, size, 0 )) &&
+        get_property( win, atom ) == value)
+        remove_property( win, atom );
+    clear_error();
+}
+
+static int prepare_dcomp_ime_publication( struct window *presentation, struct window *root,
+                                          struct window *input )
+{
+    static const enum dcomp_property_id presentation_ids[] =
+        {DCOMP_PROPERTY_INPUT, DCOMP_PROPERTY_KEYBOARD};
+    static const enum dcomp_property_id input_ids[] =
+        {DCOMP_PROPERTY_DIRECT_INPUT, DCOMP_PROPERTY_DIRECT_OWNER};
+
+    return init_dcomp_property_atoms() &&
+           reserve_dcomp_properties( presentation, presentation_ids, ARRAY_SIZE(presentation_ids) ) &&
+           reserve_dcomp_properties( root, presentation_ids, ARRAY_SIZE(presentation_ids) ) &&
+           reserve_dcomp_properties( input, input_ids, ARRAY_SIZE(input_ids) );
+}
+
+static void clear_dcomp_ime_properties( struct dcomp_ime_relationship *relationship )
+{
+    lparam_t input, owner, presentation;
+    unsigned int error = get_error();
+
+    if (!relationship->input) return;
+    input = relationship->input->handle;
+    presentation = relationship->presentation->handle;
+    owner = get_dcomp_property( relationship->input, direct_ownerW, sizeof(direct_ownerW) );
+    remove_dcomp_property( relationship->presentation, dcomp_inputW, sizeof(dcomp_inputW), input );
+    remove_dcomp_property( relationship->presentation, dcomp_keyboardW, sizeof(dcomp_keyboardW), input );
+    if (!owner || owner == presentation)
+    {
+        remove_dcomp_property( relationship->root, dcomp_inputW, sizeof(dcomp_inputW), input );
+        remove_dcomp_property( relationship->root, dcomp_keyboardW, sizeof(dcomp_keyboardW), input );
+        remove_dcomp_property( relationship->input, direct_inputW, sizeof(direct_inputW), 0x57444952 );
+        remove_dcomp_property( relationship->input, direct_ownerW, sizeof(direct_ownerW), presentation );
+    }
+    set_error( error );
+}
+
+static struct dcomp_ime_relationship *find_dcomp_root_winner( struct window *root )
+{
+    struct dcomp_ime_relationship *rel, *winner = NULL;
+
+    LIST_FOR_EACH_ENTRY( rel, &dcomp_ime_relationships, struct dcomp_ime_relationship, entry )
+        if (rel->root == root && rel->generation && (!winner || rel->generation > winner->generation))
+            winner = rel;
+    return winner;
+}
+
+static struct dcomp_ime_relationship *find_dcomp_input_winner( struct window *input )
+{
+    struct dcomp_ime_relationship *rel, *winner = NULL;
+
+    LIST_FOR_EACH_ENTRY( rel, &dcomp_ime_relationships, struct dcomp_ime_relationship, entry )
+        if (rel->input == input && rel->generation && (!winner || rel->generation > winner->generation))
+            winner = rel;
+    return winner;
+}
+
+static struct dcomp_ime_relationship *find_dcomp_presentation_winner( struct window *presentation )
+{
+    struct dcomp_ime_relationship *rel, *winner = NULL;
+
+    LIST_FOR_EACH_ENTRY( rel, &dcomp_ime_relationships, struct dcomp_ime_relationship, entry )
+        if (rel->presentation == presentation && rel->generation &&
+            (!winner || rel->generation > winner->generation))
+            winner = rel;
+    return winner;
+}
+
+static void republish_dcomp_ime_root( struct window *root )
+{
+    struct dcomp_ime_relationship *winner = find_dcomp_root_winner( root );
+
+    remove_reserved_dcomp_property( root, DCOMP_PROPERTY_INPUT );
+    remove_reserved_dcomp_property( root, DCOMP_PROPERTY_KEYBOARD );
+    if (!winner) return;
+    set_reserved_dcomp_property( root, DCOMP_PROPERTY_INPUT, winner->input->handle );
+    set_reserved_dcomp_property( root, DCOMP_PROPERTY_KEYBOARD, winner->input->handle );
+}
+
+static void republish_dcomp_ime_input( struct window *input )
+{
+    struct dcomp_ime_relationship *winner = find_dcomp_input_winner( input );
+
+    remove_reserved_dcomp_property( input, DCOMP_PROPERTY_DIRECT_INPUT );
+    remove_reserved_dcomp_property( input, DCOMP_PROPERTY_DIRECT_OWNER );
+    if (!winner) return;
+    set_reserved_dcomp_property( input, DCOMP_PROPERTY_DIRECT_INPUT, 0x57444952 );
+    set_reserved_dcomp_property( input, DCOMP_PROPERTY_DIRECT_OWNER, winner->presentation->handle );
+}
+
+static void republish_dcomp_ime_presentation( struct window *presentation )
+{
+    struct dcomp_ime_relationship *winner = find_dcomp_presentation_winner( presentation );
+
+    remove_reserved_dcomp_property( presentation, DCOMP_PROPERTY_INPUT );
+    remove_reserved_dcomp_property( presentation, DCOMP_PROPERTY_KEYBOARD );
+    if (!winner) return;
+    set_reserved_dcomp_property( presentation, DCOMP_PROPERTY_INPUT, winner->input->handle );
+    set_reserved_dcomp_property( presentation, DCOMP_PROPERTY_KEYBOARD, winner->input->handle );
+}
+
+static struct dcomp_task_relationship *find_dcomp_task_winner( struct window *window,
+                                                               unsigned int flag )
+{
+    struct dcomp_task_relationship *rel, *winner = NULL;
+
+    LIST_FOR_EACH_ENTRY( rel, &dcomp_task_relationships, struct dcomp_task_relationship, entry )
+    {
+        if (!(rel->flags & flag)) continue;
+        if ((flag == DCOMP_TASK_DELEGATE_BASE && rel->target != window) ||
+            (flag == DCOMP_TASK_DELEGATE_TASK && rel->root != window)) continue;
+        if (!winner || rel->generation > winner->generation) winner = rel;
+    }
+    return winner;
+}
+
+static void republish_dcomp_task_target( struct window *target )
+{
+    struct dcomp_task_relationship *winner =
+        find_dcomp_task_winner( target, DCOMP_TASK_DELEGATE_BASE );
+
+    remove_reserved_dcomp_property( target, DCOMP_PROPERTY_BASE_PRESENTATION );
+    if (winner)
+        set_reserved_dcomp_property( target, DCOMP_PROPERTY_BASE_PRESENTATION,
+                                     winner->presentation->handle );
+}
+
+static void republish_dcomp_task_root( struct window *root )
+{
+    struct dcomp_task_relationship *winner =
+        find_dcomp_task_winner( root, DCOMP_TASK_DELEGATE_TASK );
+
+    remove_reserved_dcomp_property( root, DCOMP_PROPERTY_TASK_DELEGATED );
+    remove_reserved_dcomp_property( root, DCOMP_PROPERTY_TASK_TARGET );
+    if (!winner) return;
+    set_reserved_dcomp_property( root, DCOMP_PROPERTY_TASK_DELEGATED,
+                                 winner->presentation->handle );
+    set_reserved_dcomp_property( root, DCOMP_PROPERTY_TASK_TARGET, winner->target->handle );
+}
+
+static int prepare_dcomp_task_publication( struct window *root, struct window *target,
+                                           unsigned int flags )
+{
+    static const enum dcomp_property_id base_id[] = {DCOMP_PROPERTY_BASE_PRESENTATION};
+    static const enum dcomp_property_id task_ids[] =
+        {DCOMP_PROPERTY_TASK_DELEGATED, DCOMP_PROPERTY_TASK_TARGET};
+
+    if (!init_dcomp_property_atoms()) return 0;
+    if ((flags & DCOMP_TASK_DELEGATE_BASE) &&
+        !reserve_dcomp_properties( target, base_id, ARRAY_SIZE(base_id) )) return 0;
+    if ((flags & DCOMP_TASK_DELEGATE_TASK) &&
+        !reserve_dcomp_properties( root, task_ids, ARRAY_SIZE(task_ids) )) return 0;
+    return 1;
+}
+
+static void cleanup_dcomp_task_relationships( struct window *win )
+{
+    struct dcomp_task_relationship *rel, *next;
+
+    LIST_FOR_EACH_ENTRY_SAFE( rel, next, &dcomp_task_relationships,
+                              struct dcomp_task_relationship, entry )
+    {
+        if (rel->presentation != win && rel->root != win && rel->target != win) continue;
+        remove_dcomp_task_relationship( rel );
+    }
+}
+
+static int get_dcomp_task_ancestry( struct window *target, struct window **input,
+                                    struct window **root )
+{
+    struct window *child = target, *parent;
+
+    *input = *root = NULL;
+    while ((parent = child->parent) && !is_desktop_window( parent ))
+    {
+        if (parent->desktop != target->desktop || !child->thread || !parent->thread ||
+            (child->thread->process != parent->thread->process &&
+             !child->parent_owner_authorized)) return 0;
+        if (!*input) *input = parent;
+        *root = parent;
+        child = parent;
+    }
+    return *input != NULL;
+}
+
+DECL_HANDLER(update_dcomp_task_delegate)
+{
+    const unsigned int valid_flags = DCOMP_TASK_DELEGATE_BASE | DCOMP_TASK_DELEGATE_TASK;
+    struct dcomp_task_relationship *task_rel = NULL, *new_task_rel = NULL, *rel;
+    struct dcomp_ime_relationship *relationship;
+    struct window *presentation, *target = NULL, *input = NULL, *root = NULL;
+    struct window *old_task_root = NULL, *old_task_target = NULL;
+    struct window *old_ime_root = NULL, *old_ime_input = NULL;
+    int browser_binding, presentation_binding, input_binding;
+
+    if (req->flags & ~valid_flags || (!req->target && req->flags))
+    {
+        set_error( STATUS_INVALID_PARAMETER );
+        return;
+    }
+    if (!(relationship = find_dcomp_ime_relationship( req->token_low, req->token_high )))
+    {
+        set_error( STATUS_NOT_FOUND );
+        return;
+    }
+    if (!(presentation = get_window( req->presentation ))) return;
+    if (relationship->presentation != presentation)
+    {
+        set_error( STATUS_ACCESS_DENIED );
+        return;
+    }
+    browser_binding = relationship->presentation_process != current->process;
+    presentation_binding = !browser_binding && !relationship->browser_process;
+    input_binding = browser_binding || presentation_binding;
+    if (browser_binding && relationship->browser_process &&
+        relationship->browser_process != current->process)
+    {
+        set_error( STATUS_ACCESS_DENIED );
+        return;
+    }
+
+    LIST_FOR_EACH_ENTRY( rel, &dcomp_task_relationships, struct dcomp_task_relationship, entry )
+        if (rel->presentation == presentation)
+        {
+            task_rel = rel;
+            break;
+        }
+
+    if (req->target)
+    {
+        if (!(target = get_window( req->target ))) return;
+        if (!target->thread || target->thread->process != current->process ||
+            !get_dcomp_task_ancestry( target, &input, &root ) ||
+            root->desktop != presentation->desktop)
+        {
+            set_error( STATUS_ACCESS_DENIED );
+            return;
+        }
+        if (input_binding && !prepare_dcomp_ime_publication( presentation, root, input )) return;
+        if (req->flags && !prepare_dcomp_task_publication( root, target, req->flags )) return;
+        if (req->flags && (!task_rel || task_rel->root != root || task_rel->target != target) &&
+            !(new_task_rel = mem_alloc( sizeof(*new_task_rel) ))) return;
+    }
+
+    if (task_rel)
+    {
+        old_task_root = task_rel->root;
+        old_task_target = task_rel->target;
+    }
+    if (!req->target || !req->flags || new_task_rel)
+    {
+        if (task_rel)
+        {
+            list_remove( &task_rel->entry );
+            free( task_rel );
+            task_rel = NULL;
+        }
+        if (new_task_rel)
+        {
+            new_task_rel->generation = ++dcomp_task_generation;
+            new_task_rel->flags = req->flags;
+            new_task_rel->presentation = presentation;
+            new_task_rel->root = root;
+            new_task_rel->target = target;
+            list_add_tail( &dcomp_task_relationships, &new_task_rel->entry );
+            task_rel = new_task_rel;
+        }
+    }
+    else if (task_rel)
+    {
+        task_rel->flags = req->flags;
+        task_rel->generation = ++dcomp_task_generation;
+    }
+
+    if (!req->target)
+    {
+        deactivate_dcomp_ime_relationship( relationship );
+        if (old_task_target) republish_dcomp_task_target( old_task_target );
+        if (old_task_root) republish_dcomp_task_root( old_task_root );
+        return;
+    }
+
+    if (input_binding)
+    {
+        old_ime_root = relationship->root;
+        old_ime_input = relationship->input;
+        relationship->root = root;
+        relationship->input = input;
+        relationship->target = target;
+        relationship->presentation_root = root->handle;
+        relationship->presentation_target = target->handle;
+        relationship->generation = ++dcomp_ime_generation;
+        if (browser_binding && !relationship->browser_process)
+            relationship->browser_process = (struct process *)grab_object( current->process );
+
+        if (old_ime_root && old_ime_root != root) republish_dcomp_ime_root( old_ime_root );
+        republish_dcomp_ime_root( root );
+        if (old_ime_input && old_ime_input != input) republish_dcomp_ime_input( old_ime_input );
+        republish_dcomp_ime_input( input );
+        republish_dcomp_ime_presentation( presentation );
+    }
+    if (old_task_target && old_task_target != target) republish_dcomp_task_target( old_task_target );
+    republish_dcomp_task_target( target );
+    if (old_task_root && old_task_root != root) republish_dcomp_task_root( old_task_root );
+    republish_dcomp_task_root( root );
+}
+
 /* destroy all properties of a window */
 static inline void destroy_properties( struct window *win )
 {
@@ -664,6 +1484,8 @@ static struct window *create_window( struct window *parent, struct window *owner
     win->is_layered     = 0;
     win->is_orphan      = 0;
     win->set_foreground = 0;
+    win->parent_owner_authorized = parent && parent->thread &&
+                                   parent->thread->process == current->process;
     win->text           = NULL;
     win->text_len       = 0;
     win->paint_flags    = 0;
@@ -1011,11 +1833,10 @@ static struct window *child_window_from_point( struct window *parent, int x, int
 
 static int window_has_direct_hardware_input( struct window *win )
 {
-    int i;
+    struct dcomp_ime_relationship *relationship;
 
-    for (i = 0; i < win->prop_inuse; i++)
-        if (win->properties[i].type != PROP_TYPE_FREE &&
-            win->properties[i].data == 0x57444952) return 1;
+    LIST_FOR_EACH_ENTRY( relationship, &dcomp_ime_relationships, struct dcomp_ime_relationship, entry )
+        if (relationship->input == win) return 1;
     return 0;
 }
 
@@ -2208,6 +3029,8 @@ void free_window_handle( struct window *win )
     if (win == win->desktop->taskman_window) win->desktop->taskman_window = NULL;
     free_hotkeys( win->desktop, win->handle );
     cleanup_clipboard_window( win->desktop, win->handle );
+    cleanup_dcomp_ime_relationships( win );
+    cleanup_dcomp_task_relationships( win );
     destroy_properties( win );
     if (is_desktop_window(win))
     {
@@ -2356,18 +3179,26 @@ DECL_HANDLER(set_window_fnid)
 DECL_HANDLER(set_parent)
 {
     struct window *win, *parent = NULL;
+    int parent_owner_authorized;
 
     if (!(win = get_window( req->handle ))) return;
     if (req->parent && !(parent = get_window( req->parent ))) return;
+    parent_owner_authorized = parent == win->parent && win->parent_owner_authorized;
 
     if (is_desktop_window(win) || is_orphan_window( win ) || (parent && is_orphan_window( parent )))
     {
         set_error( STATUS_INVALID_PARAMETER );
         return;
     }
+    if (parent && parent->thread)
+        parent_owner_authorized = parent_owner_authorized ||
+                parent->thread->process == current->process ||
+                is_current_set_parent_message( win->handle, parent->handle,
+                                               parent->thread->process );
     reply->old_parent  = win->parent->handle;
     reply->full_parent = parent ? parent->handle : 0;
-    set_parent_window( win, parent );
+    if (set_parent_window( win, parent ))
+        win->parent_owner_authorized = parent_owner_authorized;
 }
 
 
@@ -2387,6 +3218,140 @@ DECL_HANDLER(destroy_window)
         else set_error( STATUS_ACCESS_DENIED );
     }
 }
+DECL_HANDLER(create_dcomp_ime_offer)
+{
+    struct dcomp_ime_relationship *relationship;
+    struct window *presentation;
+
+    reply->token_low = reply->token_high = 0;
+    if (!(presentation = get_window( req->presentation ))) return;
+    if (!presentation->thread || presentation->thread->process != current->process)
+    {
+        set_error( STATUS_ACCESS_DENIED );
+        return;
+    }
+    if ((relationship = find_dcomp_ime_presentation( presentation )))
+    {
+        if (!relationship->offer_refcount)
+        {
+            if (!generate_dcomp_ime_token( relationship )) return;
+            relationship->offer_refcount = 1;
+        }
+        else
+        {
+            if (relationship->offer_refcount == MAX_DCOMP_IME_OFFERS)
+            {
+                set_error( STATUS_INSUFFICIENT_RESOURCES );
+                return;
+            }
+            relationship->offer_refcount++;
+        }
+        reply->token_low = relationship->token_low;
+        reply->token_high = relationship->token_high;
+        return;
+    }
+    if (!(relationship = mem_alloc( sizeof(*relationship) ))) return;
+    relationship->token_low = relationship->token_high = 0;
+    if (!generate_dcomp_ime_token( relationship ))
+    {
+        free( relationship );
+        return;
+    }
+
+    relationship->generation = 0;
+    relationship->offer_refcount = 1;
+    relationship->presentation_process = (struct process *)grab_object( current->process );
+    relationship->browser_process = NULL;
+    relationship->presentation = presentation;
+    relationship->root = NULL;
+    relationship->input = NULL;
+    relationship->target = NULL;
+    relationship->presentation_root = 0;
+    relationship->presentation_target = 0;
+    list_add_tail( &dcomp_ime_relationships, &relationship->entry );
+    reply->token_low = relationship->token_low;
+    reply->token_high = relationship->token_high;
+}
+
+DECL_HANDLER(set_dcomp_ime_relationship)
+{
+    struct dcomp_ime_relationship *relationship;
+    struct window *target, *input, *root, *old_root, *old_input;
+
+    if (!(relationship = find_dcomp_ime_relationship( req->token_low, req->token_high )))
+    {
+        set_error( STATUS_NOT_FOUND );
+        return;
+    }
+    if (relationship->presentation_process == current->process ||
+        (relationship->browser_process && relationship->browser_process != current->process))
+    {
+        set_error( STATUS_ACCESS_DENIED );
+        return;
+    }
+    if (!req->target)
+    {
+        deactivate_dcomp_ime_relationship( relationship );
+        return;
+    }
+    if (!(target = get_window( req->target )))
+    {
+        set_error( STATUS_NOT_FOUND );
+        return;
+    }
+    if (!target->thread || target->thread->process != current->process ||
+        !(input = target->parent) || is_desktop_window( input ) ||
+        !input->thread || input->thread->process != current->process)
+    {
+        set_error( STATUS_ACCESS_DENIED );
+        return;
+    }
+    root = input;
+    while (root->parent && !is_desktop_window( root->parent )) root = root->parent;
+    if (!root->thread || root->thread->process != current->process ||
+        root->desktop != relationship->presentation->desktop)
+    {
+        set_error( STATUS_ACCESS_DENIED );
+        return;
+    }
+    if (!prepare_dcomp_ime_publication( relationship->presentation, root, input )) return;
+
+    old_root = relationship->root;
+    old_input = relationship->input;
+    relationship->root = root;
+    relationship->input = input;
+    relationship->target = target;
+    relationship->presentation_root = root->handle;
+    relationship->presentation_target = target->handle;
+    relationship->generation = ++dcomp_ime_generation;
+    if (!relationship->browser_process)
+        relationship->browser_process = (struct process *)grab_object( current->process );
+
+    if (old_root && old_root != root) republish_dcomp_ime_root( old_root );
+    republish_dcomp_ime_root( root );
+    if (old_input && old_input != input) republish_dcomp_ime_input( old_input );
+    republish_dcomp_ime_input( input );
+    republish_dcomp_ime_presentation( relationship->presentation );
+}
+
+DECL_HANDLER(revoke_dcomp_ime_offer)
+{
+    struct dcomp_ime_relationship *relationship;
+
+    if (!(relationship = find_dcomp_ime_relationship( req->token_low, req->token_high ))) return;
+    if (relationship->presentation_process != current->process)
+    {
+        set_error( STATUS_ACCESS_DENIED );
+        return;
+    }
+    if (--relationship->offer_refcount) return;
+    clear_dcomp_key_owners( relationship->presentation->desktop,
+                            relationship->presentation->handle );
+    cleanup_dcomp_task_presentation( relationship->presentation );
+    release_dcomp_ime_browser( relationship );
+    relationship->token_low = relationship->token_high = 0;
+}
+
 /* Update a helper-owned broadcast exclusion. */
 DECL_HANDLER(update_window_broadcast_exclusion)
 {
@@ -3242,24 +4207,44 @@ DECL_HANDLER(redraw_window)
 }
 
 
+static int is_reserved_dcomp_property( atom_t atom )
+{
+    unsigned int error = get_error();
+    unsigned int i;
+    int found = 0;
+
+    for (i = 0; i < DCOMP_PROPERTY_COUNT; i++)
+    {
+        if (get_dcomp_property_atom( dcomp_property_names[i].name,
+                                     dcomp_property_names[i].size, 0 ) == atom)
+        {
+            found = 1;
+            break;
+        }
+        clear_error();
+    }
+    set_error( error );
+    return found;
+}
+
 /* set a window property */
 DECL_HANDLER(set_window_property)
 {
     struct unicode_str name = get_req_unicode_str();
     struct atom_table *table = get_global_atom_table();
     struct window *win = get_window( req->window );
+    atom_t atom;
 
     if (!win) return;
 
     if (name.len)
     {
-        atom_t atom = add_atom( table, &name );
-        if (atom)
-        {
-            set_property( win, atom, req->data, PROP_TYPE_STRING );
-            release_atom( table, atom );
-        }
+        if (!(atom = add_atom( table, &name ))) return;
+        if (is_reserved_dcomp_property( atom )) set_error( STATUS_ACCESS_DENIED );
+        else set_property( win, atom, req->data, PROP_TYPE_STRING );
+        release_atom( table, atom );
     }
+    else if (is_reserved_dcomp_property( req->atom )) set_error( STATUS_ACCESS_DENIED );
     else set_property( win, req->atom, req->data, PROP_TYPE_ATOM );
 }
 
@@ -3274,7 +4259,8 @@ DECL_HANDLER(remove_window_property)
     if (win)
     {
         atom_t atom = name.len ? find_atom( table, &name ) : req->atom;
-        if (atom) reply->data = remove_property( win, atom );
+        if (atom && is_reserved_dcomp_property( atom )) set_error( STATUS_ACCESS_DENIED );
+        else if (atom) reply->data = remove_property( win, atom );
     }
 }
 

--- a/server/window.c
+++ b/server/window.c
@@ -1439,6 +1439,10 @@ static struct window *create_window( struct window *parent, struct window *owner
     struct obj_locator class_locator;
     unsigned int fnid;
 
+    /* Keep the protected property atom ids stable before applications can
+     * allocate and release ids that would otherwise be reused here. */
+    if (!init_dcomp_property_atoms()) return NULL;
+
     if (!(desktop = get_thread_desktop( current, DESKTOP_CREATEWINDOW ))) return NULL;
 
     if (!(class = grab_class( current->process, atom, class_instance, &class_locator )))

--- a/tools/make_requests
+++ b/tools/make_requests
@@ -36,6 +36,7 @@ my %formats =
     "thread_id_t"   => [  4,   4,  "%04x" ],
     "d3dkmt_handle_t"=>[  4,   4,  "%08x" ],
     "unsigned __int64" => [ 8, 8,  "&uint64" ],
+    "capability_t"  => [  8,   8,  "<redacted>" ],
     "timeout_t"     => [  8,   8 ],
     "abstime_t"     => [  8,   8 ],
     "ioctl_code_t"  => [  4,   4 ],
@@ -118,33 +119,40 @@ sub DO_DUMP_FUNC($$@)
 	if (defined($formats{$type}))
 	{
             my $fmt = ${$formats{$type}}[2];
-            while ($fmt && $fmt !~ /^[%&]/)
+            if (defined($fmt) && $fmt eq "<redacted>")
             {
-                $type = $fmt;
-                $fmt = ${$formats{$type}}[2];
-            }
-            if (!$fmt)
-            {
-                my $func = $type;
-                $func =~ s/^(struct|union)\s+//;
-                $func =~ s/_t$//;
-                push @trace_lines, "    dump_$func( \"$prefix$var=\", &req->$var );\n";
-                $dump_funcs{$func} = $type;
-            }
-            elsif ($fmt =~ /^&(.*)/)
-            {
-                my $func = $1;
-                push @trace_lines, "    dump_$func( \"$prefix$var=\", &req->$var );\n";
-                $dump_funcs{$func} = $type;
-            }
-            elsif ($fmt =~ /^(%.*)\s+\((.*)\)/)
-            {
-                my ($format, $cast) = ($1, $2);
-                push @trace_lines, "    fprintf( stderr, \"$prefix$var=$format\", ($cast)req->$var );\n";
+                push @trace_lines, "    fprintf( stderr, \"$prefix$var=<redacted>\" );\n";
             }
             else
             {
-                push @trace_lines, "    fprintf( stderr, \"$prefix$var=$fmt\", req->$var );\n";
+                while ($fmt && $fmt !~ /^[%&]/)
+                {
+                    $type = $fmt;
+                    $fmt = ${$formats{$type}}[2];
+                }
+                if (!$fmt)
+                {
+                    my $func = $type;
+                    $func =~ s/^(struct|union)\s+//;
+                    $func =~ s/_t$//;
+                    push @trace_lines, "    dump_$func( \"$prefix$var=\", &req->$var );\n";
+                    $dump_funcs{$func} = $type;
+                }
+                elsif ($fmt =~ /^&(.*)/)
+                {
+                    my $func = $1;
+                    push @trace_lines, "    dump_$func( \"$prefix$var=\", &req->$var );\n";
+                    $dump_funcs{$func} = $type;
+                }
+                elsif ($fmt =~ /^(%.*)\s+\((.*)\)/)
+                {
+                    my ($format, $cast) = ($1, $2);
+                    push @trace_lines, "    fprintf( stderr, \"$prefix$var=$format\", ($cast)req->$var );\n";
+                }
+                else
+                {
+                    push @trace_lines, "    fprintf( stderr, \"$prefix$var=$fmt\", req->$var );\n";
+                }
             }
 	}
 	else  # must be some varargs format


### PR DESCRIPTION
## Stack

PR 5 of 8. Stacked on #28; merge only after #28.

## Summary

- Authenticate cross-process DirectComposition presentation, target, and input relationships in wineserver.
- Publish task, keyboard, IME, and base-presentation state transactionally from server-owned topology.
- Enforce parent-owner consent, same-desktop ownership, revocation, reparent invalidation, and process-exit cleanup.
- Preserve WoW64 hardware-input fields and add deterministic cross-process lifecycle regressions.

## Functional boundary

Includes the DComp/DXGI capability foundation, win32u/wow64 routing, server relationship ownership, protocol generation, and focused tests.

Excludes Wayland consumption of the authorized endpoints, which is isolated in #30, and native frame presentation in later PRs.

## Validation

- `git diff --check` passes.
- Protocol sources, generator support, generated outputs, implementations, consumers, and tests are committed atomically.
- The validated integration passed the focused DComp/IME and parent-owner topology suites on x86_64 and i386 with zero failures.
- Direct WoW64 hardware-input regressions passed on both architectures.

## Provenance

- Base branch: `feature/outlook-new-04-manager-lifecycle`.
- Reconstructed from final integration HEAD `cf77f3b43ce5981bac562d692d25c74dc1ed6be1`.
- The original dirty integration worktree was not modified.

## Review notes

Capability tokens are redacted in traces. Public window properties are outputs of server authorization, never authority inputs. Review replacement, revocation, reparenting, and process-teardown paths as one transaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Authorize and maintain cross-process DirectComposition input topology transactionally through wineserver-owned relationships.

New Features:
- Authorize cross-process DirectComposition presentation, target, and input relationships through server-managed capability tokens and ownership checks.
- Expose authorized composition swapchain state and support transactional publication of input, keyboard, IME, base-presentation, and task-delegation mappings.

Bug Fixes:
- Prevent stale or unauthorized IME, keyboard, and task-delegation state from surviving revocation, reparenting, window destruction, or process exit.
- Preserve WoW64 hardware-input data when routing 32-bit input requests.

Enhancements:
- Move protected DirectComposition properties and relationship lifecycle management into wineserver, including consent, same-desktop validation, winner selection, and dispatch-time message revalidation.
- Route authorized cross-process IME updates and hardware keyboard input through the validated topology while keeping capability tokens redacted in traces.

Documentation:
- Document the cross-process DirectComposition input improvements in the changelog.

Tests:
- Add deterministic win32u and DXGI regressions covering cross-process topology authorization, revocation, replacement, reparenting, teardown, IME forwarding, keyboard transitions, composition swapchains, and WoW64 hardware input.
- Add coverage for keyboard repeat metadata and lifecycle cleanup across presentation processes.

Chores:
- Extend the wineserver protocol and generated request handlers for DirectComposition offers, relationships, delegation, and message authorization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved keyboard input, key repeat, and IME composition across cross-process DirectComposition views.
  * Added support for IME composition updates and composition-window positioning in delegated views.
  * Added DirectComposition IME support for D3D12 composition swap chains.

* **Bug Fixes**
  * Improved input routing and authorization when applications use DirectComposition relationships.
  * Improved cleanup when windows, swap chains, or processes are closed.

* **Documentation**
  * Updated the unreleased changelog with the keyboard and IME improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->