### PR TITLE
winewayland: Route input through delegated DComp surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+- Let modern Office identify the current user without exposing machine, account,
+  or application identifiers.
+- Let packaged Office components discover their local application-data folders
+  and education-environment state.
+- Let modern Office web views observe text and child-node changes reliably.
+- Keep Outlook shortcuts working safely across Store package changes and
+  classic Outlook fallback.
+- Route keyboard, pointer, and IME input through delegated DirectComposition
+  surfaces on Wayland.
+
 ## 0.2.0-beta.1 — 2026-08-19
 
 - Let Office finish proofing-language updates without crashing Click-to-Run.

--- a/dlls/winewayland.drv/wayland.c
+++ b/dlls/winewayland.drv/wayland.c
@@ -256,6 +256,8 @@ static void registry_handle_global_remove(void *data, struct wl_registry *regist
     {
         TRACE("removing seat\n");
         if (process_wayland.pointer.wl_pointer) wayland_pointer_deinit();
+        else wayland_pointer_clear_button_owners(NULL);
+        wayland_keyboard_deinit();
         if (process_wayland.text_input.zwp_text_input_v3) wayland_text_input_deinit();
         pthread_mutex_lock(&seat->mutex);
         wl_seat_release(seat->wl_seat);

--- a/dlls/winewayland.drv/wayland_keyboard.c
+++ b/dlls/winewayland.drv/wayland_keyboard.c
@@ -36,6 +36,8 @@
 #include "wine/server.h"
 
 WINE_DEFAULT_DEBUG_CHANNEL(keyboard);
+
+#define WM_WINE_DCOMP_FOCUS 0x80000ff0
 WINE_DECLARE_DEBUG_CHANNEL(key);
 
 static BOOL is_ime_hkl(HKL hkl)
@@ -111,6 +113,8 @@ static struct rxkb_context *rxkb_context;
 static HKL keyboard_hkl; /* the HKL matching the currently active xkb group */
 static LANGID keyboard_lang; /* the language matching the currently active xkb group */
 
+static HWND wayland_keyboard_input_hwnd(HWND hwnd);
+
 static BOOL keyboard_language_uses_ime(void)
 {
     switch (PRIMARYLANGID(keyboard_lang))
@@ -130,6 +134,7 @@ void activate_keyboard_hkl(HWND hwnd, BOOL ime)
 
     if (ime && keyboard_language_uses_ime() && !is_ime_hkl(hkl))
         hkl = get_ime_hkl(keyboard_lang ? keyboard_lang : LOWORD(hkl));
+    if (!(hwnd = wayland_keyboard_input_hwnd(hwnd))) return;
     TRACE("Changing keyboard layout to %p\n", hkl);
     NtUserPostMessage(hwnd, WM_WAYLAND_SET_KEYBOARD_LAYOUT, 0, (LPARAM)hkl);
 }
@@ -658,7 +663,8 @@ static void set_current_xkb_group(xkb_layout_index_t xkb_group)
     keyboard_hkl = hkl;
 
     pthread_mutex_lock(&text_input->mutex);
-    ime = text_input->focused_hwnd && text_input->focused_hwnd == keyboard->focused_hwnd;
+    ime = text_input->focused_surface_hwnd &&
+          text_input->focused_surface_hwnd == keyboard->focused_hwnd;
     pthread_mutex_unlock(&text_input->mutex);
 
     activate_keyboard_hkl(keyboard->focused_hwnd, ime);
@@ -684,39 +690,113 @@ static BOOL find_xkb_layout_variant(const char *name, const char **layout, const
 
 static HWND wayland_keyboard_input_hwnd(HWND hwnd)
 {
-    HWND mapped = wayland_get_input_hwnd(hwnd);
-
-    return mapped == hwnd ? hwnd : NULL;
+    return hwnd ? wayland_get_input_hwnd(hwnd) : NULL;
 }
 
-static void release_all_keys(HWND hwnd)
+static void send_right_control(HWND hwnd, uint32_t state);
+
+static BOOL right_control_is_pressed(const struct wayland_keyboard *keyboard)
 {
-    BYTE state[256];
-    int vkey;
+    return keyboard->key_hwnds[KEY_RIGHTCTRL] || keyboard->synthetic_right_control_hwnd;
+}
+
+static void update_right_control(struct wayland_keyboard *keyboard, HWND hwnd, BOOL physical, BOOL pressed)
+{
+    BOOL was_pressed = right_control_is_pressed(keyboard);
+
+    if (physical) keyboard->key_hwnds[KEY_RIGHTCTRL] = pressed ? hwnd : NULL;
+    else keyboard->synthetic_right_control_hwnd = pressed ? hwnd : NULL;
+    if (was_pressed == right_control_is_pressed(keyboard)) return;
+    if (pressed)
+    {
+        keyboard->right_control_hwnd = hwnd;
+        send_right_control(hwnd, WL_KEYBOARD_KEY_STATE_PRESSED);
+    }
+    else
+    {
+        send_right_control(keyboard->right_control_hwnd, WL_KEYBOARD_KEY_STATE_RELEASED);
+        keyboard->right_control_hwnd = NULL;
+    }
+}
+
+static void send_key_input(HWND hwnd, uint32_t key, uint32_t state)
+{
+    UINT scan = key2scan(key);
     INPUT input = {.type = INPUT_KEYBOARD};
 
-    hwnd = wayland_keyboard_input_hwnd(hwnd);
+    input.ki.wScan = (scan & 0x300) ? scan + 0xdf00 : scan;
+    input.ki.dwFlags = KEYEVENTF_SCANCODE;
+    if (scan & ~0xff) input.ki.dwFlags |= KEYEVENTF_EXTENDEDKEY;
+    if (state == WL_KEYBOARD_KEY_STATE_RELEASED) input.ki.dwFlags |= KEYEVENTF_KEYUP;
+    NtUserSendHardwareInput(hwnd, 0, &input, 0);
+}
 
-    NtUserGetAsyncKeyboardState(state);
+static void release_all_keys(struct wayland_keyboard *keyboard)
+{
+    uint32_t key;
 
-    for (vkey = 1; vkey < 256; vkey++)
+    for (key = 0; key < WAYLAND_KEY_COUNT; key++)
     {
-        /* Skip mouse buttons. */
-        if (vkey < 7 && vkey != VK_CANCEL) continue;
-        /* Skip left/right-agnostic modifier vkeys. */
-        if (vkey == VK_SHIFT || vkey == VK_CONTROL || vkey == VK_MENU) continue;
+        HWND hwnd = keyboard->key_hwnds[key];
 
-        if (state[vkey] & 0x80)
+        if (!hwnd) continue;
+        if (key == KEY_RIGHTALT)
+            update_right_control(keyboard, keyboard->synthetic_right_control_hwnd, FALSE, FALSE);
+        if (key == KEY_RIGHTCTRL)
+            update_right_control(keyboard, hwnd, TRUE, FALSE);
+        else
         {
-            UINT scan = NtUserMapVirtualKeyEx(vkey, MAPVK_VK_TO_VSC_EX,
-                                              keyboard_hkl);
-            input.ki.wVk = vkey;
-            input.ki.wScan = scan & 0xff;
-            input.ki.dwFlags = KEYEVENTF_KEYUP;
-            if (scan & ~0xff) input.ki.dwFlags |= KEYEVENTF_EXTENDEDKEY;
-            NtUserSendHardwareInput(hwnd, 0, &input, 0);
+            send_key_input(hwnd, key, WL_KEYBOARD_KEY_STATE_RELEASED);
+            keyboard->key_hwnds[key] = NULL;
         }
     }
+    if (keyboard->synthetic_right_control_hwnd)
+        update_right_control(keyboard, keyboard->synthetic_right_control_hwnd, FALSE, FALSE);
+}
+
+static BOOL clear_keyboard_focus(HWND hwnd, HWND *input_hwnd, unsigned int *generation)
+{
+    struct wayland_keyboard *keyboard = &process_wayland.keyboard;
+    BOOL focused = FALSE;
+
+    pthread_mutex_lock(&keyboard->mutex);
+    if (keyboard->focused_hwnd == hwnd)
+    {
+        if (input_hwnd) *input_hwnd = keyboard->focused_input_hwnd;
+        release_all_keys(keyboard);
+        keyboard->focused_hwnd = NULL;
+        keyboard->focused_input_hwnd = NULL;
+        keyboard->focus_generation++;
+        if (generation) *generation = keyboard->focus_generation;
+        focused = TRUE;
+    }
+    pthread_mutex_unlock(&keyboard->mutex);
+    return focused;
+}
+
+BOOL wayland_keyboard_clear_surface_focus(HWND hwnd)
+{
+    return clear_keyboard_focus(hwnd, NULL, NULL);
+}
+
+void wayland_keyboard_destroy_window(HWND hwnd)
+{
+    struct wayland_keyboard *keyboard = &process_wayland.keyboard;
+
+    pthread_mutex_lock(&keyboard->mutex);
+    if (keyboard->focused_hwnd == hwnd)
+    {
+        release_all_keys(keyboard);
+        keyboard->focused_hwnd = NULL;
+        keyboard->focused_input_hwnd = NULL;
+        keyboard->focus_generation++;
+    }
+    else if (keyboard->focused_input_hwnd == hwnd)
+    {
+        release_all_keys(keyboard);
+        keyboard->focused_input_hwnd = NULL;
+    }
+    pthread_mutex_unlock(&keyboard->mutex);
 }
 
 /**********************************************************************
@@ -817,7 +897,7 @@ static void keyboard_handle_enter(void *private, struct wl_keyboard *wl_keyboard
     struct wayland_keyboard *keyboard = &process_wayland.keyboard;
     struct wayland_surface *surface;
     struct wayland_win_data *data;
-    HWND hwnd;
+    HWND hwnd, input_hwnd;
 
     InterlockedExchange(&process_wayland.input_serial, serial);
 
@@ -826,14 +906,30 @@ static void keyboard_handle_enter(void *private, struct wl_keyboard *wl_keyboard
     /* The wl_surface user data remains valid and immutable for the whole
      * lifetime of the object, so it's safe to access without locking. */
     hwnd = wl_surface_get_user_data(wl_surface);
+    if (!hwnd) return;
     TRACE("serial=%u hwnd=%p\n", serial, hwnd);
 
-    pthread_mutex_lock(&keyboard->mutex);
-    keyboard->focused_hwnd = hwnd;
-    pthread_mutex_unlock(&keyboard->mutex);
+    input_hwnd = wayland_keyboard_input_hwnd(hwnd);
 
-    NtUserPostMessage(keyboard->focused_hwnd, WM_WAYLAND_SET_KEYBOARD_LAYOUT, 0,
-                      (LPARAM)keyboard_hkl);
+    pthread_mutex_lock(&keyboard->mutex);
+    if (keyboard->focused_hwnd != hwnd || keyboard->focused_input_hwnd != input_hwnd)
+    {
+        release_all_keys(keyboard);
+        keyboard->focus_generation++;
+    }
+    keyboard->focused_hwnd = hwnd;
+    keyboard->focused_input_hwnd = input_hwnd;
+    pthread_mutex_unlock(&keyboard->mutex);
+    if (input_hwnd && input_hwnd != hwnd)
+    {
+        /* A detached DirectComposition surface may not be the Win32 input
+         * endpoint. Synchronize focus with its mapped host before routing
+         * keyboard input and layout changes there. */
+        NtUserPostMessage(input_hwnd, WM_WAYLAND_SET_FOREGROUND, 0, 0);
+        NtUserPostMessage(input_hwnd, WM_WINE_DCOMP_FOCUS, 0, 0);
+    }
+    if (input_hwnd)
+        NtUserPostMessage(input_hwnd, WM_WAYLAND_SET_KEYBOARD_LAYOUT, 0, (LPARAM)keyboard_hkl);
 
     if (!(data = wayland_win_data_get(hwnd))) return;
 
@@ -843,7 +939,7 @@ static void keyboard_handle_enter(void *private, struct wl_keyboard *wl_keyboard
          * directly once it's updated to not explicitly deactivate the old
          * foreground window when both the old and new foreground windows
          * are in the same non-current thread. */
-        if (surface->window.managed)
+        if (surface->window.managed && input_hwnd == hwnd)
             NtUserPostMessage(hwnd, WM_WAYLAND_SET_FOREGROUND, 0, 0);
     }
 
@@ -853,7 +949,9 @@ static void keyboard_handle_enter(void *private, struct wl_keyboard *wl_keyboard
 struct foreground_sync
 {
     struct wl_callback *callback;
-    HWND hwnd;
+    HWND presentation_hwnd;
+    HWND input_hwnd;
+    unsigned int focus_generation;
 };
 
 static void foreground_sync_done(void *data, struct wl_callback *callback, uint32_t serial)
@@ -864,14 +962,15 @@ static void foreground_sync_done(void *data, struct wl_callback *callback, uint3
     BOOL focused;
 
     pthread_mutex_lock(&keyboard->mutex);
-    focused = !!keyboard->focused_hwnd;
+    focused = keyboard->focus_generation != sync->focus_generation ||
+              !!keyboard->focused_hwnd;
     pthread_mutex_unlock(&keyboard->mutex);
 
     /* A keyboard leave is also sent while the compositor switches between
      * surfaces belonging to one activated toplevel.  Keep the Windows
      * foreground state in that case; xdg_toplevel activation is the
      * compositor's authoritative application-focus state. */
-    if (!focused && (win_data = wayland_win_data_get(sync->hwnd)))
+    if (!focused && (win_data = wayland_win_data_get(sync->presentation_hwnd)))
     {
         struct wayland_surface *surface = win_data->wayland_surface;
         enum wayland_surface_config_state state = 0;
@@ -887,7 +986,7 @@ static void foreground_sync_done(void *data, struct wl_callback *callback, uint3
     }
 
     wl_callback_destroy(callback);
-    if (!focused && NtUserGetForegroundWindow() == sync->hwnd)
+    if (!focused && NtUserGetForegroundWindow() == sync->input_hwnd)
         NtUserSetForegroundWindowInternal(NtUserGetDesktopWindow());
     free(sync);
 }
@@ -900,10 +999,10 @@ static const struct wl_callback_listener foreground_sync_listener =
 static void keyboard_handle_leave(void *data, struct wl_keyboard *wl_keyboard,
                                   uint32_t serial, struct wl_surface *wl_surface)
 {
-    struct wayland_keyboard *keyboard = &process_wayland.keyboard;
     struct foreground_sync *sync;
+    unsigned int focus_generation;
     BOOL clear_foreground = FALSE;
-    HWND hwnd;
+    HWND hwnd, input_hwnd = NULL;
 
     InterlockedExchange(&process_wayland.input_serial, serial);
 
@@ -912,23 +1011,16 @@ static void keyboard_handle_leave(void *data, struct wl_keyboard *wl_keyboard,
     /* The wl_surface user data remains valid and immutable for the whole
      * lifetime of the object, so it's safe to access without locking. */
     hwnd = wl_surface_get_user_data(wl_surface);
+    if (!hwnd) return;
     TRACE("serial=%u hwnd=%p\n", serial, hwnd);
 
-    pthread_mutex_lock(&keyboard->mutex);
-    if (keyboard->focused_hwnd == hwnd)
-    {
-        keyboard->focused_hwnd = NULL;
-        clear_foreground = TRUE;
-    }
-    pthread_mutex_unlock(&keyboard->mutex);
-
-    /* The spec for the leave event tells us to treat all keys as released,
-     * and for any key repetition to stop. */
-    release_all_keys(hwnd);
+    clear_foreground = clear_keyboard_focus(hwnd, &input_hwnd, &focus_generation);
 
     if (clear_foreground && (sync = malloc(sizeof(*sync))))
     {
-        sync->hwnd = hwnd;
+        sync->presentation_hwnd = hwnd;
+        sync->input_hwnd = input_hwnd;
+        sync->focus_generation = focus_generation;
         sync->callback = wl_display_sync(process_wayland.wl_display);
         wl_proxy_set_queue((struct wl_proxy *)sync->callback, process_wayland.wl_event_queue);
         wl_callback_add_listener(sync->callback, &foreground_sync_listener, sync);
@@ -950,27 +1042,66 @@ static void keyboard_handle_key(void *data, struct wl_keyboard *wl_keyboard,
                                 uint32_t serial, uint32_t time, uint32_t key,
                                 uint32_t state)
 {
-    UINT scan = key2scan(key);
-    INPUT input = {0};
+    struct wayland_keyboard *keyboard = &process_wayland.keyboard;
     HWND hwnd;
 
     InterlockedExchange(&process_wayland.input_serial, serial);
 
-    if (!(hwnd = wayland_keyboard_get_focused_hwnd())) return;
-    hwnd = wayland_keyboard_input_hwnd(hwnd);
+    if (state == WL_KEYBOARD_KEY_STATE_PRESSED)
+    {
+        HWND input_hwnd, presentation_hwnd;
 
-    TRACE_(key)("serial=%u hwnd=%p key=%d scan=%#x state=%#x\n", serial, hwnd, key, scan, state);
+        pthread_mutex_lock(&keyboard->mutex);
+        presentation_hwnd = keyboard->focused_hwnd;
+        pthread_mutex_unlock(&keyboard->mutex);
+        input_hwnd = wayland_keyboard_input_hwnd(presentation_hwnd);
 
-    /* NOTE: Windows normally sends VK_CONTROL + VK_MENU only if the layout has KLLF_ALTGR */
-    if (key == KEY_RIGHTALT) send_right_control(hwnd, state);
+        pthread_mutex_lock(&keyboard->mutex);
+        if (keyboard->focused_hwnd == presentation_hwnd &&
+            keyboard->focused_input_hwnd != input_hwnd)
+        {
+            release_all_keys(keyboard);
+            keyboard->focused_input_hwnd = input_hwnd;
+            if (input_hwnd && input_hwnd != presentation_hwnd)
+            {
+                NtUserPostMessage(input_hwnd, WM_WAYLAND_SET_FOREGROUND, 0, 0);
+                NtUserPostMessage(input_hwnd, WM_WINE_DCOMP_FOCUS, 0, 0);
+                NtUserPostMessage(input_hwnd, WM_WAYLAND_SET_KEYBOARD_LAYOUT, 0,
+                                  (LPARAM)keyboard_hkl);
+            }
+        }
+    }
+    else
+        pthread_mutex_lock(&keyboard->mutex);
 
-    input.type = INPUT_KEYBOARD;
-    input.ki.wScan = (scan & 0x300) ? scan + 0xdf00 : scan;
-    input.ki.dwFlags = KEYEVENTF_SCANCODE;
-    if (scan & ~0xff) input.ki.dwFlags |= KEYEVENTF_EXTENDEDKEY;
+    if (key >= WAYLAND_KEY_COUNT)
+    {
+        pthread_mutex_unlock(&keyboard->mutex);
+        return;
+    }
+    if (state == WL_KEYBOARD_KEY_STATE_PRESSED)
+        hwnd = keyboard->focused_input_hwnd;
+    else
+        hwnd = keyboard->key_hwnds[key];
+    if (!hwnd)
+    {
+        pthread_mutex_unlock(&keyboard->mutex);
+        return;
+    }
 
-    if (state == WL_KEYBOARD_KEY_STATE_RELEASED) input.ki.dwFlags |= KEYEVENTF_KEYUP;
-    NtUserSendHardwareInput(hwnd, 0, &input, 0);
+    TRACE_(key)("serial=%u hwnd=%p key=%d scan=%#x state=%#x\n", serial, hwnd, key,
+            key2scan(key), state);
+
+    if (key == KEY_RIGHTALT)
+        update_right_control(keyboard, hwnd, FALSE, state == WL_KEYBOARD_KEY_STATE_PRESSED);
+    if (key == KEY_RIGHTCTRL)
+        update_right_control(keyboard, hwnd, TRUE, state == WL_KEYBOARD_KEY_STATE_PRESSED);
+    else
+    {
+        send_key_input(hwnd, key, state);
+        keyboard->key_hwnds[key] = state == WL_KEYBOARD_KEY_STATE_PRESSED ? hwnd : NULL;
+    }
+    pthread_mutex_unlock(&keyboard->mutex);
 }
 
 static void keyboard_handle_modifiers(void *data, struct wl_keyboard *wl_keyboard,
@@ -1062,6 +1193,10 @@ void wayland_keyboard_deinit(void)
     struct wayland_keyboard *keyboard = &process_wayland.keyboard;
 
     pthread_mutex_lock(&keyboard->mutex);
+    release_all_keys(keyboard);
+    keyboard->focused_hwnd = NULL;
+    keyboard->focused_input_hwnd = NULL;
+    keyboard->focus_generation++;
     if (keyboard->wl_keyboard)
     {
         wl_keyboard_destroy(keyboard->wl_keyboard);

--- a/dlls/winewayland.drv/wayland_pointer.c
+++ b/dlls/winewayland.drv/wayland_pointer.c
@@ -28,6 +28,7 @@
 #undef SW_MAX /* Also defined in winuser.rh */
 #include <math.h>
 #include <stdlib.h>
+#include <string.h>
 
 #define OEMRESOURCE
 
@@ -219,12 +220,8 @@ static HWND wayland_get_input_hwnd_internal(HWND hwnd, BOOL keyboard)
 {
     static const WCHAR target_prop[] = {'_','_','w','i','n','e','_','d','c','o','m','p','_',
             'd','e','t','a','c','h','e','d','_','w','i','n','d','o','w',0};
-    static const WCHAR input_prop[] = {'_','_','w','i','n','e','_','d','c','o','m','p','_',
-            'i','n','p','u','t','_','w','i','n','d','o','w',0};
     static const WCHAR keyboard_prop[] = {'_','_','w','i','n','e','_','d','c','o','m','p','_',
             'k','e','y','b','o','a','r','d','_','w','i','n','d','o','w',0};
-    static const WCHAR direct_input_prop[] = {'_','_','w','i','n','e','_','d','i','r','e','c','t','_',
-            'h','a','r','d','w','a','r','e','_','i','n','p','u','t',0};
     static const WCHAR cursor_window_prop[] = {'_','_','w','i','n','e','_','d','c','o','m','p','_',
             'c','u','r','s','o','r','_','w','i','n','d','o','w',0};
     HWND target, parent, input_window, root;
@@ -234,6 +231,8 @@ static HWND wayland_get_input_hwnd_internal(HWND hwnd, BOOL keyboard)
         if ((input_window = NtUserGetProp(hwnd, keyboard_prop))) return input_window;
         if ((input_window = NtUserGetProp(NtUserGetAncestor(hwnd, GA_ROOT), keyboard_prop)))
             return input_window;
+        if (NtUserGetProp(hwnd, dcomp_caption_overlay_prop)) return hwnd;
+        if (NtUserGetProp(hwnd, target_prop)) return NULL;
     }
 
     /* Cross-process DirectComposition swapchains use a detached presentation
@@ -247,11 +246,9 @@ static HWND wayland_get_input_hwnd_internal(HWND hwnd, BOOL keyboard)
     if (!(target = NtUserGetProp(hwnd, target_prop))) return hwnd;
     if (!(parent = NtUserGetAncestor(target, GA_PARENT))) return hwnd;
     input_window = parent;
-    NtUserSetProp(parent, input_prop, input_window);
-    NtUserSetProp(input_window, direct_input_prop, (HANDLE)(ULONG_PTR)0x57444952);
     NtUserSetProp(input_window, cursor_window_prop, hwnd);
     if ((root = NtUserGetAncestor(target, GA_ROOT)))
-        NtUserSetProp(root, keyboard_prop, input_window);
+        NtUserSetProp(root, cursor_window_prop, hwnd);
     TRACE("DComp input presentation hwnd %p -> target %p parent %p input %p root %p\n",
           hwnd, target, parent, input_window, root);
     return input_window;
@@ -265,6 +262,81 @@ HWND wayland_get_input_hwnd(HWND hwnd)
 static HWND wayland_get_pointer_input_hwnd(HWND hwnd)
 {
     return wayland_get_input_hwnd_internal(hwnd, FALSE);
+}
+
+static struct wayland_pointer_button *wayland_pointer_find_button_locked(
+        struct wayland_pointer *pointer, uint32_t button, BOOL create)
+{
+    struct wayland_pointer_button *free_slot = NULL;
+    unsigned int i;
+
+    for (i = 0; i < ARRAY_SIZE(pointer->buttons); i++)
+    {
+        if (pointer->buttons[i].pressed && pointer->buttons[i].button == button)
+            return &pointer->buttons[i];
+        if (!pointer->buttons[i].pressed && !free_slot) free_slot = &pointer->buttons[i];
+    }
+
+    if (create && free_slot)
+    {
+        free_slot->button = button;
+        free_slot->pressed = TRUE;
+        return free_slot;
+    }
+    return NULL;
+}
+
+static void wayland_pointer_update_button_compat_locked(struct wayland_pointer *pointer)
+{
+    struct wayland_pointer_button *best = NULL;
+    unsigned int i;
+
+    for (i = 0; i < ARRAY_SIZE(pointer->buttons); i++)
+    {
+        struct wayland_pointer_button *button = &pointer->buttons[i];
+
+        if (!button->pressed) continue;
+        if (!best || (button->edge_resize && !best->edge_resize) ||
+            (button->edge_resize == best->edge_resize && button->button == BTN_LEFT &&
+             best->button != BTN_LEFT))
+            best = button;
+    }
+
+    pointer->button_hwnd = best ? best->root_hwnd : NULL;
+    pointer->button_serial = best ? best->serial : 0;
+}
+
+static void wayland_pointer_send_button_up(const struct wayland_pointer_button *button)
+{
+    INPUT input = { .type = INPUT_MOUSE };
+
+    if (!button->injected || !button->input_hwnd) return;
+    input.mi.dwFlags = button->up_flags;
+    input.mi.mouseData = button->mouse_data;
+    NtUserSendHardwareInput(NtUserIsWindow(button->input_hwnd) ? button->input_hwnd : NULL,
+                            SEND_HWMSG_RAWINPUT, &input, 0);
+}
+
+void wayland_pointer_clear_button_owners(HWND hwnd)
+{
+    struct wayland_pointer *pointer = &process_wayland.pointer;
+    struct wayland_pointer_button owners[WAYLAND_POINTER_BUTTON_COUNT];
+    unsigned int i, count = 0;
+
+    pthread_mutex_lock(&pointer->mutex);
+    for (i = 0; i < ARRAY_SIZE(pointer->buttons); i++)
+    {
+        struct wayland_pointer_button *button = &pointer->buttons[i];
+
+        if (!button->pressed || (hwnd && button->hwnd != hwnd && button->root_hwnd != hwnd &&
+                                 button->input_hwnd != hwnd)) continue;
+        if (button->injected) owners[count++] = *button;
+        memset(button, 0, sizeof(*button));
+    }
+    wayland_pointer_update_button_compat_locked(pointer);
+    pthread_mutex_unlock(&pointer->mutex);
+
+    for (i = 0; i < count; i++) wayland_pointer_send_button_up(&owners[i]);
 }
 
 static void wayland_pointer_update_dcomp_cursor(HWND hwnd);
@@ -390,6 +462,7 @@ static void pointer_handle_leave(void *data, struct wl_pointer *wl_pointer,
 
     TRACE("hwnd=%p\n", wl_surface_get_user_data(wl_surface));
 
+    wayland_pointer_clear_button_owners(NULL);
     pthread_mutex_lock(&pointer->mutex);
     pointer->focused_hwnd = NULL;
     pointer->enter_serial = 0;
@@ -481,30 +554,59 @@ static void pointer_handle_button(void *data, struct wl_pointer *wl_pointer,
                                   uint32_t state)
 {
     struct wayland_pointer *pointer = &process_wayland.pointer;
-    BOOL edge_resize;
+    struct wayland_pointer_button *owner;
+    struct wayland_pointer_button released = {0};
+    struct wayland_pointer_button injected = {0};
     INPUT input = {0};
-    HWND hwnd, input_hwnd, root, command, caption, resize_hwnd, resize_surface_hwnd;
+    HWND hwnd = NULL, input_hwnd, root = NULL, command, caption, resize_hwnd, resize_surface_hwnd;
+    NTSTATUS status;
     UINT resize_edge;
 
     InterlockedExchange(&process_wayland.input_serial, serial);
-    pthread_mutex_lock(&pointer->mutex);
-    edge_resize = pointer->edge_resize;
-    if (state == WL_POINTER_BUTTON_STATE_PRESSED)
+
+    if (state == WL_POINTER_BUTTON_STATE_RELEASED)
     {
-        pointer->button_serial = serial;
-        pointer->button_hwnd = NULL;
-        pointer->edge_resize = FALSE;
+        pthread_mutex_lock(&pointer->mutex);
+        owner = wayland_pointer_find_button_locked(pointer, button, FALSE);
+        if (!owner)
+        {
+            pthread_mutex_unlock(&pointer->mutex);
+            return;
+        }
+        released = *owner;
+        memset(owner, 0, sizeof(*owner));
+        wayland_pointer_update_button_compat_locked(pointer);
+        pthread_mutex_unlock(&pointer->mutex);
+
+        if (released.edge_resize) return;
+        if (released.injected)
+        {
+            wayland_pointer_send_button_up(&released);
+            return;
+        }
+        hwnd = released.hwnd;
+        root = released.root_hwnd;
     }
     else
     {
-        pointer->button_serial = 0;
-        pointer->button_hwnd = NULL;
-        pointer->edge_resize = FALSE;
-    }
-    pthread_mutex_unlock(&pointer->mutex);
+        if (!(hwnd = wayland_pointer_get_focused_hwnd())) return;
+        if (!(root = NtUserGetAncestor(hwnd, GA_ROOT))) root = hwnd;
 
-    if (state == WL_POINTER_BUTTON_STATE_RELEASED && edge_resize) return;
-    if (!(hwnd = wayland_pointer_get_focused_hwnd())) return;
+        pthread_mutex_lock(&pointer->mutex);
+        owner = wayland_pointer_find_button_locked(pointer, button, TRUE);
+        if (!owner)
+        {
+            pthread_mutex_unlock(&pointer->mutex);
+            WARN("Dropping button %#x press because the owner table is full\n", button);
+            return;
+        }
+        owner->serial = serial;
+        owner->hwnd = hwnd;
+        owner->root_hwnd = root;
+        owner->edge_resize = FALSE;
+        wayland_pointer_update_button_compat_locked(pointer);
+        pthread_mutex_unlock(&pointer->mutex);
+    }
 
     caption = NtUserGetProp(hwnd, dcomp_caption_overlay_prop) ? hwnd :
             NtUserGetProp(hwnd, dcomp_caption_pointer_prop);
@@ -546,9 +648,6 @@ static void pointer_handle_button(void *data, struct wl_pointer *wl_pointer,
     {
         resize_hwnd = pointer_get_resize_hwnd(hwnd);
         resize_surface_hwnd = pointer_get_resize_surface_hwnd(hwnd, resize_hwnd);
-        pthread_mutex_lock(&pointer->mutex);
-        pointer->button_hwnd = hwnd;
-        pthread_mutex_unlock(&pointer->mutex);
 
         if (button == BTN_LEFT && resize_surface_hwnd &&
             (resize_edge = pointer_get_resize_edge(resize_hwnd, hwnd, resize_surface_hwnd)) &&
@@ -556,7 +655,12 @@ static void pointer_handle_button(void *data, struct wl_pointer *wl_pointer,
                                               SC_SIZE, resize_edge, serial))
         {
             pthread_mutex_lock(&pointer->mutex);
-            pointer->edge_resize = TRUE;
+            owner = wayland_pointer_find_button_locked(pointer, button, FALSE);
+            if (owner)
+            {
+                owner->edge_resize = TRUE;
+                wayland_pointer_update_button_compat_locked(pointer);
+            }
             pthread_mutex_unlock(&pointer->mutex);
 
             TRACE("edge resize hwnd=%p focused=%p edge=%u serial=%u\n",
@@ -589,10 +693,60 @@ static void pointer_handle_button(void *data, struct wl_pointer *wl_pointer,
 
     TRACE("hwnd=%p button=%#x state=%u\n", hwnd, button, state);
 
-    input_hwnd = wayland_get_pointer_input_hwnd(hwnd);
-    NtUserSendHardwareInput(input_hwnd, SEND_HWMSG_RAWINPUT, &input, 0);
-    if (state == WL_POINTER_BUTTON_STATE_RELEASED && input_hwnd != hwnd)
-        NtUserPostMessage(input_hwnd, WM_WINE_DCOMP_FOCUS, 0, 0);
+    if (state == WL_POINTER_BUTTON_STATE_PRESSED)
+    {
+        BOOL orphaned = FALSE;
+
+        input_hwnd = wayland_get_pointer_input_hwnd(hwnd);
+        pthread_mutex_lock(&pointer->mutex);
+        owner = wayland_pointer_find_button_locked(pointer, button, FALSE);
+        if (owner)
+        {
+            owner->input_hwnd = input_hwnd;
+            owner->up_flags = input.mi.dwFlags << 1;
+            owner->mouse_data = input.mi.mouseData;
+            owner->injected = FALSE;
+            injected = *owner;
+        }
+        pthread_mutex_unlock(&pointer->mutex);
+
+        if (!injected.pressed || !input_hwnd || !input.mi.dwFlags)
+        {
+            pthread_mutex_lock(&pointer->mutex);
+            owner = wayland_pointer_find_button_locked(pointer, button, FALSE);
+            if (owner && owner->serial == serial)
+            {
+                memset(owner, 0, sizeof(*owner));
+                wayland_pointer_update_button_compat_locked(pointer);
+            }
+            pthread_mutex_unlock(&pointer->mutex);
+            return;
+        }
+
+        status = NtUserSendHardwareInput(input_hwnd, SEND_HWMSG_RAWINPUT, &input, 0);
+        pthread_mutex_lock(&pointer->mutex);
+        owner = wayland_pointer_find_button_locked(pointer, button, FALSE);
+        if (owner && owner->serial == serial)
+        {
+            if (!status)
+                owner->injected = TRUE;
+            else
+            {
+                memset(owner, 0, sizeof(*owner));
+                wayland_pointer_update_button_compat_locked(pointer);
+            }
+        }
+        else if (!status)
+            orphaned = TRUE;
+        pthread_mutex_unlock(&pointer->mutex);
+
+        if (orphaned)
+        {
+            injected.injected = TRUE;
+            wayland_pointer_send_button_up(&injected);
+        }
+        if (status) WARN("Failed to inject pointer button input, status %#x\n", status);
+    }
 }
 
 static void pointer_handle_axis_value120(void *data, struct wl_pointer *wl_pointer,
@@ -792,6 +946,8 @@ void wayland_pointer_init(struct wl_pointer *wl_pointer)
     pointer->wl_pointer = wl_pointer;
     pointer->focused_hwnd = NULL;
     pointer->enter_serial = 0;
+    memset(pointer->buttons, 0, sizeof(pointer->buttons));
+    wayland_pointer_update_button_compat_locked(pointer);
     pthread_mutex_unlock(&pointer->mutex);
     wl_pointer_add_listener(pointer->wl_pointer, &pointer_listener, NULL);
 
@@ -812,6 +968,7 @@ void wayland_pointer_deinit(void)
 {
     struct wayland_pointer *pointer = &process_wayland.pointer;
 
+    wayland_pointer_clear_button_owners(NULL);
     pthread_mutex_lock(&pointer->mutex);
     if (pointer->zwp_confined_pointer_v1)
     {

--- a/dlls/winewayland.drv/wayland_surface.c
+++ b/dlls/winewayland.drv/wayland_surface.c
@@ -38,6 +38,10 @@ static const WCHAR dcomp_foreign_handle_prop[] =
     {'_','_','w','i','n','e','_','d','c','o','m','p','_','x','d','g','_','e','x','p','o','r','t','_','h','a','n','d','l','e',0};
 static const WCHAR dcomp_task_delegated_prop[] =
     {'_','_','w','i','n','e','_','d','c','o','m','p','_','t','a','s','k','_','d','e','l','e','g','a','t','e','d',0};
+static const WCHAR dcomp_task_delegated_target_prop[] =
+    {'_','_','w','i','n','e','_','d','c','o','m','p','_','t','a','s','k','_','d','e','l','e','g','a','t','e','d','_','t','a','r','g','e','t',0};
+static const WCHAR dcomp_base_presentation_prop[] =
+    {'_','_','w','i','n','e','_','d','c','o','m','p','_','b','a','s','e','_','p','r','e','s','e','n','t','a','t','i','o','n',0};
 static const WCHAR dcomp_task_app_id_prop[] =
     {'_','_','w','i','n','e','_','d','c','o','m','p','_','t','a','s','k','_','a','p','p','_','i','d',0};
 static const WCHAR dcomp_detached_window_prop[] =
@@ -98,6 +102,7 @@ static void wayland_surface_enable_plasma_positioning(struct wayland_surface *su
 
 BOOL wayland_surface_export_toplevel(struct wayland_surface *surface)
 {
+    HWND delegate, target;
     BOOL task_delegated;
 
     if (!process_wayland.zxdg_exporter_v2 || surface->role != WAYLAND_SURFACE_ROLE_TOPLEVEL ||
@@ -110,7 +115,12 @@ BOOL wayland_surface_export_toplevel(struct wayland_surface *surface)
      * positioning request.  Position the exported host through Plasma as
      * well, so its Win32 screen coordinates and the detached surfaces share
      * the same origin. */
-    task_delegated = !!NtUserGetProp(surface->hwnd, dcomp_task_delegated_prop);
+    delegate = NtUserGetProp(surface->hwnd, dcomp_task_delegated_prop);
+    target = NtUserGetProp(surface->hwnd, dcomp_task_delegated_target_prop);
+    task_delegated = delegate && target && NtUserIsWindow(delegate) && NtUserIsWindow(target) &&
+                     NtUserGetAncestor(target, GA_ROOT) == surface->hwnd &&
+                     NtUserGetProp(delegate, dcomp_detached_window_prop) == target &&
+                     NtUserGetProp(target, dcomp_base_presentation_prop) == delegate;
     wayland_surface_enable_plasma_positioning(surface, task_delegated);
 
     if (surface->zxdg_exported_v2) return TRUE;
@@ -384,15 +394,10 @@ void wayland_surface_destroy(struct wayland_surface *surface)
         wayland_pointer_clear_constraint();
     pthread_mutex_unlock(&process_wayland.pointer.mutex);
 
-    pthread_mutex_lock(&process_wayland.keyboard.mutex);
-    if (process_wayland.keyboard.focused_hwnd == surface->hwnd)
-        process_wayland.keyboard.focused_hwnd = NULL;
-    pthread_mutex_unlock(&process_wayland.keyboard.mutex);
+    wayland_pointer_clear_button_owners(surface->hwnd);
+    wayland_keyboard_clear_surface_focus(surface->hwnd);
 
-    pthread_mutex_lock(&process_wayland.text_input.mutex);
-    if (process_wayland.text_input.focused_hwnd == surface->hwnd)
-        process_wayland.text_input.focused_hwnd = NULL;
-    pthread_mutex_unlock(&process_wayland.text_input.mutex);
+    wayland_text_input_clear_focus(surface->hwnd);
 
     wayland_surface_clear_role(surface);
 

--- a/dlls/winewayland.drv/wayland_surface.c
+++ b/dlls/winewayland.drv/wayland_surface.c
@@ -36,12 +36,6 @@ WINE_DEFAULT_DEBUG_CHANNEL(waylanddrv);
 
 static const WCHAR dcomp_foreign_handle_prop[] =
     {'_','_','w','i','n','e','_','d','c','o','m','p','_','x','d','g','_','e','x','p','o','r','t','_','h','a','n','d','l','e',0};
-static const WCHAR dcomp_task_delegated_prop[] =
-    {'_','_','w','i','n','e','_','d','c','o','m','p','_','t','a','s','k','_','d','e','l','e','g','a','t','e','d',0};
-static const WCHAR dcomp_task_delegated_target_prop[] =
-    {'_','_','w','i','n','e','_','d','c','o','m','p','_','t','a','s','k','_','d','e','l','e','g','a','t','e','d','_','t','a','r','g','e','t',0};
-static const WCHAR dcomp_base_presentation_prop[] =
-    {'_','_','w','i','n','e','_','d','c','o','m','p','_','b','a','s','e','_','p','r','e','s','e','n','t','a','t','i','o','n',0};
 static const WCHAR dcomp_task_app_id_prop[] =
     {'_','_','w','i','n','e','_','d','c','o','m','p','_','t','a','s','k','_','a','p','p','_','i','d',0};
 static const WCHAR dcomp_detached_window_prop[] =
@@ -102,9 +96,6 @@ static void wayland_surface_enable_plasma_positioning(struct wayland_surface *su
 
 BOOL wayland_surface_export_toplevel(struct wayland_surface *surface)
 {
-    HWND delegate, target;
-    BOOL task_delegated;
-
     if (!process_wayland.zxdg_exporter_v2 || surface->role != WAYLAND_SURFACE_ROLE_TOPLEVEL ||
         !surface->xdg_toplevel)
         return FALSE;
@@ -115,13 +106,8 @@ BOOL wayland_surface_export_toplevel(struct wayland_surface *surface)
      * positioning request.  Position the exported host through Plasma as
      * well, so its Win32 screen coordinates and the detached surfaces share
      * the same origin. */
-    delegate = NtUserGetProp(surface->hwnd, dcomp_task_delegated_prop);
-    target = NtUserGetProp(surface->hwnd, dcomp_task_delegated_target_prop);
-    task_delegated = delegate && target && NtUserIsWindow(delegate) && NtUserIsWindow(target) &&
-                     NtUserGetAncestor(target, GA_ROOT) == surface->hwnd &&
-                     NtUserGetProp(delegate, dcomp_detached_window_prop) == target &&
-                     NtUserGetProp(target, dcomp_base_presentation_prop) == delegate;
-    wayland_surface_enable_plasma_positioning(surface, task_delegated);
+    wayland_surface_enable_plasma_positioning(surface,
+            wayland_window_is_dcomp_task_delegated(surface->hwnd));
 
     if (surface->zxdg_exported_v2) return TRUE;
 

--- a/dlls/winewayland.drv/wayland_text_input.c
+++ b/dlls/winewayland.drv/wayland_text_input.c
@@ -33,13 +33,44 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(imm);
 
-static void post_ime_update(HWND hwnd, UINT cursor_pos, WCHAR *comp_str, WCHAR *result_str)
+static void post_ime_update(HWND hwnd, HWND surface_hwnd, UINT cursor_pos, WCHAR *comp_str, WCHAR *result_str)
 {
+    struct send_message_timeout_params params = { .flags = SMTO_ABORTIFHUNG, .timeout = 250 };
+    COPYDATASTRUCT copydata = { .dwData = WINE_IME_UPDATE_COPYDATA };
+    struct wine_ime_update *update;
+    UINT comp_len, result_len;
+    SIZE_T comp_chars, result_chars, size;
+
     /* Windows uses an empty string to clear the composition string. */
     if (!comp_str && !result_str) comp_str = (WCHAR *)L"";
+    comp_chars = comp_str ? wcslen(comp_str) + 1 : 0;
+    result_chars = result_str ? wcslen(result_str) + 1 : 0;
+    if (comp_chars > WINE_IME_UPDATE_MAX_CHARS || result_chars > WINE_IME_UPDATE_MAX_CHARS ||
+        comp_chars + result_chars > WINE_IME_UPDATE_MAX_CHARS)
+        return;
+    comp_len = comp_chars;
+    result_len = result_chars;
 
-    NtUserMessageCall(hwnd, WINE_IME_POST_UPDATE, cursor_pos, (LPARAM)comp_str, result_str,
-            NtUserImeDriverCall, FALSE);
+    if (HandleToULong(NtUserQueryWindow(hwnd, WindowProcess)) == GetCurrentProcessId())
+    {
+        NtUserMessageCall(hwnd, WINE_IME_POST_UPDATE, cursor_pos, (LPARAM)comp_str, result_str,
+                NtUserImeDriverCall, FALSE);
+        return;
+    }
+
+    size = offsetof(struct wine_ime_update, strings) +
+            (SIZE_T)(comp_len + result_len) * sizeof(WCHAR);
+    if (!(update = malloc(size))) return;
+    update->cursor_pos = cursor_pos;
+    update->comp_len = comp_len;
+    update->result_len = result_len;
+    if (comp_len) memcpy(update->strings, comp_str, comp_len * sizeof(WCHAR));
+    if (result_len) memcpy(update->strings + comp_len, result_str, result_len * sizeof(WCHAR));
+    copydata.cbData = size;
+    copydata.lpData = update;
+    NtUserMessageCall(hwnd, WM_COPYDATA, (WPARAM)surface_hwnd, (LPARAM)&copydata, &params,
+            NtUserSendMessageTimeout, FALSE);
+    free(update);
 }
 
 static WCHAR *strdupUtoW(const char *str)
@@ -60,6 +91,15 @@ static WCHAR *strdupUtoW(const char *str)
     return ret;
 }
 
+static WCHAR *strdupW(const WCHAR *str)
+{
+    size_t size = (wcslen(str) + 1) * sizeof(*str);
+    WCHAR *ret;
+
+    if ((ret = malloc(size))) memcpy(ret, str, size);
+    return ret;
+}
+
 static void wayland_text_input_reset_pending_state(struct wayland_text_input *text_input)
 {
     free(text_input->preedit.string);
@@ -77,6 +117,25 @@ static void wayland_text_input_reset_all_state(struct wayland_text_input *text_i
     wayland_text_input_reset_pending_state(text_input);
 }
 
+void wayland_text_input_clear_focus(HWND surface_hwnd)
+{
+    struct wayland_text_input *text_input = &process_wayland.text_input;
+    HWND focused_hwnd = NULL;
+
+    pthread_mutex_lock(&text_input->mutex);
+    if (text_input->focused_surface_hwnd == surface_hwnd)
+    {
+        focused_hwnd = text_input->focused_hwnd;
+        wayland_text_input_reset_all_state(text_input);
+        text_input->focused_hwnd = NULL;
+        text_input->focused_surface_hwnd = NULL;
+        text_input->focused_root_hwnd = NULL;
+    }
+    pthread_mutex_unlock(&text_input->mutex);
+
+    if (focused_hwnd) post_ime_update(focused_hwnd, surface_hwnd, 0, NULL, NULL);
+}
+
 static void text_input_enter(void *data, struct zwp_text_input_v3 *zwp_text_input_v3,
         struct wl_surface *surface)
 {
@@ -89,7 +148,9 @@ static void text_input_enter(void *data, struct zwp_text_input_v3 *zwp_text_inpu
     TRACE("data %p, text_input %p, hwnd %p.\n", data, zwp_text_input_v3, hwnd);
 
     pthread_mutex_lock(&text_input->mutex);
-    text_input->focused_hwnd = hwnd;
+    text_input->focused_surface_hwnd = hwnd;
+    text_input->focused_hwnd = wayland_get_input_hwnd(hwnd);
+    text_input->focused_root_hwnd = NtUserGetAncestor(text_input->focused_hwnd, GA_ROOT);
     zwp_text_input_v3_enable(text_input->zwp_text_input_v3);
     zwp_text_input_v3_set_content_type(text_input->zwp_text_input_v3,
             ZWP_TEXT_INPUT_V3_CONTENT_HINT_NONE,
@@ -105,18 +166,21 @@ static void text_input_leave(void *data, struct zwp_text_input_v3 *zwp_text_inpu
         struct wl_surface *surface)
 {
     struct wayland_text_input *text_input = data;
+    HWND focused_hwnd, surface_hwnd;
     TRACE("data %p, text_input %p.\n", data, zwp_text_input_v3);
 
     pthread_mutex_lock(&text_input->mutex);
     zwp_text_input_v3_disable(text_input->zwp_text_input_v3);
     zwp_text_input_v3_commit(text_input->zwp_text_input_v3);
-    if (text_input->focused_hwnd)
-    {
-        post_ime_update(text_input->focused_hwnd, 0, NULL, NULL);
-        text_input->focused_hwnd = NULL;
-    }
+    focused_hwnd = text_input->focused_hwnd;
+    surface_hwnd = text_input->focused_surface_hwnd;
+    text_input->focused_hwnd = NULL;
+    text_input->focused_surface_hwnd = NULL;
+    text_input->focused_root_hwnd = NULL;
     wayland_text_input_reset_all_state(text_input);
     pthread_mutex_unlock(&text_input->mutex);
+
+    if (focused_hwnd) post_ime_update(focused_hwnd, surface_hwnd, 0, NULL, NULL);
 }
 
 static void text_input_preedit_string(void *data, struct zwp_text_input_v3 *zwp_text_input_v3,
@@ -163,6 +227,9 @@ static void text_input_done(void *data, struct zwp_text_input_v3 *zwp_text_input
         uint32_t serial)
 {
     struct wayland_text_input *text_input = data;
+    HWND focused_hwnd = NULL, surface_hwnd = NULL;
+    UINT cursor_pos = 0;
+    WCHAR *comp_str = NULL, *result_str = NULL;
     TRACE("data %p, text_input %p, serial %u.\n", data, zwp_text_input_v3, serial);
 
     pthread_mutex_lock(&text_input->mutex);
@@ -177,14 +244,23 @@ static void text_input_done(void *data, struct zwp_text_input_v3 *zwp_text_input
          (text_input->preedit.string && text_input->current_preedit.string &&
           wcscmp(text_input->preedit.string, text_input->current_preedit.string))))
     {
-        post_ime_update(text_input->focused_hwnd, text_input->preedit.cursor_pos,
-                text_input->preedit.string, text_input->commit_string);
+        focused_hwnd = text_input->focused_hwnd;
+        surface_hwnd = text_input->focused_surface_hwnd;
+        cursor_pos = text_input->preedit.cursor_pos;
+        if (text_input->preedit.string) comp_str = strdupW(text_input->preedit.string);
+        if (text_input->commit_string) result_str = strdupW(text_input->commit_string);
+        if ((text_input->preedit.string && !comp_str) || (text_input->commit_string && !result_str))
+            focused_hwnd = NULL;
     }
     free(text_input->current_preedit.string);
     text_input->current_preedit = text_input->preedit;
     text_input->preedit.string = NULL;
     wayland_text_input_reset_pending_state(text_input);
     pthread_mutex_unlock(&text_input->mutex);
+
+    if (focused_hwnd) post_ime_update(focused_hwnd, surface_hwnd, cursor_pos, comp_str, result_str);
+    free(comp_str);
+    free(result_str);
 }
 
 static const struct zwp_text_input_v3_listener text_input_listener =
@@ -211,13 +287,20 @@ void wayland_text_input_init(void)
 void wayland_text_input_deinit(void)
 {
     struct wayland_text_input *text_input = &process_wayland.text_input;
+    HWND focused_hwnd, surface_hwnd;
 
     pthread_mutex_lock(&text_input->mutex);
+    focused_hwnd = text_input->focused_hwnd;
+    surface_hwnd = text_input->focused_surface_hwnd;
     zwp_text_input_v3_destroy(text_input->zwp_text_input_v3);
     text_input->zwp_text_input_v3 = NULL;
     text_input->focused_hwnd = NULL;
+    text_input->focused_surface_hwnd = NULL;
+    text_input->focused_root_hwnd = NULL;
     wayland_text_input_reset_all_state(text_input);
     pthread_mutex_unlock(&text_input->mutex);
+
+    if (focused_hwnd) post_ime_update(focused_hwnd, surface_hwnd, 0, NULL, NULL);
 };
 
 /***********************************************************************
@@ -228,28 +311,29 @@ BOOL WAYLAND_SetIMECompositionRect(HWND hwnd, RECT rect)
     struct wayland_text_input *text_input = &process_wayland.text_input;
     struct wayland_win_data *data;
     struct wayland_surface *surface;
+    HWND surface_hwnd;
     RECT surface_rect;
 
     TRACE("hwnd %p, rect %s.\n", hwnd, wine_dbgstr_rect(&rect));
 
     pthread_mutex_lock(&text_input->mutex);
+    if (hwnd == text_input->focused_root_hwnd)
+        surface_hwnd = text_input->focused_surface_hwnd;
+    else if (hwnd == text_input->focused_surface_hwnd)
+        surface_hwnd = hwnd;
+    else
+        surface_hwnd = NULL;
+    pthread_mutex_unlock(&text_input->mutex);
+    if (!surface_hwnd || !(data = wayland_win_data_get(surface_hwnd))) return FALSE;
 
-    if (!text_input->zwp_text_input_v3 || hwnd != text_input->focused_hwnd)
+    pthread_mutex_lock(&text_input->mutex);
+    if (!text_input->zwp_text_input_v3 || surface_hwnd != text_input->focused_surface_hwnd ||
+        (hwnd != text_input->focused_root_hwnd && hwnd != surface_hwnd) ||
+        !(surface = data->wayland_surface))
         goto err;
-
-    if (!(data = wayland_win_data_get(hwnd)))
-        goto err;
-
-    if (!(surface = data->wayland_surface))
-    {
-        wayland_win_data_release(data);
-        goto err;
-    }
-
 
     OffsetRect(&rect, -surface->window.rect.left, -surface->window.rect.top);
     surface_rect = map_rect_to_surface(surface, rect);
-    wayland_win_data_release(data);
 
     zwp_text_input_v3_set_cursor_rectangle(text_input->zwp_text_input_v3,
             surface_rect.left, surface_rect.top, surface_rect.right - surface_rect.left,
@@ -257,9 +341,11 @@ BOOL WAYLAND_SetIMECompositionRect(HWND hwnd, RECT rect)
     zwp_text_input_v3_commit(text_input->zwp_text_input_v3);
 
     pthread_mutex_unlock(&text_input->mutex);
+    wayland_win_data_release(data);
     return TRUE;
 
 err:
     pthread_mutex_unlock(&text_input->mutex);
+    wayland_win_data_release(data);
     return FALSE;
 }

--- a/dlls/winewayland.drv/waylanddrv.h
+++ b/dlls/winewayland.drv/waylanddrv.h
@@ -92,12 +92,19 @@ enum wayland_surface_role
     WAYLAND_SURFACE_ROLE_SUBSURFACE,
 };
 
+#define WAYLAND_KEY_COUNT 0x300
+
 struct wayland_keyboard
 {
     struct wl_keyboard *wl_keyboard;
     struct xkb_context *xkb_context;
     struct xkb_state *xkb_state;
     HWND focused_hwnd;
+    HWND focused_input_hwnd;
+    HWND key_hwnds[WAYLAND_KEY_COUNT];
+    HWND synthetic_right_control_hwnd;
+    HWND right_control_hwnd;
+    unsigned int focus_generation;
     pthread_mutex_t mutex;
 };
 
@@ -107,6 +114,22 @@ struct wayland_cursor
     struct wl_surface *wl_surface;
     struct wp_viewport *wp_viewport;
     int hotspot_x, hotspot_y;
+};
+
+#define WAYLAND_POINTER_BUTTON_COUNT 32
+
+struct wayland_pointer_button
+{
+    uint32_t button;
+    uint32_t serial;
+    HWND hwnd;
+    HWND root_hwnd;
+    HWND input_hwnd;
+    DWORD up_flags;
+    DWORD mouse_data;
+    BOOL pressed;
+    BOOL injected;
+    BOOL edge_resize;
 };
 
 struct wayland_pointer
@@ -121,9 +144,9 @@ struct wayland_pointer
     HWND constraint_hwnd;
     BOOL relative_mode;
     BOOL pending_warp;
-    BOOL edge_resize;
     uint32_t enter_serial;
     uint32_t button_serial;
+    struct wayland_pointer_button buttons[WAYLAND_POINTER_BUTTON_COUNT];
     struct wayland_cursor cursor;
     double accum_x;
     double accum_y;
@@ -144,6 +167,8 @@ struct wayland_text_input
     } preedit, current_preedit;
     WCHAR *commit_string;
     HWND focused_hwnd;
+    HWND focused_surface_hwnd;
+    HWND focused_root_hwnd;
     pthread_mutex_t mutex;
 };
 
@@ -460,6 +485,8 @@ UINT WAYLAND_GetKeyboardLayoutList(INT size, HKL *layouts);
 const KBDTABLES *WAYLAND_KbdLayerDescriptor(HKL hkl);
 void WAYLAND_ReleaseKbdTables(const KBDTABLES *);
 void activate_keyboard_hkl(HWND hwnd, BOOL ime);
+BOOL wayland_keyboard_clear_surface_focus(HWND hwnd);
+void wayland_keyboard_destroy_window(HWND hwnd);
 
 /**********************************************************************
  *          Wayland pointer
@@ -468,6 +495,7 @@ void activate_keyboard_hkl(HWND hwnd, BOOL ime);
 void wayland_pointer_init(struct wl_pointer *wl_pointer);
 HWND wayland_get_input_hwnd(HWND hwnd);
 void wayland_pointer_deinit(void);
+void wayland_pointer_clear_button_owners(HWND hwnd);
 void wayland_pointer_clear_constraint(void);
 
 /**********************************************************************
@@ -512,6 +540,7 @@ BOOL WAYLAND_ClipCursor(const RECT *clip, BOOL reset);
 LRESULT WAYLAND_DesktopWindowProc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp);
 void WAYLAND_DestroyWindow(HWND hwnd);
 BOOL WAYLAND_SetIMECompositionRect(HWND hwnd, RECT rect);
+void wayland_text_input_clear_focus(HWND surface_hwnd);
 void WAYLAND_SetCursor(HWND hwnd, HCURSOR hcursor);
 BOOL WAYLAND_SetCursorPos(INT x, INT y);
 void WAYLAND_SetLayeredWindowAttributes(HWND hwnd, COLORREF key, BYTE alpha, DWORD flags);

--- a/dlls/winewayland.drv/waylanddrv.h
+++ b/dlls/winewayland.drv/waylanddrv.h
@@ -472,6 +472,7 @@ struct wayland_shm_buffer *get_window_surface_contents(HWND hwnd);
 void wayland_reapply_cursor_clipping(HWND hwnd);
 void wayland_restack_after_surface_flush(HWND owner);
 void wayland_window_surface_presented(HWND hwnd);
+BOOL wayland_window_is_dcomp_task_delegated(HWND root);
 void wayland_window_init(void);
 
 /**********************************************************************

--- a/dlls/winewayland.drv/window.c
+++ b/dlls/winewayland.drv/window.c
@@ -43,6 +43,52 @@ static const WCHAR dcomp_background_prop[] =
     {'_','_','w','i','n','e','_','d','c','o','m','p','_','c','o','m','p','o','s','i','t','e','_','a','l','p','h','a','_','b','a','c','k','g','r','o','u','n','d',0};
 static const WCHAR dcomp_caption_overlay_prop[] =
     {'_','_','w','i','n','e','_','d','c','o','m','p','_','c','a','p','t','i','o','n','_','o','v','e','r','l','a','y',0};
+static const WCHAR dcomp_task_delegated_prop[] =
+    {'_','_','w','i','n','e','_','d','c','o','m','p','_','t','a','s','k','_','d','e','l','e','g','a','t','e','d',0};
+static const WCHAR dcomp_task_delegated_target_prop[] =
+    {'_','_','w','i','n','e','_','d','c','o','m','p','_','t','a','s','k','_','d','e','l','e','g','a','t','e','d','_','t','a','r','g','e','t',0};
+static const WCHAR dcomp_base_presentation_prop[] =
+    {'_','_','w','i','n','e','_','d','c','o','m','p','_','b','a','s','e','_','p','r','e','s','e','n','t','a','t','i','o','n',0};
+static const WCHAR dcomp_task_delegate_timer_prop[] =
+    {'_','_','w','i','n','e','_','d','c','o','m','p','_','t','a','s','k','_','d','e','l','e','g','a','t','e','_','t','i','m','e','r',0};
+
+static BOOL wayland_dcomp_task_delegated(HWND root)
+{
+    HWND delegate = NtUserGetProp(root, dcomp_task_delegated_prop);
+    HWND target = NtUserGetProp(root, dcomp_task_delegated_target_prop);
+
+    return delegate && target && NtUserIsWindow(delegate) && NtUserIsWindow(target) &&
+           NtUserGetAncestor(target, GA_ROOT) == root &&
+           NtUserGetProp(delegate, dcomp_detached_window_prop) == target &&
+           NtUserGetProp(target, dcomp_base_presentation_prop) == delegate;
+}
+
+static void WINAPI wayland_dcomp_task_delegate_timer(HWND hwnd, UINT msg, UINT_PTR id, DWORD time)
+{
+    if (wayland_dcomp_task_delegated(hwnd)) return;
+
+    NtUserKillTimer(hwnd, id);
+    if (NtUserGetProp(hwnd, dcomp_task_delegate_timer_prop) == (HANDLE)id)
+        NtUserRemoveProp(hwnd, dcomp_task_delegate_timer_prop);
+    NtUserPostMessage(hwnd, WM_WAYLAND_DCOMP_EXPORT, 0, 0);
+}
+
+static void wayland_update_dcomp_task_delegate_timer(HWND hwnd, BOOL delegated)
+{
+    UINT_PTR id = (UINT_PTR)NtUserGetProp(hwnd, dcomp_task_delegate_timer_prop);
+
+    if (delegated && !id)
+    {
+        id = NtUserSetTimer(hwnd, 0, 1000, wayland_dcomp_task_delegate_timer,
+                            TIMERV_DEFAULT_COALESCING);
+        if (id) NtUserSetProp(hwnd, dcomp_task_delegate_timer_prop, (HANDLE)id);
+    }
+    else if (!delegated && id)
+    {
+        NtUserKillTimer(hwnd, id);
+        NtUserRemoveProp(hwnd, dcomp_task_delegate_timer_prop);
+    }
+}
 
 
 static int wayland_win_data_cmp_rb(const void *key,
@@ -409,10 +455,12 @@ static BOOL wayland_win_data_create_wayland_surface(struct wayland_win_data *dat
         !data->contents_presented && !state->has_background)
         visible = FALSE;
 
-    /* A DirectComposition-only notification host is a logical Win32 target,
-     * not a presentation surface. Keep it role-less and let the detached
-     * composition window be the only compositor-visible surface. */
-    if (!visible || (data->dcomp_only_host && (state->exstyle & WS_EX_NOREDIRECTIONBITMAP)))
+    /* DirectComposition-only notification hosts and roots which delegated
+     * their desktop task are logical Win32 targets, not presentation
+     * surfaces. Mapping the delegated root beside its opaque DComp base leaves
+     * two unrelated toplevels and lets the root's white buffer cover the app. */
+    if (!visible || wayland_dcomp_task_delegated(data->hwnd) ||
+        (data->dcomp_only_host && (state->exstyle & WS_EX_NOREDIRECTIONBITMAP)))
         role = WAYLAND_SURFACE_ROLE_NONE;
     else if (owner_surface) role = WAYLAND_SURFACE_ROLE_SUBSURFACE;
     else role = WAYLAND_SURFACE_ROLE_TOPLEVEL;
@@ -757,6 +805,9 @@ void WAYLAND_DestroyWindow(HWND hwnd)
 
     TRACE("%p\n", hwnd);
 
+    wayland_update_dcomp_task_delegate_timer(hwnd, FALSE);
+    wayland_pointer_clear_button_owners(hwnd);
+    wayland_keyboard_destroy_window(hwnd);
     if (!(data = wayland_win_data_get(hwnd))) return;
     wayland_win_data_destroy(data);
 }
@@ -1098,13 +1149,44 @@ LRESULT WAYLAND_WindowMessage(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp)
     case WM_WAYLAND_DCOMP_EXPORT:
     {
         struct wayland_win_data *data;
+        struct wayland_window_state state;
+        BOOL delegated, reapply_clip = FALSE, update_clients = FALSE;
 
+        delegated = wayland_dcomp_task_delegated(hwnd);
+        wayland_update_dcomp_task_delegate_timer(hwnd, delegated);
+        get_wayland_window_state(hwnd, &state);
         if ((data = wayland_win_data_get(hwnd)))
         {
-            if (data->wayland_surface)
-                wayland_surface_export_toplevel(data->wayland_surface);
+            enum wayland_surface_role old_role = data->wayland_surface ?
+                                                  data->wayland_surface->role :
+                                                  WAYLAND_SURFACE_ROLE_NONE;
+            BOOL surface_recreated = FALSE;
+
+            /* A wl_surface cannot shed an xdg_toplevel role. Destroy the
+             * compositor object when its Win32 root delegates presentation;
+             * the detached DComp base remains as the sole desktop task. */
+            if (delegated && data->wayland_surface &&
+                data->wayland_surface->role != WAYLAND_SURFACE_ROLE_NONE)
+            {
+                struct wayland_surface *surface = data->wayland_surface;
+
+                data->wayland_surface = NULL;
+                wayland_surface_destroy(surface);
+                update_clients = TRUE;
+            }
+            if (wayland_win_data_create_wayland_surface(data, NULL, &state,
+                                                        &reapply_clip, &surface_recreated))
+            {
+                update_clients = surface_recreated ||
+                                 old_role != data->wayland_surface->role;
+                wayland_win_data_update_wayland_state(data);
+                if (wayland_surface_is_toplevel(data->wayland_surface))
+                    wayland_surface_export_toplevel(data->wayland_surface);
+            }
             wayland_win_data_release(data);
         }
+        if (reapply_clip) wayland_reapply_cursor_clipping(hwnd);
+        if (update_clients) update_client_surfaces(hwnd);
         return 0;
     }
     case WM_WAYLAND_SET_KEYBOARD_LAYOUT:

--- a/dlls/winewayland.drv/window.c
+++ b/dlls/winewayland.drv/window.c
@@ -52,7 +52,7 @@ static const WCHAR dcomp_base_presentation_prop[] =
 static const WCHAR dcomp_task_delegate_timer_prop[] =
     {'_','_','w','i','n','e','_','d','c','o','m','p','_','t','a','s','k','_','d','e','l','e','g','a','t','e','_','t','i','m','e','r',0};
 
-static BOOL wayland_dcomp_task_delegated(HWND root)
+BOOL wayland_window_is_dcomp_task_delegated(HWND root)
 {
     HWND delegate = NtUserGetProp(root, dcomp_task_delegated_prop);
     HWND target = NtUserGetProp(root, dcomp_task_delegated_target_prop);
@@ -65,7 +65,7 @@ static BOOL wayland_dcomp_task_delegated(HWND root)
 
 static void WINAPI wayland_dcomp_task_delegate_timer(HWND hwnd, UINT msg, UINT_PTR id, DWORD time)
 {
-    if (wayland_dcomp_task_delegated(hwnd)) return;
+    if (wayland_window_is_dcomp_task_delegated(hwnd)) return;
 
     NtUserKillTimer(hwnd, id);
     if (NtUserGetProp(hwnd, dcomp_task_delegate_timer_prop) == (HANDLE)id)
@@ -459,7 +459,7 @@ static BOOL wayland_win_data_create_wayland_surface(struct wayland_win_data *dat
      * their desktop task are logical Win32 targets, not presentation
      * surfaces. Mapping the delegated root beside its opaque DComp base leaves
      * two unrelated toplevels and lets the root's white buffer cover the app. */
-    if (!visible || wayland_dcomp_task_delegated(data->hwnd) ||
+    if (!visible || wayland_window_is_dcomp_task_delegated(data->hwnd) ||
         (data->dcomp_only_host && (state->exstyle & WS_EX_NOREDIRECTIONBITMAP)))
         role = WAYLAND_SURFACE_ROLE_NONE;
     else if (owner_surface) role = WAYLAND_SURFACE_ROLE_SUBSURFACE;
@@ -1152,7 +1152,7 @@ LRESULT WAYLAND_WindowMessage(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp)
         struct wayland_window_state state;
         BOOL delegated, reapply_clip = FALSE, update_clients = FALSE;
 
-        delegated = wayland_dcomp_task_delegated(hwnd);
+        delegated = wayland_window_is_dcomp_task_delegated(hwnd);
         wayland_update_dcomp_task_delegate_timer(hwnd, delegated);
         get_wayland_window_state(hwnd, &state);
         if ((data = wayland_win_data_get(hwnd)))


### PR DESCRIPTION
## Stack

PR 6 of 8. Stacked on #29; merge only after #29.

## Summary

- Keep compositor focus on the synthetic presentation while routing input to server-authorized logical endpoints.
- Preserve keyboard ownership across remapping, AltGr, focus changes, seat loss, and process teardown.
- Route pointer and text-input state without trusting stale client-published topology.
- Keep delegated logical roots roleless while the opaque presentation owns the task surface.

## Functional boundary

Includes the Wayland consumer side of the DComp authorization model from #29.

Excludes native nonclient frames, frame-aware configure handling, allocation stability, and task icons from #31-#32.

## Validation

- `git diff --check` passes.
- The validated combined-WoW64 integration rebuilt `winewayland.so` cleanly.
- Focused x86_64 and i386 DComp input, keyboard ownership, key-up, restart, and teardown regressions passed with zero failures.
- New Outlook WebView keyboard input was confirmed over native Wayland RDP without submitting account data.

## Provenance

- Base branch: `feature/outlook-new-05-dcomp-authorization`.
- Reconstructed from final integration HEAD `cf77f3b43ce5981bac562d692d25c74dc1ed6be1`.
- The original dirty integration worktree was not modified.

## Review notes

The presentation surface remains the compositor focus identity; every routed input endpoint is revalidated through the server-owned relationship before delivery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Route Wayland input through server-authorized DirectComposition surfaces while keeping delegated logical roots roleless and presentation focus stable.

New Features:
- Route keyboard, pointer, and text-input events through authorized DirectComposition input endpoints while retaining the presentation surface as the compositor focus identity.

Bug Fixes:
- Preserve and safely release keyboard and pointer ownership across focus changes, remapping, seat loss, window destruction, and driver teardown.
- Prevent delegated logical roots from becoming competing Wayland presentation surfaces.

Enhancements:
- Track delegated DirectComposition relationships and recover presentation exports when delegation becomes invalid.
- Improve cross-process IME update delivery and validate composition targets against the focused surface topology.

Documentation:
- Document delegated DirectComposition input routing in the changelog.