### PR TITLE
dxgi: Frame DComp task presentations with correct identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- Let modern Office identify the current user without exposing machine, account,
+  or application identifiers.
+- Let packaged Office components discover their local application-data folders
+  and education-environment state.
+- Let modern Office web views observe text and child-node changes reliably.
+- Keep Outlook shortcuts working safely across Store package changes and
+  classic Outlook fallback.
+- Give DirectComposition-hosted Office windows their original frame and task identity.
+
 ## 0.2.0-beta.1 — 2026-08-19
 
 - Let Office finish proofing-language updates without crashing Click-to-Run.

--- a/dlls/dcomp/tests/device.c
+++ b/dlls/dcomp/tests/device.c
@@ -337,7 +337,10 @@ static BOOL get_test_swapchain_rect(IDXGISwapChain1 *swapchain, RECT *rect)
 {
     HWND window;
 
-    return SUCCEEDED(IDXGISwapChain1_GetHwnd(swapchain, &window)) && GetWindowRect(window, rect);
+    if (FAILED(IDXGISwapChain1_GetHwnd(swapchain, &window)) || !GetClientRect(window, rect))
+        return FALSE;
+    MapWindowPoints(window, NULL, (POINT *)rect, 2);
+    return TRUE;
 }
 
 static void check_test_rect(const char *name, const RECT *base, const RECT *got,
@@ -370,7 +373,7 @@ static void test_visual_geometry(void)
     IDCompositionVisual *root = NULL, *child1 = NULL, *child2 = NULL;
     IDCompositionVisualPrivate *root_private = NULL;
     HMODULE d3d11 = NULL, dxgi = NULL;
-    HWND target_window = NULL, child1_window = NULL, child2_window = NULL;
+    HWND target_root = NULL, target_window = NULL, child1_window = NULL, child2_window = NULL;
     d3d11_create_device_proc pD3D11CreateDevice;
     create_dxgi_factory_proc pCreateDXGIFactory1;
     D2D_MATRIX_3X2_F root_transform = {0}, child_transform = {0};
@@ -422,15 +425,23 @@ static void test_visual_geometry(void)
         win_skip("DCompositionCreateDevice failed, hr %#lx.\n", hr);
         goto done;
     }
-    target_window = CreateWindowW(L"static", L"dcomp geometry test", WS_OVERLAPPEDWINDOW,
+    target_root = CreateWindowW(L"static", L"dcomp geometry test", WS_OVERLAPPEDWINDOW,
             100, 100, 320, 200, NULL, NULL, NULL, NULL);
-    if (!target_window)
+    if (!target_root)
     {
-        win_skip("Could not create geometry target window.\n");
+        win_skip("Could not create geometry root window.\n");
         goto done;
     }
-    ShowWindow(target_window, SW_SHOW);
-    UpdateWindow(target_window);
+    ShowWindow(target_root, SW_SHOW);
+    UpdateWindow(target_root);
+    if (!GetClientRect(target_root, &target_rect) ||
+        !(target_window = CreateWindowW(L"static", L"dcomp geometry target",
+                WS_CHILD | WS_VISIBLE, 0, 0, target_rect.right, target_rect.bottom,
+                target_root, NULL, NULL, NULL)))
+    {
+        win_skip("Could not create geometry child target window.\n");
+        goto done;
+    }
     if (FAILED(hr = IDCompositionDevice_CreateTargetForHwnd(device, target_window, FALSE, &target)))
     {
         win_skip("CreateTargetForHwnd failed, hr %#lx.\n", hr);
@@ -644,6 +655,7 @@ done:
     if (dxgi_device) IDXGIDevice_Release(dxgi_device);
     if (d3d_device) ID3D11Device_Release(d3d_device);
     if (target_window) DestroyWindow(target_window);
+    if (target_root) DestroyWindow(target_root);
     if (d3d11) FreeLibrary(d3d11);
 }
 

--- a/dlls/dxgi/dxgi_private.h
+++ b/dlls/dxgi/dxgi_private.h
@@ -198,6 +198,9 @@ struct d3d11_swapchain
 
 void dxgi_swapchain_set_composition_window(IDXGISwapChain1 *iface, HWND window);
 BOOL dxgi_composition_window_get_rect(HWND window, HWND target, RECT *rect);
+BOOL dxgi_composition_window_needs_update(HWND window, const RECT *rect, UINT flags);
+BOOL dxgi_composition_window_update_frame(HWND window, HWND target, HWND root,
+        BOOL base_presentation, BOOL transparent_base);
 
 HRESULT d3d11_swapchain_init(struct d3d11_swapchain *swapchain, struct dxgi_device *device,
         struct wined3d_swapchain_desc *desc, const DXGI_SWAP_CHAIN_FULLSCREEN_DESC *fullscreen_desc);

--- a/dlls/dxgi/dxgi_private.h
+++ b/dlls/dxgi/dxgi_private.h
@@ -197,6 +197,7 @@ struct d3d11_swapchain
 };
 
 void dxgi_swapchain_set_composition_window(IDXGISwapChain1 *iface, HWND window);
+BOOL dxgi_composition_window_get_rect(HWND window, HWND target, RECT *rect);
 
 HRESULT d3d11_swapchain_init(struct d3d11_swapchain *swapchain, struct dxgi_device *device,
         struct wined3d_swapchain_desc *desc, const DXGI_SWAP_CHAIN_FULLSCREEN_DESC *fullscreen_desc);

--- a/dlls/dxgi/factory.c
+++ b/dlls/dxgi/factory.c
@@ -31,7 +31,7 @@ WINE_DEFAULT_DEBUG_CHANNEL(dxgi);
         WS_MINIMIZEBOX | WS_MAXIMIZEBOX)
 #define DCOMP_FRAME_EXSTYLE_MASK (WS_EX_DLGMODALFRAME | WS_EX_CLIENTEDGE | \
         WS_EX_STATICEDGE | WS_EX_WINDOWEDGE | WS_EX_LAYOUTRTL | \
-        WS_EX_RTLREADING | WS_EX_LEFTSCROLLBAR)
+        WS_EX_RTLREADING | WS_EX_LEFTSCROLLBAR | WS_EX_TOOLWINDOW)
 
 static const WCHAR dcomp_synthetic_window_prop[] =
     {'_','_','w','i','n','e','_','d','c','o','m','p','_','s','y','n','t','h','e','t','i','c','_','w','i','n','d','o','w',0};
@@ -516,7 +516,6 @@ BOOL dxgi_composition_window_get_rect(HWND window, HWND target, RECT *rect)
 {
     RECT frame;
     DWORD style, exstyle;
-    HWND root;
     UINT dpi;
 
     if (!dxgi_composition_window_get_content_rect(window, target, rect)) return FALSE;
@@ -524,8 +523,7 @@ BOOL dxgi_composition_window_get_rect(HWND window, HWND target, RECT *rect)
 
     style = GetWindowLongW(window, GWL_STYLE);
     exstyle = GetWindowLongW(window, GWL_EXSTYLE);
-    root = GetAncestor(target, GA_ROOT);
-    dpi = GetDpiForWindow(root ? root : window);
+    dpi = GetDpiForWindow(window);
     SetRect(&frame, 0, 0, rect->right - rect->left, rect->bottom - rect->top);
     if (!AdjustWindowRectExForDpi(&frame, style, FALSE, exstyle, dpi)) return FALSE;
     frame.right += rect->left;
@@ -536,7 +534,7 @@ BOOL dxgi_composition_window_get_rect(HWND window, HWND target, RECT *rect)
     return TRUE;
 }
 
-static BOOL dxgi_composition_window_needs_update(HWND window, const RECT *rect, UINT flags)
+BOOL dxgi_composition_window_needs_update(HWND window, const RECT *rect, UINT flags)
 {
     RECT current;
 
@@ -843,7 +841,7 @@ static BOOL dxgi_composition_window_has_native_frame(HWND window, HWND target, H
     return EqualRect(&content, &client);
 }
 
-static BOOL dxgi_composition_window_update_frame(HWND window, HWND target, HWND root,
+BOOL dxgi_composition_window_update_frame(HWND window, HWND target, HWND root,
         BOOL base_presentation, BOOL transparent_base)
 {
     DWORD old_style, old_exstyle, root_style, root_exstyle;
@@ -972,27 +970,35 @@ static void dxgi_composition_window_clear_owned_icons(HWND window)
     }
 }
 
-static void dxgi_composition_window_set_executable_icons(HWND window, const WCHAR *image)
+static BOOL dxgi_composition_window_set_executable_icons(HWND window, const WCHAR *image)
 {
     HICON big_icon = NULL, small_icon = NULL;
+    BOOL installed = FALSE;
     UINT count;
 
     count = PrivateExtractIconExW(image, 0, &big_icon, &small_icon, 1);
-    if (!count || count == ~0u) return;
+    if (!count || count == ~0u) return FALSE;
     if (big_icon)
     {
         if (SetPropW(window, dcomp_task_icon_big_prop, big_icon))
+        {
             SendMessageW(window, WM_SETICON, ICON_BIG, (LPARAM)big_icon);
+            installed = TRUE;
+        }
         else
             DestroyIcon(big_icon);
     }
     if (small_icon)
     {
         if (SetPropW(window, dcomp_task_icon_small_prop, small_icon))
+        {
             SendMessageW(window, WM_SETICON, ICON_SMALL, (LPARAM)small_icon);
+            installed = TRUE;
+        }
         else
             DestroyIcon(small_icon);
     }
+    return installed;
 }
 
 static void dxgi_composition_window_update_identity(HWND window, HWND root)
@@ -1027,9 +1033,9 @@ static void dxgi_composition_window_update_identity(HWND window, HWND root)
                             SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER |
                             SWP_NOACTIVATE | SWP_FRAMECHANGED);
                 }
-                if (process_id != GetCurrentProcessId())
-                    dxgi_composition_window_set_executable_icons(window, image);
-                SetPropW(window, L"__wine_dcomp_task_identity", root);
+                if (process_id == GetCurrentProcessId() ||
+                    dxgi_composition_window_set_executable_icons(window, image))
+                    SetPropW(window, L"__wine_dcomp_task_identity", root);
             }
             CloseHandle(process);
         }

--- a/dlls/dxgi/factory.c
+++ b/dlls/dxgi/factory.c
@@ -1017,6 +1017,7 @@ static void dxgi_composition_window_update_identity(HWND window, HWND root)
     GetWindowThreadProcessId(root, &process_id);
     if (GetPropW(window, L"__wine_dcomp_task_identity") != root)
     {
+        RemovePropW(window, L"__wine_dcomp_task_identity");
         dxgi_composition_window_clear_owned_icons(window);
         if ((process = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, process_id)))
         {

--- a/dlls/dxgi/factory.c
+++ b/dlls/dxgi/factory.c
@@ -27,8 +27,16 @@ WINE_DEFAULT_DEBUG_CHANNEL(dxgi);
 #define WM_WAYLAND_DCOMP_CAPTION_REDRAW (WM_APP + 0x104)
 #define WM_WINE_DCOMP_FOCUS     0x80000ff0
 
+#define DCOMP_FRAME_STYLE_MASK (WS_CAPTION | WS_SYSMENU | WS_THICKFRAME | \
+        WS_MINIMIZEBOX | WS_MAXIMIZEBOX)
+#define DCOMP_FRAME_EXSTYLE_MASK (WS_EX_DLGMODALFRAME | WS_EX_CLIENTEDGE | \
+        WS_EX_STATICEDGE | WS_EX_WINDOWEDGE | WS_EX_LAYOUTRTL | \
+        WS_EX_RTLREADING | WS_EX_LEFTSCROLLBAR)
+
 static const WCHAR dcomp_synthetic_window_prop[] =
     {'_','_','w','i','n','e','_','d','c','o','m','p','_','s','y','n','t','h','e','t','i','c','_','w','i','n','d','o','w',0};
+static const WCHAR dcomp_native_frame_prop[] =
+    {'_','_','w','i','n','e','_','d','c','o','m','p','_','n','a','t','i','v','e','_','f','r','a','m','e',0};
 
 static void dxgi_mark_synthetic_window(HWND window)
 {
@@ -431,12 +439,13 @@ static void STDMETHODCALLTYPE dxgi_factory_UnregisterOcclusionStatus(IWineDXGIFa
     FIXME("iface %p, cookie %#lx stub!\n", iface, cookie);
 }
 
-static BOOL dxgi_composition_window_get_rect(HWND window, HWND target, RECT *rect)
+static BOOL dxgi_composition_window_get_content_rect(HWND window, HWND target, RECT *rect)
 {
     HWND root;
     LONG offset_x, offset_y, scale_x = 10000, scale_y = 10000;
     LONGLONG base_width, base_height, scaled_width, scaled_height;
     LONGLONG left, top, right, bottom;
+
     if (GetPropW(window, L"__wine_dcomp_bounds_enabled"))
     {
         LONG bounds_x = (LONG)HandleToULong(GetPropW(window, L"__wine_dcomp_bounds_x"));
@@ -458,7 +467,6 @@ static BOOL dxgi_composition_window_get_rect(HWND window, HWND target, RECT *rec
         SetRect(rect, left, top, right, bottom);
         return TRUE;
     }
-
 
     if (!GetPropW(window, L"__wine_dcomp_client_rect") &&
         !GetPropW(window, L"__wine_dcomp_composite_alpha_background"))
@@ -504,6 +512,39 @@ static BOOL dxgi_composition_window_get_rect(HWND window, HWND target, RECT *rec
     return TRUE;
 }
 
+BOOL dxgi_composition_window_get_rect(HWND window, HWND target, RECT *rect)
+{
+    RECT frame;
+    DWORD style, exstyle;
+    HWND root;
+    UINT dpi;
+
+    if (!dxgi_composition_window_get_content_rect(window, target, rect)) return FALSE;
+    if (!GetPropW(window, dcomp_native_frame_prop)) return TRUE;
+
+    style = GetWindowLongW(window, GWL_STYLE);
+    exstyle = GetWindowLongW(window, GWL_EXSTYLE);
+    root = GetAncestor(target, GA_ROOT);
+    dpi = GetDpiForWindow(root ? root : window);
+    SetRect(&frame, 0, 0, rect->right - rect->left, rect->bottom - rect->top);
+    if (!AdjustWindowRectExForDpi(&frame, style, FALSE, exstyle, dpi)) return FALSE;
+    frame.right += rect->left;
+    frame.bottom += rect->top;
+    frame.left += rect->left;
+    frame.top += rect->top;
+    *rect = frame;
+    return TRUE;
+}
+
+static BOOL dxgi_composition_window_needs_update(HWND window, const RECT *rect, UINT flags)
+{
+    RECT current;
+
+    if ((flags & SWP_SHOWWINDOW) && !IsWindowVisible(window)) return TRUE;
+    if ((flags & SWP_FRAMECHANGED) || !(flags & SWP_NOZORDER)) return TRUE;
+    return !GetWindowRect(window, &current) || !EqualRect(&current, rect);
+}
+
 static BOOL dxgi_apps_use_light_theme(void)
 {
     DWORD light_theme = TRUE, size = sizeof(light_theme);
@@ -518,6 +559,10 @@ static const WCHAR dcomp_task_delegated_prop[] =
     {'_','_','w','i','n','e','_','d','c','o','m','p','_','t','a','s','k','_','d','e','l','e','g','a','t','e','d',0};
 static const WCHAR dcomp_task_app_id_prop[] =
     {'_','_','w','i','n','e','_','d','c','o','m','p','_','t','a','s','k','_','a','p','p','_','i','d',0};
+static const WCHAR dcomp_task_icon_big_prop[] =
+    {'_','_','w','i','n','e','_','d','c','o','m','p','_','t','a','s','k','_','i','c','o','n','_','b','i','g',0};
+static const WCHAR dcomp_task_icon_small_prop[] =
+    {'_','_','w','i','n','e','_','d','c','o','m','p','_','t','a','s','k','_','i','c','o','n','_','s','m','a','l','l',0};
 static const WCHAR dcomp_caption_window_prop[] =
     {'_','_','w','i','n','e','_','d','c','o','m','p','_','c','a','p','t','i','o','n','_','w','i','n','d','o','w',0};
 static const WCHAR dcomp_caption_root_prop[] =
@@ -756,6 +801,92 @@ static BOOL dxgi_composition_window_has_dwm_caption(HWND root)
     return client_rect.top - window_rect.top < MulDiv(16, dpi, USER_DEFAULT_SCREEN_DPI);
 }
 
+static BOOL dxgi_composition_window_has_native_frame(HWND window, HWND target, HWND root,
+        BOOL base_presentation, BOOL transparent_base)
+{
+    HANDLE transform, policy;
+    DWORD style;
+    LONG offset_x, offset_y, scale_x, scale_y;
+    BOOL custom_caption;
+    RECT content, client;
+
+    if (!base_presentation || transparent_base || !root) return FALSE;
+    policy = GetPropW(root, wine_dwm_nc_rendering_policy_prop);
+    style = GetWindowLongW(root, GWL_STYLE);
+    transform = GetPropW(window, L"__wine_dcomp_transform_enabled");
+    offset_x = (LONG)HandleToULong(GetPropW(window, L"__wine_dcomp_offset_x"));
+    offset_y = (LONG)HandleToULong(GetPropW(window, L"__wine_dcomp_offset_y"));
+    scale_x = (LONG)HandleToULong(GetPropW(window, L"__wine_dcomp_scale_x"));
+    scale_y = (LONG)HandleToULong(GetPropW(window, L"__wine_dcomp_scale_y"));
+    custom_caption = dxgi_composition_window_has_dwm_caption(root);
+    TRACE("DComp frame gate window %p target %p root %p style %#lx menu %p client %p clip %p "
+            "policy %p custom %u offset %ld,%ld transform %p scale %ld,%ld.\n",
+            window, target, root, style, GetMenu(root),
+            GetPropW(window, L"__wine_dcomp_client_rect"),
+            GetPropW(window, L"__wine_dcomp_clip_enabled"), policy, custom_caption,
+            offset_x, offset_y, transform, scale_x, scale_y);
+
+    if ((style & (WS_CHILD | WS_POPUP)) ||
+        (style & (WS_CAPTION | WS_SYSMENU)) != (WS_CAPTION | WS_SYSMENU) ||
+        GetMenu(root) || GetPropW(window, L"__wine_dcomp_client_rect") ||
+        GetPropW(window, L"__wine_dcomp_clip_enabled") ||
+        (policy && HandleToULong(policy) == DWMNCRP_DISABLED + 1) || custom_caption ||
+        offset_x || offset_y || (transform && (scale_x != 10000 || scale_y != 10000)))
+        return FALSE;
+
+    if (!dxgi_composition_window_get_content_rect(window, target, &content) ||
+        !GetClientRect(root, &client))
+        return FALSE;
+    MapWindowPoints(root, NULL, (POINT *)&client, 2);
+    TRACE("DComp frame geometry window %p content %s client %s equal %u.\n",
+            window, wine_dbgstr_rect(&content), wine_dbgstr_rect(&client), EqualRect(&content, &client));
+    return EqualRect(&content, &client);
+}
+
+static BOOL dxgi_composition_window_update_frame(HWND window, HWND target, HWND root,
+        BOOL base_presentation, BOOL transparent_base)
+{
+    DWORD old_style, old_exstyle, root_style, root_exstyle;
+    DWORD style, exstyle;
+    BOOL native_frame, old_native_frame;
+
+    TRACE("Updating DComp frame window %p target %p root %p base %u transparent %u.\n",
+            window, target, root, base_presentation, transparent_base);
+    native_frame = dxgi_composition_window_has_native_frame(window, target, root,
+            base_presentation, transparent_base);
+    old_style = GetWindowLongW(window, GWL_STYLE);
+    old_exstyle = GetWindowLongW(window, GWL_EXSTYLE);
+    old_native_frame = !!GetPropW(window, dcomp_native_frame_prop);
+    root_style = root ? GetWindowLongW(root, GWL_STYLE) : 0;
+    root_exstyle = root ? GetWindowLongW(root, GWL_EXSTYLE) : 0;
+
+    style = old_style & (WS_VISIBLE | WS_CLIPSIBLINGS);
+    if (native_frame)
+        style |= root_style & (DCOMP_FRAME_STYLE_MASK | WS_DISABLED | WS_MINIMIZE | WS_MAXIMIZE);
+    else
+        style |= WS_POPUP | (old_style & (WS_DISABLED | WS_MINIMIZE | WS_MAXIMIZE));
+
+    exstyle = native_frame ? root_exstyle & DCOMP_FRAME_EXSTYLE_MASK :
+            WS_EX_NOACTIVATE | WS_EX_TOOLWINDOW;
+    if (!base_presentation || transparent_base) exstyle |= WS_EX_LAYERED | WS_EX_TRANSPARENT;
+
+    if (style == old_style && exstyle == old_exstyle && native_frame == old_native_frame)
+        return native_frame;
+
+    if (native_frame)
+        SetPropW(window, dcomp_native_frame_prop, ULongToHandle(1));
+    else
+        RemovePropW(window, dcomp_native_frame_prop);
+    if (style != old_style) SetWindowLongW(window, GWL_STYLE, style);
+    if (exstyle != old_exstyle) SetWindowLongW(window, GWL_EXSTYLE, exstyle);
+    SetWindowPos(window, NULL, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE |
+            SWP_NOZORDER | SWP_NOOWNERZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
+    if (native_frame)
+        RedrawWindow(window, NULL, NULL,
+                RDW_INVALIDATE | RDW_FRAME | RDW_UPDATENOW | RDW_NOCHILDREN);
+    return native_frame;
+}
+
 static void dxgi_composition_window_update_caption(HWND window, HWND root)
 {
     static INIT_ONCE caption_class_once = INIT_ONCE_STATIC_INIT;
@@ -823,11 +954,52 @@ static void dxgi_composition_window_update_caption(HWND window, HWND root)
     UpdateWindow(caption);
 }
 
+static void dxgi_composition_window_clear_owned_icons(HWND window)
+{
+    HICON icon;
+
+    if ((icon = RemovePropW(window, dcomp_task_icon_big_prop)))
+    {
+        if ((HICON)SendMessageW(window, WM_GETICON, ICON_BIG, 0) == icon)
+            SendMessageW(window, WM_SETICON, ICON_BIG, 0);
+        DestroyIcon(icon);
+    }
+    if ((icon = RemovePropW(window, dcomp_task_icon_small_prop)))
+    {
+        if ((HICON)SendMessageW(window, WM_GETICON, ICON_SMALL, 0) == icon)
+            SendMessageW(window, WM_SETICON, ICON_SMALL, 0);
+        DestroyIcon(icon);
+    }
+}
+
+static void dxgi_composition_window_set_executable_icons(HWND window, const WCHAR *image)
+{
+    HICON big_icon = NULL, small_icon = NULL;
+    UINT count;
+
+    count = PrivateExtractIconExW(image, 0, &big_icon, &small_icon, 1);
+    if (!count || count == ~0u) return;
+    if (big_icon)
+    {
+        if (SetPropW(window, dcomp_task_icon_big_prop, big_icon))
+            SendMessageW(window, WM_SETICON, ICON_BIG, (LPARAM)big_icon);
+        else
+            DestroyIcon(big_icon);
+    }
+    if (small_icon)
+    {
+        if (SetPropW(window, dcomp_task_icon_small_prop, small_icon))
+            SendMessageW(window, WM_SETICON, ICON_SMALL, (LPARAM)small_icon);
+        else
+            DestroyIcon(small_icon);
+    }
+}
+
 static void dxgi_composition_window_update_identity(HWND window, HWND root)
 {
     WCHAR current[256], title[256];
     WCHAR image[MAX_PATH], *name;
-    DWORD image_len = ARRAY_SIZE(image), process_id;
+    DWORD image_len = ARRAY_SIZE(image), process_id = 0;
     DWORD_PTR icon;
     HANDLE process;
     ATOM atom;
@@ -836,31 +1008,36 @@ static void dxgi_composition_window_update_identity(HWND window, HWND root)
         (!GetWindowTextW(window, current, ARRAY_SIZE(current)) || wcscmp(current, title)))
         SetWindowTextW(window, title);
 
-    if (GetPropW(window, L"__wine_dcomp_task_identity") == root) return;
-
     GetWindowThreadProcessId(root, &process_id);
-    if ((process = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, process_id)))
+    if (GetPropW(window, L"__wine_dcomp_task_identity") != root)
     {
-        if (!QueryFullProcessImageNameW(process, 0, image, &image_len))
+        dxgi_composition_window_clear_owned_icons(window);
+        if ((process = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, process_id)))
         {
+            if (QueryFullProcessImageNameW(process, 0, image, &image_len))
+            {
+                name = wcsrchr(image, '\\');
+                if (!name) name = wcsrchr(image, '/');
+                name = name ? name + 1 : image;
+                if ((atom = RegisterWindowMessageW(name)) &&
+                    HandleToULong(GetPropW(window, dcomp_task_app_id_prop)) != atom)
+                {
+                    SetPropW(window, dcomp_task_app_id_prop, ULongToHandle(atom));
+                    SetWindowPos(window, NULL, 0, 0, 0, 0,
+                            SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER |
+                            SWP_NOACTIVATE | SWP_FRAMECHANGED);
+                }
+                if (process_id != GetCurrentProcessId())
+                    dxgi_composition_window_set_executable_icons(window, image);
+                SetPropW(window, L"__wine_dcomp_task_identity", root);
+            }
             CloseHandle(process);
-            return;
         }
-        name = wcsrchr(image, '\\');
-        if (!name) name = wcsrchr(image, '/');
-        name = name ? name + 1 : image;
-        if ((atom = RegisterWindowMessageW(name)) &&
-            HandleToULong(GetPropW(window, dcomp_task_app_id_prop)) != atom)
-        {
-            SetPropW(window, dcomp_task_app_id_prop, ULongToHandle(atom));
-            SetWindowPos(window, NULL, 0, 0, 0, 0,
-                    SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER |
-                    SWP_NOACTIVATE | SWP_FRAMECHANGED);
-        }
-        CloseHandle(process);
     }
-    else
-        return;
+
+    /* USER icon handles are process-local, so foreign roots use icons
+     * reconstructed from their process image above. */
+    if (process_id != GetCurrentProcessId()) return;
 
     icon = 0;
     SendMessageTimeoutW(root, WM_GETICON, ICON_BIG, 0, SMTO_ABORTIFHUNG, 100, &icon);
@@ -873,7 +1050,6 @@ static void dxgi_composition_window_update_identity(HWND window, HWND root)
     if (!icon) icon = GetClassLongPtrW(root, GCLP_HICONSM);
     if (icon && (HICON)SendMessageW(window, WM_GETICON, ICON_SMALL, 0) != (HICON)icon)
         SendMessageW(window, WM_SETICON, ICON_SMALL, icon);
-    SetPropW(window, L"__wine_dcomp_task_identity", root);
 }
 
 static void dxgi_composition_window_update_backdrop(HWND window)
@@ -897,15 +1073,39 @@ static LRESULT CALLBACK dxgi_composition_window_proc(HWND window, UINT message, 
     {
         switch (message)
         {
+            case WM_NCHITTEST:
+            case WM_SETCURSOR:
+            case WM_NCMOUSEMOVE:
+            case WM_NCLBUTTONDOWN:
+            case WM_NCLBUTTONUP:
+            case WM_NCLBUTTONDBLCLK:
+            case WM_NCRBUTTONDOWN:
+            case WM_NCRBUTTONUP:
+            case WM_NCRBUTTONDBLCLK:
+                if (GetPropW(window, dcomp_native_frame_prop))
+                    return DefWindowProcW(window, message, wparam, lparam);
+                break;
+
             case WM_TIMER:
             {
                 UINT flags = SWP_NOACTIVATE | SWP_SHOWWINDOW;
+                BOOL base_presentation, transparent_base = FALSE;
+                DWORD root_style = 0, root_exstyle = 0;
 
                 if (wparam != 1) break;
-                if (GetPropW(target, L"__wine_dcomp_base_presentation") == window)
-                    dxgi_composition_window_update_backdrop(window);
+                base_presentation = GetPropW(target, L"__wine_dcomp_base_presentation") == window;
+                if (base_presentation) dxgi_composition_window_update_backdrop(window);
                 root = GetAncestor(target, GA_ROOT);
-                if (root && GetPropW(target, L"__wine_dcomp_base_presentation") == window &&
+                if (root)
+                {
+                    root_style = GetWindowLongW(root, GWL_STYLE);
+                    root_exstyle = GetWindowLongW(root, GWL_EXSTYLE);
+                    transparent_base = (root_style & WS_POPUP) &&
+                            (root_exstyle & WS_EX_TOOLWINDOW) && (root_exstyle & WS_EX_TOPMOST);
+                    dxgi_composition_window_update_frame(window, target, root,
+                            base_presentation, transparent_base);
+                }
+                if (root && base_presentation &&
                     GetPropW(window, L"__wine_dcomp_composite_alpha_background"))
                     dxgi_composition_window_update_caption(window, root);
                 if (!root || !IsWindowVisible(root) || !IsWindowVisible(target))
@@ -941,9 +1141,10 @@ static LRESULT CALLBACK dxgi_composition_window_proc(HWND window, UINT message, 
                             RemovePropW(window, L"__wine_dcomp_raised_while_active");
                     }
                     dxgi_composition_window_update_identity(window, root);
-                    SetWindowPos(window, HWND_TOP, rect.left, rect.top,
-                            max(rect.right - rect.left, 1), max(rect.bottom - rect.top, 1),
-                            flags);
+                    if (dxgi_composition_window_needs_update(window, &rect, flags))
+                        SetWindowPos(window, HWND_TOP, rect.left, rect.top,
+                                max(rect.right - rect.left, 1), max(rect.bottom - rect.top, 1),
+                                flags);
                 }
                 return 0;
             }
@@ -986,6 +1187,7 @@ static LRESULT CALLBACK dxgi_composition_window_proc(HWND window, UINT message, 
             case WM_DESTROY:
                 if ((root = GetPropW(window, dcomp_caption_window_prop))) DestroyWindow(root);
                 RemovePropW(window, dcomp_caption_window_prop);
+                dxgi_composition_window_clear_owned_icons(window);
                 KillTimer(window, 1);
                 break;
 
@@ -1030,7 +1232,7 @@ void WINAPI __wine_dxgi_bind_composition_window(HWND window, HWND target,
     HWND old_target = GetPropW(window, L"__wine_dcomp_detached_window");
     HWND input_window, target_root;
     BOOL base_presentation;
-    DWORD exstyle, target_style, target_exstyle;
+    DWORD target_style, target_exstyle;
     BOOL transparent_base;
     NTSTATUS status;
     RECT rect;
@@ -1051,6 +1253,7 @@ void WINAPI __wine_dxgi_bind_composition_window(HWND window, HWND target,
         }
         SERVER_END_REQ;
         if (status) WARN("Failed to clear DComp task delegation, status %#lx.\n", status);
+        KillTimer(window, 1);
         if ((input_window = GetPropW(window, dcomp_caption_window_prop))) DestroyWindow(input_window);
         RemovePropW(window, dcomp_caption_window_prop);
         ShowWindow(window, SW_HIDE);
@@ -1058,9 +1261,18 @@ void WINAPI __wine_dxgi_bind_composition_window(HWND window, HWND target,
         RemovePropW(window, L"__wine_dcomp_raised_while_active");
         RemovePropW(window, L"__wine_dcomp_composite_alpha_background");
         RemovePropW(window, L"__wine_dcomp_task_minimized");
+        dxgi_composition_window_clear_owned_icons(window);
         RemovePropW(window, L"__wine_dcomp_task_identity");
         RemovePropW(window, dcomp_task_app_id_prop);
         RemovePropW(window, L"__wine_dcomp_client_rect");
+        RemovePropW(window, dcomp_native_frame_prop);
+        SetWindowLongW(window, GWL_STYLE, WS_POPUP);
+        SetWindowLongW(window, GWL_EXSTYLE,
+                WS_EX_NOACTIVATE | WS_EX_TOOLWINDOW | WS_EX_LAYERED);
+        SetWindowLongPtrW(window, GWLP_HWNDPARENT, 0);
+        SetLayeredWindowAttributes(window, 0, 255, LWA_ALPHA);
+        SetWindowPos(window, NULL, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE |
+                SWP_NOZORDER | SWP_NOOWNERZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
         return;
     }
 
@@ -1090,13 +1302,15 @@ void WINAPI __wine_dxgi_bind_composition_window(HWND window, HWND target,
         WARN("Failed to update DComp task delegation, status %#lx.\n", status);
         return;
     }
-    exstyle = WS_EX_NOACTIVATE | WS_EX_TOOLWINDOW;
-    if (!base_presentation || transparent_base) exstyle |= WS_EX_LAYERED | WS_EX_TRANSPARENT;
-
     SetPropW(window, L"__wine_dcomp_detached_window", target);
-    SetWindowLongW(window, GWL_STYLE, WS_POPUP);
-    SetWindowLongW(window, GWL_EXSTYLE, exstyle);
     SetWindowLongPtrW(window, GWLP_HWNDPARENT, (LONG_PTR)target);
+    if (transparent_base)
+        SetPropW(window, L"__wine_dcomp_client_rect", ULongToHandle(1));
+    else
+        RemovePropW(window, L"__wine_dcomp_client_rect");
+    dxgi_composition_window_update_frame(window, target, target_root,
+            base_presentation, transparent_base);
+
     if (base_presentation && !transparent_base && target_root)
     {
         PostMessageW(target_root, WM_WAYLAND_DCOMP_EXPORT, 0, 0);
@@ -1111,22 +1325,18 @@ void WINAPI __wine_dxgi_bind_composition_window(HWND window, HWND target,
         dxgi_composition_window_update_backdrop(window);
     if (base_presentation && !transparent_base && target_root)
         dxgi_composition_window_update_caption(window, target_root);
-    if (transparent_base)
-        SetPropW(window, L"__wine_dcomp_client_rect", ULongToHandle(1));
-    else
-        RemovePropW(window, L"__wine_dcomp_client_rect");
 
     if (target_root) PostMessageW(target_root, WM_WAYLAND_DCOMP_EXPORT, 0, 0);
     if (!GetPropW(window, L"__wine_dcomp_old_proc"))
-    {
         SetPropW(window, L"__wine_dcomp_old_proc", (HANDLE)SetWindowLongPtrW(window, GWLP_WNDPROC,
                 (LONG_PTR)dxgi_composition_window_proc));
-        SetTimer(window, 1, 250, NULL);
-    }
+    SetTimer(window, 1, 250, NULL);
     if (dxgi_composition_window_get_rect(window, target, &rect))
+    {
         SetWindowPos(window, HWND_TOP, rect.left, rect.top,
                 max(rect.right - rect.left, 1), max(rect.bottom - rect.top, 1),
                 SWP_NOACTIVATE | SWP_SHOWWINDOW);
+    }
 }
 
 static HRESULT STDMETHODCALLTYPE dxgi_factory_CreateSwapChainForComposition(IWineDXGIFactory *iface,

--- a/dlls/dxgi/factory.c
+++ b/dlls/dxgi/factory.c
@@ -952,22 +952,19 @@ static void dxgi_composition_window_update_caption(HWND window, HWND root)
     UpdateWindow(caption);
 }
 
-static void dxgi_composition_window_clear_owned_icons(HWND window)
+static void dxgi_composition_window_clear_task_icons(HWND window)
 {
-    HICON icon;
+    HICON big_icon, small_icon;
 
-    if ((icon = RemovePropW(window, dcomp_task_icon_big_prop)))
-    {
-        if ((HICON)SendMessageW(window, WM_GETICON, ICON_BIG, 0) == icon)
-            SendMessageW(window, WM_SETICON, ICON_BIG, 0);
-        DestroyIcon(icon);
-    }
-    if ((icon = RemovePropW(window, dcomp_task_icon_small_prop)))
-    {
-        if ((HICON)SendMessageW(window, WM_GETICON, ICON_SMALL, 0) == icon)
-            SendMessageW(window, WM_SETICON, ICON_SMALL, 0);
-        DestroyIcon(icon);
-    }
+    big_icon = RemovePropW(window, dcomp_task_icon_big_prop);
+    small_icon = RemovePropW(window, dcomp_task_icon_small_prop);
+    TRACE("Clearing task icons for window %p, current %p/%p, owned %p/%p.\n", window,
+            (HICON)SendMessageW(window, WM_GETICON, ICON_BIG, 0),
+            (HICON)SendMessageW(window, WM_GETICON, ICON_SMALL, 0), big_icon, small_icon);
+    SendMessageW(window, WM_SETICON, ICON_BIG, 0);
+    SendMessageW(window, WM_SETICON, ICON_SMALL, 0);
+    if (big_icon) DestroyIcon(big_icon);
+    if (small_icon) DestroyIcon(small_icon);
 }
 
 static BOOL dxgi_composition_window_set_executable_icons(HWND window, const WCHAR *image)
@@ -1018,7 +1015,7 @@ static void dxgi_composition_window_update_identity(HWND window, HWND root)
     if (GetPropW(window, L"__wine_dcomp_task_identity") != root)
     {
         RemovePropW(window, L"__wine_dcomp_task_identity");
-        dxgi_composition_window_clear_owned_icons(window);
+        dxgi_composition_window_clear_task_icons(window);
         if ((process = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, process_id)))
         {
             if (QueryFullProcessImageNameW(process, 0, image, &image_len))
@@ -1194,7 +1191,7 @@ static LRESULT CALLBACK dxgi_composition_window_proc(HWND window, UINT message, 
             case WM_DESTROY:
                 if ((root = GetPropW(window, dcomp_caption_window_prop))) DestroyWindow(root);
                 RemovePropW(window, dcomp_caption_window_prop);
-                dxgi_composition_window_clear_owned_icons(window);
+                dxgi_composition_window_clear_task_icons(window);
                 KillTimer(window, 1);
                 break;
 
@@ -1268,7 +1265,7 @@ void WINAPI __wine_dxgi_bind_composition_window(HWND window, HWND target,
         RemovePropW(window, L"__wine_dcomp_raised_while_active");
         RemovePropW(window, L"__wine_dcomp_composite_alpha_background");
         RemovePropW(window, L"__wine_dcomp_task_minimized");
-        dxgi_composition_window_clear_owned_icons(window);
+        dxgi_composition_window_clear_task_icons(window);
         RemovePropW(window, L"__wine_dcomp_task_identity");
         RemovePropW(window, dcomp_task_app_id_prop);
         RemovePropW(window, L"__wine_dcomp_client_rect");

--- a/dlls/dxgi/swapchain.c
+++ b/dlls/dxgi/swapchain.c
@@ -441,21 +441,14 @@ static HRESULT STDMETHODCALLTYPE d3d11_swapchain_GetDevice(IDXGISwapChain4 *ifac
 static HRESULT d3d11_swapchain_preserve_present1_contents(struct d3d11_swapchain *swapchain,
         const DXGI_PRESENT_PARAMETERS *parameters);
 
-static BOOL d3d11_composition_window_needs_update(HWND window, const RECT *rect, UINT flags)
-{
-    RECT current;
-
-    if ((flags & SWP_SHOWWINDOW) && !IsWindowVisible(window)) return TRUE;
-    if ((flags & SWP_FRAMECHANGED) || !(flags & SWP_NOZORDER)) return TRUE;
-    return !GetWindowRect(window, &current) || !EqualRect(&current, rect);
-}
-
 static void d3d11_swapchain_update_composition_window(struct d3d11_swapchain *swapchain)
 {
     HWND window = d3d11_swapchain_get_hwnd(swapchain);
     HWND target = GetPropW(window, L"__wine_dcomp_detached_window");
     ATOM foreign_atom, old_foreign_atom;
     HWND base, foreign_parent, root;
+    DWORD root_style, root_exstyle;
+    BOOL base_presentation, transparent_base;
     RECT rect;
     UINT flags = SWP_NOACTIVATE | SWP_SHOWWINDOW;
 
@@ -495,6 +488,13 @@ static void d3d11_swapchain_update_composition_window(struct d3d11_swapchain *sw
         return;
     }
 
+    base_presentation = GetPropW(target, L"__wine_dcomp_base_presentation") == window;
+    root_style = GetWindowLongW(root, GWL_STYLE);
+    root_exstyle = GetWindowLongW(root, GWL_EXSTYLE);
+    transparent_base = (root_style & WS_POPUP) && (root_exstyle & WS_EX_TOOLWINDOW) &&
+            (root_exstyle & WS_EX_TOPMOST);
+    dxgi_composition_window_update_frame(window, target, root,
+            base_presentation, transparent_base);
     if (!dxgi_composition_window_get_rect(window, target, &rect)) return;
     if (!(flags & SWP_FRAMECHANGED) && IsWindowVisible(window)
             && GetPropW(window, L"__wine_dcomp_composite_alpha_background"))
@@ -509,7 +509,7 @@ static void d3d11_swapchain_update_composition_window(struct d3d11_swapchain *sw
                 || !GetWindowTextLengthW(root) || GetForegroundWindow() != root)
             RemovePropW(window, L"__wine_dcomp_raised_while_active");
     }
-    if (d3d11_composition_window_needs_update(window, &rect, flags))
+    if (dxgi_composition_window_needs_update(window, &rect, flags))
         SetWindowPos(window, HWND_TOP, rect.left, rect.top,
                 max(rect.right - rect.left, 1), max(rect.bottom - rect.top, 1),
                 flags);

--- a/dlls/dxgi/swapchain.c
+++ b/dlls/dxgi/swapchain.c
@@ -441,37 +441,13 @@ static HRESULT STDMETHODCALLTYPE d3d11_swapchain_GetDevice(IDXGISwapChain4 *ifac
 static HRESULT d3d11_swapchain_preserve_present1_contents(struct d3d11_swapchain *swapchain,
         const DXGI_PRESENT_PARAMETERS *parameters);
 
-static BOOL d3d11_composition_window_get_rect(HWND window, HWND target, RECT *rect)
+static BOOL d3d11_composition_window_needs_update(HWND window, const RECT *rect, UINT flags)
 {
-    HWND root;
-    if (GetPropW(window, L"__wine_dcomp_bounds_enabled"))
-    {
-        LONG x = (LONG)HandleToULong(GetPropW(window, L"__wine_dcomp_bounds_x"));
-        LONG y = (LONG)HandleToULong(GetPropW(window, L"__wine_dcomp_bounds_y"));
-        LONG width = (LONG)HandleToULong(GetPropW(window, L"__wine_dcomp_bounds_width"));
-        LONG height = (LONG)HandleToULong(GetPropW(window, L"__wine_dcomp_bounds_height"));
+    RECT current;
 
-        if ((root = GetAncestor(target, GA_ROOT))) target = root;
-        if (width <= 0 || height <= 0 || !GetClientRect(target, rect)) return FALSE;
-        MapWindowPoints(target, NULL, (POINT *)rect, 2);
-        if ((LONGLONG)rect->left + x < INT_MIN || (LONGLONG)rect->left + x > INT_MAX
-                || (LONGLONG)rect->top + y < INT_MIN || (LONGLONG)rect->top + y > INT_MAX
-                || (LONGLONG)rect->left + x + width > INT_MAX
-                || (LONGLONG)rect->top + y + height > INT_MAX)
-            return FALSE;
-        SetRect(rect, rect->left + x, rect->top + y,
-                rect->left + x + width, rect->top + y + height);
-        return TRUE;
-    }
-
-
-    if (!GetPropW(window, L"__wine_dcomp_client_rect") &&
-        !GetPropW(window, L"__wine_dcomp_composite_alpha_background"))
-        return GetWindowRect(target, rect);
-    if ((root = GetAncestor(target, GA_ROOT))) target = root;
-    if (!GetClientRect(target, rect)) return FALSE;
-    MapWindowPoints(target, NULL, (POINT *)rect, 2);
-    return TRUE;
+    if ((flags & SWP_SHOWWINDOW) && !IsWindowVisible(window)) return TRUE;
+    if ((flags & SWP_FRAMECHANGED) || !(flags & SWP_NOZORDER)) return TRUE;
+    return !GetWindowRect(window, &current) || !EqualRect(&current, rect);
 }
 
 static void d3d11_swapchain_update_composition_window(struct d3d11_swapchain *swapchain)
@@ -519,7 +495,7 @@ static void d3d11_swapchain_update_composition_window(struct d3d11_swapchain *sw
         return;
     }
 
-    if (!d3d11_composition_window_get_rect(window, target, &rect)) return;
+    if (!dxgi_composition_window_get_rect(window, target, &rect)) return;
     if (!(flags & SWP_FRAMECHANGED) && IsWindowVisible(window)
             && GetPropW(window, L"__wine_dcomp_composite_alpha_background"))
     {
@@ -533,9 +509,10 @@ static void d3d11_swapchain_update_composition_window(struct d3d11_swapchain *sw
                 || !GetWindowTextLengthW(root) || GetForegroundWindow() != root)
             RemovePropW(window, L"__wine_dcomp_raised_while_active");
     }
-    SetWindowPos(window, HWND_TOP, rect.left, rect.top,
-            max(rect.right - rect.left, 1), max(rect.bottom - rect.top, 1),
-            flags);
+    if (d3d11_composition_window_needs_update(window, &rect, flags))
+        SetWindowPos(window, HWND_TOP, rect.left, rect.top,
+                max(rect.right - rect.left, 1), max(rect.bottom - rect.top, 1),
+                flags);
 }
 
 static HRESULT d3d11_swapchain_present(struct d3d11_swapchain *swapchain,

--- a/dlls/dxgi/tests/dxgi.c
+++ b/dlls/dxgi/tests/dxgi.c
@@ -2649,7 +2649,7 @@ static void test_create_composition_swapchain(IUnknown *device, BOOL is_d3d12)
             "Standard frame helper has a synthetic caption overlay.\n");
     dpi = GetDpiForWindow(window);
     hit_point.x = helper_rect.right - 5 * GetSystemMetricsForDpi(SM_CXSIZE, dpi) / 2;
-    hit_point.y = helper_rect.top + GetSystemMetricsForDpi(SM_CYSIZE, dpi) / 2;
+    hit_point.y = (helper_rect.top + helper_client.top) / 2;
     state.custom_hit_test = TRUE;
     state.hit_test_count = 0;
     target_hit = SendMessageW(target_window, WM_NCHITTEST, 0,
@@ -2724,7 +2724,8 @@ static void test_create_composition_swapchain(IUnknown *device, BOOL is_d3d12)
 
     target_exstyle = GetWindowLongW(target_window, GWL_EXSTYLE);
     SetWindowLongW(target_window, GWL_STYLE, target_style & ~WS_MAXIMIZEBOX);
-    SetWindowLongW(target_window, GWL_EXSTYLE, target_exstyle | WS_EX_RTLREADING);
+    SetWindowLongW(target_window, GWL_EXSTYLE,
+            target_exstyle | WS_EX_RTLREADING | WS_EX_TOOLWINDOW);
     SetWindowPos(target_window, NULL, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE |
             SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
     SendMessageW(window, WM_TIMER, 1, 0);
@@ -2734,6 +2735,8 @@ static void test_create_composition_swapchain(IUnknown *device, BOOL is_d3d12)
     ok(!(helper_style & WS_MAXIMIZEBOX), "Helper retained a removed maximize box.\n");
     ok(GetWindowLongW(window, GWL_EXSTYLE) & WS_EX_RTLREADING,
             "Helper did not mirror the root reading direction.\n");
+    ok(GetWindowLongW(window, GWL_EXSTYLE) & WS_EX_TOOLWINDOW,
+            "Helper did not mirror the root tool-window frame.\n");
     SetWindowLongW(target_window, GWL_STYLE, target_style);
     SetWindowLongW(target_window, GWL_EXSTYLE, target_exstyle);
     SetWindowPos(target_window, NULL, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE |

--- a/dlls/dxgi/tests/dxgi.c
+++ b/dlls/dxgi/tests/dxgi.c
@@ -2516,7 +2516,7 @@ static void test_create_composition_swapchain(IUnknown *device, BOOL is_d3d12)
     HHOOK callwndproc_hook = NULL;
     WCHAR title[64];
     UINT token_size;
-    HICON icon;
+    HICON icon = NULL;
     ATOM class_atom = 0;
     HRESULT hr;
 
@@ -2879,6 +2879,12 @@ static void test_create_composition_swapchain(IUnknown *device, BOOL is_d3d12)
                 "Unbound child retained its base presentation.\n");
         ok(!GetPropW(target_window, L"__wine_dcomp_task_delegated"),
                 "Unbound root retained its task presentation.\n");
+        ok((HICON)SendMessageW(window, WM_GETICON, ICON_BIG, 0) != icon,
+                "Unbound helper large icon %p still matches root icon %p.\n",
+                (HICON)SendMessageW(window, WM_GETICON, ICON_BIG, 0), icon);
+        ok((HICON)SendMessageW(window, WM_GETICON, ICON_SMALL, 0) != icon,
+                "Unbound helper small icon %p still matches root icon %p.\n",
+                (HICON)SendMessageW(window, WM_GETICON, ICON_SMALL, 0), icon);
         ok(GetWindowLongW(window, GWL_STYLE) == initial_style,
                 "Unbound helper style %#lx, expected %#lx.\n",
                 GetWindowLongW(window, GWL_STYLE), initial_style);

--- a/dlls/dxgi/tests/dxgi.c
+++ b/dlls/dxgi/tests/dxgi.c
@@ -26,6 +26,7 @@
 #include "d3d11.h"
 #include "d3d12.h"
 #include "d3d12sdklayers.h"
+#include "dwmapi.h"
 #include "winternl.h"
 #include "ddk/d3dkmthk.h"
 #include "wine/dcomp.h"
@@ -2422,9 +2423,75 @@ done:
     DestroyWindow(creation_desc.OutputWindow);
 }
 
+static BOOL get_client_rect_screen(HWND window, RECT *rect)
+{
+    if (!GetClientRect(window, rect)) return FALSE;
+    MapWindowPoints(window, NULL, (POINT *)rect, 2);
+    return TRUE;
+}
+
+static BOOL wait_for_window_prop(HWND window, const WCHAR *name, BOOL present)
+{
+    DWORD end = GetTickCount() + 1000;
+    MSG message;
+
+    do
+    {
+        while (PeekMessageW(&message, NULL, 0, 0, PM_REMOVE)) DispatchMessageW(&message);
+        if (!!GetPropW(window, name) == present) return TRUE;
+        MsgWaitForMultipleObjects(0, NULL, FALSE, 50, QS_ALLINPUT);
+    } while ((LONG)(end - GetTickCount()) > 0);
+    return !!GetPropW(window, name) == present;
+}
+
+struct dcomp_frame_window_state
+{
+    BOOL custom_caption;
+    BOOL custom_hit_test;
+    UINT hit_test_count;
+    WPARAM syscommand;
+};
+
+static HWND dcomp_frame_hook_window;
+static UINT dcomp_frame_windowpos_count;
+
+static LRESULT CALLBACK dcomp_frame_callwndproc_hook(int code, WPARAM wparam, LPARAM lparam)
+{
+    const CWPSTRUCT *message = (const CWPSTRUCT *)lparam;
+
+    if (code >= 0 && message->hwnd == dcomp_frame_hook_window &&
+        (message->message == WM_WINDOWPOSCHANGING || message->message == WM_WINDOWPOSCHANGED))
+        ++dcomp_frame_windowpos_count;
+    return CallNextHookEx(NULL, code, wparam, lparam);
+}
+
+static LRESULT CALLBACK dcomp_frame_window_proc(HWND window, UINT message,
+        WPARAM wparam, LPARAM lparam)
+{
+    struct dcomp_frame_window_state *state = (void *)GetWindowLongPtrW(window, GWLP_USERDATA);
+
+    if (state && message == WM_NCCALCSIZE && state->custom_caption) return 0;
+    if (state && message == WM_NCHITTEST && state->custom_hit_test)
+    {
+        ++state->hit_test_count;
+        return HTCLIENT;
+    }
+    if (state && message == WM_SYSCOMMAND)
+    {
+        state->syscommand = wparam & 0xfff0;
+        return 0;
+    }
+    return DefWindowProcW(window, message, wparam, lparam);
+}
+
 static void test_create_composition_swapchain(IUnknown *device, BOOL is_d3d12)
 {
     typedef HRESULT (WINAPI *dcomp_create_device_proc)(IDXGIDevice *, REFIID, void **);
+    typedef HRESULT (WINAPI *dwm_set_window_attribute_proc)(HWND, DWORD, const void *, DWORD);
+    const DWORD frame_style_mask = WS_CAPTION | WS_SYSMENU | WS_THICKFRAME
+            | WS_MINIMIZEBOX | WS_MAXIMIZEBOX;
+    const WCHAR frame_window_class[] = L"dxgi_dcomp_frame_window";
+    struct dcomp_frame_window_state state = {0};
     IDXGIFactory *factory_base = NULL;
     IDXGIFactory2 *factory = NULL;
     IDXGISwapChain1 *swapchain = NULL;
@@ -2434,15 +2501,24 @@ static void test_create_composition_swapchain(IUnknown *device, BOOL is_d3d12)
     DXGI_SWAP_CHAIN_DESC1 desc;
     struct wine_dcomp_ime_token token;
     dcomp_create_device_proc pDCompositionCreateDevice;
-    HMODULE dcomp = NULL;
+    dwm_set_window_attribute_proc pDwmSetWindowAttribute = NULL;
+    DWORD initial_style, initial_exstyle, helper_style, target_style, target_exstyle;
+    RECT target_rect, helper_rect, helper_client;
+    HWND window = NULL, target_window = NULL, target_child = NULL, caption;
+    LRESULT helper_hit, target_hit;
+    POINT hit_point;
+    UINT dpi;
+    enum DWMNCRENDERINGPOLICY policy;
+    D2D_RECT_F clip;
+    HWND initial_owner;
+    WNDCLASSW wc = {0};
+    HMODULE dcomp = NULL, dwmapi = NULL;
+    HHOOK callwndproc_hook = NULL;
+    WCHAR title[64];
     UINT token_size;
-    HWND window = NULL;
-    HWND target_window = NULL;
-    RECT target_rect, helper_rect;
+    HICON icon;
+    ATOM class_atom = 0;
     HRESULT hr;
-
-    if (!is_d3d12)
-        return;
 
     get_factory(device, is_d3d12, &factory_base);
     hr = IDXGIFactory_QueryInterface(factory_base, &IID_IDXGIFactory2, (void **)&factory);
@@ -2451,9 +2527,35 @@ static void test_create_composition_swapchain(IUnknown *device, BOOL is_d3d12)
     if (FAILED(hr))
         return;
 
+    wc.lpfnWndProc = dcomp_frame_window_proc;
+    wc.hInstance = GetModuleHandleW(NULL);
+    wc.lpszClassName = frame_window_class;
+    class_atom = RegisterClassW(&wc);
+    ok(!!class_atom, "Could not register DComp frame test class, error %lu.\n", GetLastError());
+    if (!class_atom) goto done;
+
+    target_window = CreateWindowW(frame_window_class, L"dxgi composition target",
+            WS_OVERLAPPEDWINDOW, 100, 100, 320, 200, NULL, NULL, wc.hInstance, NULL);
+    if (!target_window)
+    {
+        win_skip("Could not create DComp target window.\n");
+        goto done;
+    }
+    SetWindowLongPtrW(target_window, GWLP_USERDATA, (LONG_PTR)&state);
+    ShowWindow(target_window, SW_SHOW);
+    UpdateWindow(target_window);
+    ok(GetClientRect(target_window, &target_rect), "GetClientRect failed.\n");
+    target_child = CreateWindowW(L"static", L"dxgi composition child", WS_CHILD | WS_VISIBLE,
+            0, 0, target_rect.right, target_rect.bottom, target_window, NULL, NULL, NULL);
+    if (!target_child)
+    {
+        win_skip("Could not create DComp child target window.\n");
+        goto done;
+    }
+
     memset(&desc, 0, sizeof(desc));
-    desc.Width = 64;
-    desc.Height = 64;
+    desc.Width = target_rect.right;
+    desc.Height = target_rect.bottom;
     desc.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
     desc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
     desc.BufferCount = 2;
@@ -2470,6 +2572,9 @@ static void test_create_composition_swapchain(IUnknown *device, BOOL is_d3d12)
     hr = IDXGISwapChain1_GetHwnd(swapchain, &window);
     ok(hr == S_OK, "Got unexpected hr %#lx.\n", hr);
     ok(!!window, "Got NULL composition window.\n");
+    initial_style = GetWindowLongW(window, GWL_STYLE);
+    initial_exstyle = GetWindowLongW(window, GWL_EXSTYLE);
+    initial_owner = GetWindow(window, GW_OWNER);
 
     token_size = sizeof(token);
     hr = IDXGISwapChain1_GetPrivateData(swapchain, &WINE_DCOMP_IME_TOKEN_GUID, &token_size, &token);
@@ -2483,21 +2588,14 @@ static void test_create_composition_swapchain(IUnknown *device, BOOL is_d3d12)
         win_skip("DCompositionCreateDevice is unavailable.\n");
         goto done;
     }
-    target_window = CreateWindowW(L"static", L"dxgi composition target", WS_OVERLAPPEDWINDOW,
-            100, 100, 320, 200, NULL, NULL, NULL, NULL);
-    if (!target_window)
-    {
-        win_skip("Could not create DComp target window.\n");
-        goto done;
-    }
-    ShowWindow(target_window, SW_SHOW);
-    UpdateWindow(target_window);
+    if ((dwmapi = LoadLibraryW(L"dwmapi.dll")))
+        pDwmSetWindowAttribute = (void *)GetProcAddress(dwmapi, "DwmSetWindowAttribute");
 
     hr = pDCompositionCreateDevice(NULL, &IID_IDCompositionDevice, (void **)&dcomp_device);
     ok(hr == S_OK, "DCompositionCreateDevice failed, hr %#lx.\n", hr);
     if (FAILED(hr))
         goto done;
-    hr = IDCompositionDevice_CreateTargetForHwnd(dcomp_device, target_window, FALSE, &dcomp_target);
+    hr = IDCompositionDevice_CreateTargetForHwnd(dcomp_device, target_child, FALSE, &dcomp_target);
     ok(hr == S_OK, "CreateTargetForHwnd failed, hr %#lx.\n", hr);
     if (FAILED(hr))
         goto done;
@@ -2517,35 +2615,280 @@ static void test_create_composition_swapchain(IUnknown *device, BOOL is_d3d12)
     ok(hr == S_OK, "Commit failed, hr %#lx.\n", hr);
     if (FAILED(hr))
         goto done;
+    flush_events();
 
     hr = IDXGISwapChain1_GetHwnd(swapchain, &window);
     ok(hr == S_OK, "Got unexpected post-commit GetHwnd hr %#lx.\n", hr);
     ok(window && IsWindowVisible(window), "Composition helper window %p is not visible.\n", window);
-    ok(GetClientRect(target_window, &target_rect), "GetClientRect failed.\n");
-    MapWindowPoints(target_window, NULL, (POINT *)&target_rect, 2);
+    ok(get_client_rect_screen(target_window, &target_rect), "Could not map target client rect.\n");
+    ok(get_client_rect_screen(window, &helper_client), "Could not map helper client rect.\n");
+    ok(EqualRect(&helper_client, &target_rect),
+            "Got helper client {%ld,%ld,%ld,%ld}, target client {%ld,%ld,%ld,%ld}.\n",
+            helper_client.left, helper_client.top, helper_client.right, helper_client.bottom,
+            target_rect.left, target_rect.top, target_rect.right, target_rect.bottom);
     ok(GetWindowRect(window, &helper_rect), "GetWindowRect failed.\n");
-    ok(helper_rect.left == target_rect.left && helper_rect.top == target_rect.top
-            && helper_rect.right - helper_rect.left == (LONG)desc.Width
-            && helper_rect.bottom - helper_rect.top == (LONG)desc.Height,
-            "Got helper rect {%ld,%ld,%ld,%ld}, target client origin {%ld,%ld}.\n",
+    ok(helper_rect.left < helper_client.left || helper_rect.top < helper_client.top
+            || helper_rect.right > helper_client.right || helper_rect.bottom > helper_client.bottom,
+            "Helper outer rect {%ld,%ld,%ld,%ld} has no frame around client {%ld,%ld,%ld,%ld}.\n",
             helper_rect.left, helper_rect.top, helper_rect.right, helper_rect.bottom,
-            target_rect.left, target_rect.top);
+            helper_client.left, helper_client.top, helper_client.right, helper_client.bottom);
+    target_style = GetWindowLongW(target_window, GWL_STYLE);
+    helper_style = GetWindowLongW(window, GWL_STYLE);
+    ok((helper_style & frame_style_mask) == (target_style & frame_style_mask),
+            "Got helper frame style %#lx, expected %#lx from root style %#lx.\n",
+            helper_style & frame_style_mask, target_style & frame_style_mask, target_style);
+    ok(!!GetPropW(window, L"__wine_dcomp_native_frame"),
+            "Standard frame helper has no native-frame marker.\n");
+    ok(GetPropW(target_child, L"__wine_dcomp_base_presentation") == window,
+            "Child target base presentation is %p, expected %p.\n",
+            GetPropW(target_child, L"__wine_dcomp_base_presentation"), window);
+    ok(GetPropW(target_window, L"__wine_dcomp_task_delegated") == window,
+            "Root task presentation is %p, expected %p.\n",
+            GetPropW(target_window, L"__wine_dcomp_task_delegated"), window);
+    ok(!GetPropW(window, L"__wine_dcomp_caption_window"),
+            "Standard frame helper has a synthetic caption overlay.\n");
+    dpi = GetDpiForWindow(window);
+    hit_point.x = helper_rect.right - 5 * GetSystemMetricsForDpi(SM_CXSIZE, dpi) / 2;
+    hit_point.y = helper_rect.top + GetSystemMetricsForDpi(SM_CYSIZE, dpi) / 2;
+    state.custom_hit_test = TRUE;
+    state.hit_test_count = 0;
+    target_hit = SendMessageW(target_window, WM_NCHITTEST, 0,
+            MAKELPARAM(hit_point.x, hit_point.y));
+    ok(target_hit == HTCLIENT, "Root returned hit-test result %Id, expected HTCLIENT.\n",
+            target_hit);
+    ok(state.hit_test_count == 1, "Root received %u hit-test messages, expected 1.\n",
+            state.hit_test_count);
+    state.hit_test_count = 0;
+    helper_hit = SendMessageW(window, WM_NCHITTEST, 0,
+            MAKELPARAM(hit_point.x, hit_point.y));
+    ok(helper_hit == HTMINBUTTON,
+            "Helper returned hit-test result %Id, expected HTMINBUTTON.\n", helper_hit);
+    ok(!state.hit_test_count, "Helper hit testing forwarded %u messages to the root.\n",
+            state.hit_test_count);
+    state.custom_hit_test = FALSE;
+
+    hr = IDXGISwapChain1_Present(swapchain, 0, 0);
+    ok(hr == S_OK, "Present failed, hr %#lx.\n", hr);
+    flush_events();
+    ok(get_client_rect_screen(window, &helper_client), "Could not map post-Present helper client rect.\n");
+    ok(EqualRect(&helper_client, &target_rect),
+            "Post-Present helper client {%ld,%ld,%ld,%ld}, target client {%ld,%ld,%ld,%ld}.\n",
+            helper_client.left, helper_client.top, helper_client.right, helper_client.bottom,
+            target_rect.left, target_rect.top, target_rect.right, target_rect.bottom);
+
+    SendMessageW(window, WM_TIMER, 1, 0);
+    flush_events();
+    callwndproc_hook = SetWindowsHookExW(WH_CALLWNDPROC, dcomp_frame_callwndproc_hook,
+            NULL, GetCurrentThreadId());
+    ok(!!callwndproc_hook, "Could not install call-window-proc hook, error %lu.\n", GetLastError());
+    if (callwndproc_hook)
+    {
+        dcomp_frame_hook_window = window;
+        dcomp_frame_windowpos_count = 0;
+        SendMessageW(window, WM_TIMER, 1, 0);
+        ok(!dcomp_frame_windowpos_count,
+                "Unchanged timer refresh sent %u window-position messages.\n",
+                dcomp_frame_windowpos_count);
+        dcomp_frame_windowpos_count = 0;
+        hr = IDXGISwapChain1_Present(swapchain, 0, 0);
+        ok(hr == S_OK, "Repeated Present failed, hr %#lx.\n", hr);
+        ok(!dcomp_frame_windowpos_count,
+                "Unchanged Present sent %u window-position messages.\n",
+                dcomp_frame_windowpos_count);
+        flush_events();
+        dcomp_frame_hook_window = NULL;
+        UnhookWindowsHookEx(callwndproc_hook);
+        callwndproc_hook = NULL;
+    }
+
+    state.syscommand = 0;
+    SendMessageW(window, WM_SYSCOMMAND, SC_CLOSE, 0);
+    flush_events();
+    ok(state.syscommand == SC_CLOSE, "Root got system command %#Ix, expected SC_CLOSE.\n",
+            state.syscommand);
+
+    ok(SetWindowTextW(target_window, L"dxgi composition updated"),
+            "Could not update root title.\n");
+    icon = LoadIconW(NULL, (const WCHAR *)IDI_WARNING);
+    ok(!!icon, "Could not load test icon.\n");
+    SendMessageW(target_window, WM_SETICON, ICON_BIG, (LPARAM)icon);
+    SendMessageW(target_window, WM_SETICON, ICON_SMALL, (LPARAM)icon);
+    SendMessageW(window, WM_TIMER, 1, 0);
+    ok(GetWindowTextW(window, title, ARRAY_SIZE(title)), "Could not query helper title.\n");
+    ok(!wcscmp(title, L"dxgi composition updated"), "Got helper title %s.\n",
+            wine_dbgstr_w(title));
+    ok((HICON)SendMessageW(window, WM_GETICON, ICON_BIG, 0) == icon,
+            "Helper did not refresh its large icon.\n");
+    ok((HICON)SendMessageW(window, WM_GETICON, ICON_SMALL, 0) == icon,
+            "Helper did not refresh its small icon.\n");
+
+    target_exstyle = GetWindowLongW(target_window, GWL_EXSTYLE);
+    SetWindowLongW(target_window, GWL_STYLE, target_style & ~WS_MAXIMIZEBOX);
+    SetWindowLongW(target_window, GWL_EXSTYLE, target_exstyle | WS_EX_RTLREADING);
+    SetWindowPos(target_window, NULL, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE |
+            SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
+    SendMessageW(window, WM_TIMER, 1, 0);
+    helper_style = GetWindowLongW(window, GWL_STYLE);
+    ok(!!GetPropW(window, L"__wine_dcomp_native_frame"),
+            "Style refresh removed the native frame.\n");
+    ok(!(helper_style & WS_MAXIMIZEBOX), "Helper retained a removed maximize box.\n");
+    ok(GetWindowLongW(window, GWL_EXSTYLE) & WS_EX_RTLREADING,
+            "Helper did not mirror the root reading direction.\n");
+    SetWindowLongW(target_window, GWL_STYLE, target_style);
+    SetWindowLongW(target_window, GWL_EXSTYLE, target_exstyle);
+    SetWindowPos(target_window, NULL, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE |
+            SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
+    SendMessageW(window, WM_TIMER, 1, 0);
+
+    clip.left = clip.top = 0.0f;
+    clip.right = desc.Width - 8.0f;
+    clip.bottom = desc.Height - 8.0f;
+    hr = IDCompositionVisual_SetClip(dcomp_visual, &clip);
+    ok(hr == S_OK, "Setting partial visual clip failed, hr %#lx.\n", hr);
+    hr = IDCompositionDevice_Commit(dcomp_device);
+    ok(hr == S_OK, "Partial visual commit failed, hr %#lx.\n", hr);
+    flush_events();
+    SendMessageW(window, WM_TIMER, 1, 0);
+    ok(!GetPropW(window, L"__wine_dcomp_native_frame"),
+            "Clipped visual retained the native frame.\n");
+    ok(GetWindowLongW(window, GWL_STYLE) & WS_POPUP,
+            "Clipped visual helper is not a popup.\n");
+    hr = IDCompositionVisual_SetClipObject(dcomp_visual, NULL);
+    ok(hr == S_OK, "Clearing visual clip failed, hr %#lx.\n", hr);
+    hr = IDCompositionDevice_Commit(dcomp_device);
+    ok(hr == S_OK, "Visual clip restore commit failed, hr %#lx.\n", hr);
+    flush_events();
+    SendMessageW(window, WM_TIMER, 1, 0);
+    ok(!!GetPropW(window, L"__wine_dcomp_native_frame"),
+            "Clearing the visual clip did not restore the native frame.\n");
+
+    hr = IDCompositionVisual_SetOffsetX(dcomp_visual, 8.0f);
+    ok(hr == S_OK, "Setting visual offset failed, hr %#lx.\n", hr);
+    hr = IDCompositionDevice_Commit(dcomp_device);
+    ok(hr == S_OK, "Offset visual commit failed, hr %#lx.\n", hr);
+    flush_events();
+    SendMessageW(window, WM_TIMER, 1, 0);
+    ok(!GetPropW(window, L"__wine_dcomp_native_frame"),
+            "Offset visual retained the native frame.\n");
+    ok(GetWindowLongW(window, GWL_STYLE) & WS_POPUP,
+            "Offset visual helper is not a popup.\n");
+    hr = IDCompositionVisual_SetOffsetX(dcomp_visual, 0.0f);
+    ok(hr == S_OK, "Clearing visual offset failed, hr %#lx.\n", hr);
+    hr = IDCompositionDevice_Commit(dcomp_device);
+    ok(hr == S_OK, "Offset restore commit failed, hr %#lx.\n", hr);
+    flush_events();
+    SendMessageW(window, WM_TIMER, 1, 0);
+    ok(!!GetPropW(window, L"__wine_dcomp_native_frame"),
+            "Clearing the visual offset did not restore the native frame.\n");
+
+    if (pDwmSetWindowAttribute)
+    {
+        policy = DWMNCRP_DISABLED;
+        hr = pDwmSetWindowAttribute(target_window, DWMWA_NCRENDERING_POLICY,
+                &policy, sizeof(policy));
+        ok(hr == S_OK, "Disabling DWM nonclient rendering failed, hr %#lx.\n", hr);
+        if (SUCCEEDED(hr))
+        {
+            SendMessageW(window, WM_TIMER, 1, 0);
+            ok(!GetPropW(window, L"__wine_dcomp_native_frame"),
+                    "DWM-disabled root retained the native frame.\n");
+            ok(!GetPropW(window, L"__wine_dcomp_caption_window"),
+                    "DWM-disabled root gained a caption overlay.\n");
+            policy = DWMNCRP_USEWINDOWSTYLE;
+            hr = pDwmSetWindowAttribute(target_window, DWMWA_NCRENDERING_POLICY,
+                    &policy, sizeof(policy));
+            ok(hr == S_OK, "Restoring DWM nonclient rendering failed, hr %#lx.\n", hr);
+            SendMessageW(window, WM_TIMER, 1, 0);
+            ok(!!GetPropW(window, L"__wine_dcomp_native_frame"),
+                    "Restoring DWM nonclient rendering did not restore the frame.\n");
+        }
+    }
+    else
+        win_skip("DwmSetWindowAttribute is unavailable.\n");
+
+    state.custom_caption = TRUE;
+    SetWindowPos(target_window, NULL, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE |
+            SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
+    ok(GetClientRect(target_window, &target_rect), "Could not query custom root client.\n");
+    SetWindowPos(target_child, NULL, 0, 0, target_rect.right, target_rect.bottom,
+            SWP_NOZORDER | SWP_NOACTIVATE);
+    hr = IDCompositionVisual_SetContent(dcomp_visual, NULL);
+    ok(hr == S_OK, "Custom-caption unbind failed, hr %#lx.\n", hr);
+    hr = IDCompositionDevice_Commit(dcomp_device);
+    ok(hr == S_OK, "Custom-caption unbind commit failed, hr %#lx.\n", hr);
+    hr = IDCompositionVisual_SetContent(dcomp_visual, (IUnknown *)swapchain);
+    ok(hr == S_OK, "Custom-caption rebind failed, hr %#lx.\n", hr);
+    hr = IDCompositionDevice_Commit(dcomp_device);
+    ok(hr == S_OK, "Custom-caption rebind commit failed, hr %#lx.\n", hr);
+    flush_events();
+    ok(!GetPropW(window, L"__wine_dcomp_native_frame"),
+            "Custom-caption rebind gained a native frame.\n");
+    ok(GetWindowLongW(window, GWL_STYLE) & WS_POPUP,
+            "Custom-caption helper is not a popup.\n");
+    caption = GetPropW(window, L"__wine_dcomp_caption_window");
+    ok(caption && IsWindow(caption), "Custom-caption rebind has no caption overlay.\n");
+
+    state.custom_caption = FALSE;
+    SetWindowPos(target_window, NULL, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE |
+            SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
+    ok(GetClientRect(target_window, &target_rect), "Could not restore root client.\n");
+    SetWindowPos(target_child, NULL, 0, 0, target_rect.right, target_rect.bottom,
+            SWP_NOZORDER | SWP_NOACTIVATE);
+    ok(wait_for_window_prop(window, L"__wine_dcomp_native_frame", TRUE),
+            "Standard frame did not return after custom-caption mode.\n");
+    ok(!GetPropW(window, L"__wine_dcomp_caption_window"),
+            "Standard frame retained the custom caption overlay.\n");
+    ok(!caption || !IsWindow(caption), "Custom caption overlay %p was not destroyed.\n", caption);
+    ok(get_client_rect_screen(target_window, &target_rect),
+            "Could not map restored target client rect.\n");
+    ok(get_client_rect_screen(window, &helper_client),
+            "Could not map restored helper client rect.\n");
+    ok(EqualRect(&helper_client, &target_rect),
+            "Restored helper client {%ld,%ld,%ld,%ld}, target client {%ld,%ld,%ld,%ld}.\n",
+            helper_client.left, helper_client.top, helper_client.right, helper_client.bottom,
+            target_rect.left, target_rect.top, target_rect.right, target_rect.bottom);
 
     hr = IDCompositionVisual_SetContent(dcomp_visual, NULL);
     ok(hr == S_OK, "Clearing visual content failed, hr %#lx.\n", hr);
     hr = IDCompositionDevice_Commit(dcomp_device);
     ok(hr == S_OK, "Unbind commit failed, hr %#lx.\n", hr);
+    flush_events();
     ok(!IsWindowVisible(window), "Unbound composition helper window %p is still visible.\n", window);
     ok(!GetPropW(window, L"__wine_dcomp_detached_window"),
             "Unbound composition helper retained its target.\n");
+    ok(!GetPropW(window, L"__wine_dcomp_native_frame"),
+            "Unbound composition helper retained its native-frame marker.\n");
+    ok(!GetPropW(window, L"__wine_dcomp_caption_window"),
+            "Unbound composition helper retained its caption overlay.\n");
+    ok(!GetPropW(target_child, L"__wine_dcomp_base_presentation"),
+            "Unbound child retained its base presentation.\n");
+    ok(!GetPropW(target_window, L"__wine_dcomp_task_delegated"),
+            "Unbound root retained its task presentation.\n");
+    ok(GetWindowLongW(window, GWL_STYLE) == initial_style,
+            "Unbound helper style %#lx, expected %#lx.\n",
+            GetWindowLongW(window, GWL_STYLE), initial_style);
+    ok(GetWindowLongW(window, GWL_EXSTYLE) == initial_exstyle,
+            "Unbound helper exstyle %#lx, expected %#lx.\n",
+            GetWindowLongW(window, GWL_EXSTYLE), initial_exstyle);
+    ok(GetWindow(window, GW_OWNER) == initial_owner,
+            "Unbound helper owner %p, expected %p.\n", GetWindow(window, GW_OWNER), initial_owner);
 
 done:
+    dcomp_frame_hook_window = NULL;
+    if (callwndproc_hook) UnhookWindowsHookEx(callwndproc_hook);
     if (dcomp_visual) IDCompositionVisual_Release(dcomp_visual);
     if (dcomp_target) IDCompositionTarget_Release(dcomp_target);
     if (dcomp_device) IDCompositionDevice_Release(dcomp_device);
-    if (target_window) DestroyWindow(target_window);
+    if (target_child) DestroyWindow(target_child);
+    if (target_window)
+    {
+        SetWindowLongPtrW(target_window, GWLP_USERDATA, 0);
+        DestroyWindow(target_window);
+    }
+    if (class_atom) UnregisterClassW(frame_window_class, wc.hInstance);
     if (swapchain) IDXGISwapChain1_Release(swapchain);
     if (factory) IDXGIFactory2_Release(factory);
+    if (dwmapi) FreeLibrary(dwmapi);
     if (dcomp) FreeLibrary(dcomp);
 }
 
@@ -9361,10 +9704,12 @@ done_device:
 START_TEST(dxgi)
 {
     HMODULE dxgi_module, d3d11_module, d3d12_module, gdi32_module;
-    BOOL enable_debug_layer = FALSE;
+    BOOL enable_debug_layer = FALSE, composition_only = FALSE;
     unsigned int argc, i;
     ID3D12Debug *debug;
     char **argv;
+
+    argc = winetest_get_mainargs(&argv);
 
     dxgi_module = GetModuleHandleA("dxgi.dll");
     pCreateDXGIFactory1 = (void *)GetProcAddress(dxgi_module, "CreateDXGIFactory1");
@@ -9377,6 +9722,11 @@ START_TEST(dxgi)
 
     d3d11_module = LoadLibraryA("d3d11.dll");
     pD3D11CreateDevice = (void *)GetProcAddress(d3d11_module, "D3D11CreateDevice");
+    if ((d3d12_module = LoadLibraryA("d3d12.dll")))
+    {
+        pD3D12CreateDevice = (void *)GetProcAddress(d3d12_module, "D3D12CreateDevice");
+        pD3D12GetDebugInterface = (void *)GetProcAddress(d3d12_module, "D3D12GetDebugInterface");
+    }
 
     registry_mode.dmSize = sizeof(registry_mode);
     ok(EnumDisplaySettingsW(NULL, ENUM_REGISTRY_SETTINGS, &registry_mode), "Failed to get display mode.\n");
@@ -9388,7 +9738,6 @@ START_TEST(dxgi)
     if (sizeof(void *) == 4 && !strcmp(winetest_platform, "wine"))
         use_mt = FALSE;
 
-    argc = winetest_get_mainargs(&argv);
     for (i = 2; i < argc; ++i)
     {
         if (!strcmp(argv[i], "--validate"))
@@ -9399,6 +9748,19 @@ START_TEST(dxgi)
             use_adapter_idx = atoi(argv[++i]);
         else if (!strcmp(argv[i], "--single"))
             use_mt = FALSE;
+        else if (!strcmp(argv[i], "--composition-only"))
+            composition_only = TRUE;
+    }
+
+    run_on_d3d10(test_create_composition_swapchain);
+    if (d3d12_module)
+        run_on_d3d12(test_create_composition_swapchain);
+    else
+        skip("Direct3D 12 is not available.\n");
+    if (composition_only)
+    {
+        if (d3d12_module) FreeLibrary(d3d12_module);
+        return;
     }
 
     queue_test(test_adapter_desc);
@@ -9448,14 +9810,7 @@ START_TEST(dxgi)
     run_on_d3d10(test_swapchain_window_messages);
     run_on_d3d10(test_zero_size);
 
-    if (!(d3d12_module = LoadLibraryA("d3d12.dll")))
-    {
-        skip("Direct3D 12 is not available.\n");
-        return;
-    }
-
-    pD3D12CreateDevice = (void *)GetProcAddress(d3d12_module, "D3D12CreateDevice");
-    pD3D12GetDebugInterface = (void *)GetProcAddress(d3d12_module, "D3D12GetDebugInterface");
+    if (!d3d12_module) return;
 
     if (enable_debug_layer && SUCCEEDED(pD3D12GetDebugInterface(&IID_ID3D12Debug, (void **)&debug)))
     {
@@ -9464,7 +9819,6 @@ START_TEST(dxgi)
     }
 
     run_on_d3d12(test_create_swapchain);
-    run_on_d3d12(test_create_composition_swapchain);
     run_on_d3d12(test_set_fullscreen);
     run_on_d3d12(test_resize_target);
     run_on_d3d12(test_resize_fullscreen);

--- a/dlls/dxgi/tests/dxgi.c
+++ b/dlls/dxgi/tests/dxgi.c
@@ -2502,7 +2502,7 @@ static void test_create_composition_swapchain(IUnknown *device, BOOL is_d3d12)
     struct wine_dcomp_ime_token token;
     dcomp_create_device_proc pDCompositionCreateDevice;
     dwm_set_window_attribute_proc pDwmSetWindowAttribute = NULL;
-    DWORD initial_style, initial_exstyle, helper_style, target_style, target_exstyle;
+    DWORD initial_style = 0, initial_exstyle = 0, helper_style, target_style, target_exstyle;
     RECT target_rect, helper_rect, helper_client;
     HWND window = NULL, target_window = NULL, target_child = NULL, caption;
     LRESULT helper_hit, target_hit;
@@ -2510,7 +2510,7 @@ static void test_create_composition_swapchain(IUnknown *device, BOOL is_d3d12)
     UINT dpi;
     enum DWMNCRENDERINGPOLICY policy;
     D2D_RECT_F clip;
-    HWND initial_owner;
+    HWND initial_owner = NULL;
     WNDCLASSW wc = {0};
     HMODULE dcomp = NULL, dwmapi = NULL;
     HHOOK callwndproc_hook = NULL;

--- a/dlls/win32u/defwnd.c
+++ b/dlls/win32u/defwnd.c
@@ -2077,7 +2077,7 @@ LRESULT handle_nc_hit_test( HWND hwnd, POINT pt )
         {
             BOOL min_or_max_box = (style & WS_SYSMENU) && (style & (WS_MINIMIZEBOX | WS_MAXIMIZEBOX));
             int button_width = get_system_metrics( ex_style & WS_EX_TOOLWINDOW ?
-                                                  SM_CYCAPTION : SM_CXSIZE );
+                                                  SM_CYSMCAPTION : SM_CXSIZE );
             if (ex_style & WS_EX_LAYOUTRTL)
             {
                 /* Check system menu */

--- a/dlls/win32u/defwnd.c
+++ b/dlls/win32u/defwnd.c
@@ -2076,6 +2076,8 @@ LRESULT handle_nc_hit_test( HWND hwnd, POINT pt )
         if (!PtInRect( &rects.window, pt ))
         {
             BOOL min_or_max_box = (style & WS_SYSMENU) && (style & (WS_MINIMIZEBOX | WS_MAXIMIZEBOX));
+            int button_width = get_system_metrics( ex_style & WS_EX_TOOLWINDOW ?
+                                                  SM_CYCAPTION : SM_CXSIZE );
             if (ex_style & WS_EX_LAYOUTRTL)
             {
                 /* Check system menu */
@@ -2089,18 +2091,18 @@ LRESULT handle_nc_hit_test( HWND hwnd, POINT pt )
                 /* Check close button */
                 if (style & WS_SYSMENU)
                 {
-                    rects.window.left += get_system_metrics( SM_CYCAPTION );
+                    rects.window.left += button_width;
                     if (pt.x < rects.window.left) return HTCLOSE;
                 }
 
                 if (min_or_max_box && !(ex_style & WS_EX_TOOLWINDOW))
                 {
                     /* Check maximize box */
-                    rects.window.left += get_system_metrics( SM_CXSIZE );
+                    rects.window.left += button_width;
                     if (pt.x < rects.window.left) return HTMAXBUTTON;
 
                     /* Check minimize box */
-                    rects.window.left += get_system_metrics( SM_CXSIZE );
+                    rects.window.left += button_width;
                     if (pt.x < rects.window.left) return HTMINBUTTON;
                 }
             }
@@ -2117,18 +2119,18 @@ LRESULT handle_nc_hit_test( HWND hwnd, POINT pt )
                 /* Check close button */
                 if (style & WS_SYSMENU)
                 {
-                    rects.window.right -= get_system_metrics( SM_CYCAPTION );
+                    rects.window.right -= button_width;
                     if (pt.x > rects.window.right) return HTCLOSE;
                 }
 
                 if (min_or_max_box && !(ex_style & WS_EX_TOOLWINDOW))
                 {
                     /* Check maximize box */
-                    rects.window.right -= get_system_metrics( SM_CXSIZE );
+                    rects.window.right -= button_width;
                     if (pt.x > rects.window.right) return HTMAXBUTTON;
 
                     /* Check minimize box */
-                    rects.window.right -= get_system_metrics( SM_CXSIZE );
+                    rects.window.right -= button_width;
                     if (pt.x > rects.window.right) return HTMINBUTTON;
                 }
             }


### PR DESCRIPTION
## Stack

PR 7 of 8. Stacked on #30; merge only after #30.

## Summary

- Classify conventional full-client DComp presentations for native standard frames.
- Preserve exact mapped logical-root and synthetic client geometry.
- Mirror title, style, state, and nonclient commands without changing server authority.
- Reconstruct foreign-root task icons locally from the owning executable because Wine USER icon objects are process-local.

## Functional boundary

Includes platform-neutral DComp/DXGI frame selection, geometry, lifecycle cleanup, task identity, and composition regressions.

Excludes Wayland nonclient interaction, configure handling, allocation stabilization, and final changelog integration from #32.

## Validation

- `git diff --check` passes.
- Focused `dxgi --single --composition-only` runs executed 198 checks with zero failures and zero skips on x86_64 and i386.
- `oom_kill` remained unchanged during both final test runs.
- New Outlook visual QA confirmed the native title, border, controls, and Outlook icon in the validated integration.

## Provenance

- Base branch: `feature/outlook-new-06-wayland-dcomp-input`.
- Copied exactly from the validated final dirty integration tree.
- The source worktree retained its original dirty-diff checksum.

## Review notes

Do not reintroduce the rejected foreign-HWND DComp target test. `IDCompositionDevice::CreateTargetForHwnd()` correctly returns `E_ACCESSDENIED` for a HWND owned by another process, and Wine's DComp path requires the real local `IDXGISwapChain1` implementation. The production path is covered by server-authorized topology tests plus end-to-end Outlook identity evidence.

`__wine_dcomp_native_frame` is visual state only; it never grants input or topology authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Restore accurate native framing and task identity for conventional DirectComposition-hosted windows while preserving composition authority and lifecycle correctness.

New Features:
- Give conventional full-client DirectComposition presentations native standard frames that mirror the owning window’s identity and state.
- Reconstruct task icons from foreign processes’ executable images so cross-process composition helpers retain the correct task identity.

Bug Fixes:
- Preserve mapped client geometry and avoid unnecessary helper repositioning during unchanged composition updates.
- Clean up frame, identity, icon, delegation, and caption state when composition presentations are detached or rebound.

Enhancements:
- Route native-frame nonclient behavior through the helper while preserving the target window’s input and topology authority.
- Extend DirectComposition and DXGI regression coverage for frame selection, geometry, identity propagation, lifecycle cleanup, and custom presentation modes.
- Correct nonclient hit-test button sizing for tool windows.

Documentation:
- Document that DirectComposition-hosted Office windows retain their original frame and task identity.

Tests:
- Add focused composition-only DXGI tests covering native frames, geometry, styles, icons, hit testing, commands, clipping, transforms, DWM policy, custom captions, and cleanup.
- Update DirectComposition geometry tests to distinguish root windows from child composition targets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved composition-window sizing and positioning, including framed and child windows.
  * Updated caption button hit testing for tool windows and right-to-left layouts.
  * Preserved window titles, icons, styles, clipping, and non-client behavior more reliably.
  * Avoided unnecessary repositioning during repeated presentation.

* **Tests**
  * Expanded composition-window coverage for geometry, hit testing, styling, presentation, and cleanup.
  * Added an option to run composition tests independently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->