### PR TITLE
winewayland: Integrate native DComp task windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add initial New Outlook support with WebView2 input, native window frames, and correct Outlook taskbar identity.
+
 ## 0.2.0-beta.1 — 2026-08-19
 
 - Let Office finish proofing-language updates without crashing Click-to-Run.

--- a/dlls/winewayland.drv/wayland_pointer.c
+++ b/dlls/winewayland.drv/wayland_pointer.c
@@ -61,6 +61,10 @@ static const WCHAR dcomp_caption_hot_prop[] =
     {'_','_','w','i','n','e','_','d','c','o','m','p','_','c','a','p','t','i','o','n','_','h','o','t',0};
 static const WCHAR dcomp_caption_rtl_prop[] =
     {'_','_','w','i','n','e','_','d','c','o','m','p','_','c','a','p','t','i','o','n','_','r','t','l',0};
+static const WCHAR dcomp_native_frame_prop[] =
+    {'_','_','w','i','n','e','_','d','c','o','m','p','_','n','a','t','i','v','e','_','f','r','a','m','e',0};
+static const WCHAR dcomp_task_delegated_prop[] =
+    {'_','_','w','i','n','e','_','d','c','o','m','p','_','t','a','s','k','_','d','e','l','e','g','a','t','e','d',0};
 
 enum dcomp_caption_part
 {
@@ -216,6 +220,18 @@ static HWND wayland_pointer_get_focused_hwnd(void)
     return hwnd;
 }
 
+static BOOL wayland_pointer_get_screen_point(POINT *screen)
+{
+    struct wayland_pointer *pointer = &process_wayland.pointer;
+    BOOL valid;
+
+    pthread_mutex_lock(&pointer->mutex);
+    valid = pointer->screen_valid;
+    if (valid) *screen = pointer->screen;
+    pthread_mutex_unlock(&pointer->mutex);
+    return valid;
+}
+
 static HWND wayland_get_input_hwnd_internal(HWND hwnd, BOOL keyboard)
 {
     static const WCHAR target_prop[] = {'_','_','w','i','n','e','_','d','c','o','m','p','_',
@@ -259,9 +275,60 @@ HWND wayland_get_input_hwnd(HWND hwnd)
     return wayland_get_input_hwnd_internal(hwnd, TRUE);
 }
 
+static HWND wayland_get_native_frame_root(HWND hwnd)
+{
+    HWND target, root;
+
+    if (!NtUserGetProp(hwnd, dcomp_native_frame_prop) ||
+        !(target = NtUserGetProp(hwnd, dcomp_detached_window_prop)) ||
+        NtUserGetProp(target, dcomp_base_presentation_prop) != hwnd ||
+        !(root = NtUserGetAncestor(target, GA_ROOT)) ||
+        NtUserGetProp(root, dcomp_task_delegated_prop) != hwnd)
+        return NULL;
+    return root;
+}
+
+static LRESULT wayland_native_frame_hit_test(HWND hwnd, POINT screen)
+{
+    return NtUserMessageCall(hwnd, WM_NCHITTEST, 0, MAKELPARAM(screen.x, screen.y),
+            NULL, NtUserDefWindowProc, FALSE);
+}
+
 static HWND wayland_get_pointer_input_hwnd(HWND hwnd)
 {
-    return wayland_get_input_hwnd_internal(hwnd, FALSE);
+    POINT cursor = {0}, client_points[2];
+    HWND target, base, input_hwnd, root;
+    HANDLE native_frame;
+    RECT client = {0};
+    BOOL cursor_valid = FALSE, client_valid = FALSE;
+    UINT dpi;
+
+    native_frame = NtUserGetProp(hwnd, dcomp_native_frame_prop);
+    target = NtUserGetProp(hwnd, dcomp_detached_window_prop);
+    base = target ? NtUserGetProp(target, dcomp_base_presentation_prop) : NULL;
+    root = wayland_get_native_frame_root(hwnd);
+    dpi = NtUserGetDpiForWindow(hwnd);
+    if (root &&
+        (cursor_valid = wayland_pointer_get_screen_point(&cursor)) &&
+        (client_valid = NtUserGetClientRect(hwnd, &client, dpi)))
+    {
+        client_points[0].x = client.left;
+        client_points[0].y = client.top;
+        client_points[1].x = client.right;
+        client_points[1].y = client.bottom;
+        NtUserMapWindowPoints(hwnd, NULL, client_points, 2, dpi);
+        SetRect(&client, client_points[0].x, client_points[0].y,
+                client_points[1].x, client_points[1].y);
+        if (!PtInRect(&client, cursor)) input_hwnd = hwnd;
+        else input_hwnd = wayland_get_input_hwnd_internal(hwnd, FALSE);
+    }
+    else input_hwnd = wayland_get_input_hwnd_internal(hwnd, FALSE);
+
+    TRACE("DComp pointer input hwnd %p frame %p target %p base %p cursor %d,%d valid %u "
+          "client (%d,%d)-(%d,%d) valid %u -> %p\n", hwnd, native_frame, target, base,
+          cursor.x, cursor.y, cursor_valid, client.left, client.top, client.right,
+          client.bottom, client_valid, input_hwnd);
+    return input_hwnd;
 }
 
 static struct wayland_pointer_button *wayland_pointer_find_button_locked(
@@ -373,6 +440,11 @@ static void pointer_handle_motion_internal(wl_fixed_t sx, wl_fixed_t sy)
 
     wayland_win_data_release(data);
 
+    pthread_mutex_lock(&process_wayland.pointer.mutex);
+    process_wayland.pointer.screen = screen;
+    process_wayland.pointer.screen_valid = TRUE;
+    pthread_mutex_unlock(&process_wayland.pointer.mutex);
+
     caption = wayland_get_dcomp_caption(hwnd);
     if (caption && NtUserGetWindowRect(caption, &caption_rect, NtUserGetDpiForWindow(caption)) &&
         PtInRect(&caption_rect, screen))
@@ -432,6 +504,7 @@ static void pointer_handle_enter(void *data, struct wl_pointer *wl_pointer,
     pthread_mutex_lock(&pointer->mutex);
     pointer->focused_hwnd = hwnd;
     pointer->enter_serial = serial;
+    pointer->screen_valid = FALSE;
     pthread_mutex_unlock(&pointer->mutex);
 
     /* The cursor is undefined at every enter, so we set it again with
@@ -466,6 +539,7 @@ static void pointer_handle_leave(void *data, struct wl_pointer *wl_pointer,
     pthread_mutex_lock(&pointer->mutex);
     pointer->focused_hwnd = NULL;
     pointer->enter_serial = 0;
+    pointer->screen_valid = FALSE;
     pthread_mutex_unlock(&pointer->mutex);
 }
 
@@ -489,17 +563,16 @@ static HWND pointer_get_resize_surface_hwnd(HWND focused_hwnd, HWND resize_hwnd)
     return NULL;
 }
 
-static UINT pointer_get_resize_edge(HWND hwnd, HWND hit_test_hwnd, HWND resize_surface_hwnd)
+static UINT pointer_get_resize_edge(HWND hwnd, HWND hit_test_hwnd,
+                                    HWND resize_surface_hwnd, POINT cursor)
 {
     struct wayland_surface *surface;
     struct wayland_win_data *data;
     BOOL left, right, top, bottom;
     int frame_x, frame_y;
-    POINT cursor;
     RECT rect;
     UINT edge = 0;
 
-    if (!NtUserGetCursorPos(&cursor)) return 0;
     if (!(data = wayland_win_data_get(hit_test_hwnd))) return 0;
 
     surface = data->wayland_surface;
@@ -559,6 +632,9 @@ static void pointer_handle_button(void *data, struct wl_pointer *wl_pointer,
     struct wayland_pointer_button injected = {0};
     INPUT input = {0};
     HWND hwnd = NULL, input_hwnd, root = NULL, command, caption, resize_hwnd, resize_surface_hwnd;
+    BOOL cursor_valid, maximize, nonclient;
+    POINT cursor = {0};
+    LRESULT hit;
     NTSTATUS status;
     UINT resize_edge;
 
@@ -579,6 +655,32 @@ static void pointer_handle_button(void *data, struct wl_pointer *wl_pointer,
         pthread_mutex_unlock(&pointer->mutex);
 
         if (released.edge_resize) return;
+        if (!released.injected && released.native_frame_hit &&
+            wayland_get_native_frame_root(released.hwnd) == released.root_hwnd)
+        {
+            hit = released.native_frame_hit;
+            if (button == BTN_LEFT && hit != HTCAPTION &&
+                wayland_pointer_get_screen_point(&cursor) &&
+                wayland_native_frame_hit_test(released.hwnd, cursor) == hit)
+            {
+                if (hit == HTCLOSE)
+                    NtUserPostMessage(released.root_hwnd, WM_CLOSE, 0, 0);
+                else if (hit == HTMAXBUTTON)
+                {
+                    maximize = !(NtUserGetWindowLongW(released.root_hwnd, GWL_STYLE) & WS_MAXIMIZE);
+                    NtUserPostMessage(released.root_hwnd, WM_SYSCOMMAND,
+                            maximize ? SC_MAXIMIZE : SC_RESTORE, 0);
+                }
+                else if (hit == HTMINBUTTON)
+                {
+                    NtUserPostMessage(released.root_hwnd, WM_SYSCOMMAND, SC_MINIMIZE, 0);
+                    NtUserSetProp(released.hwnd, dcomp_task_minimized_prop, ULongToHandle(1));
+                    wayland_minimize_dcomp_base(released.hwnd);
+                    NtUserShowWindow(released.hwnd, SW_MINIMIZE);
+                }
+            }
+            return;
+        }
         if (released.injected)
         {
             wayland_pointer_send_button_up(&released);
@@ -646,11 +748,39 @@ static void pointer_handle_button(void *data, struct wl_pointer *wl_pointer,
 
     if (state == WL_POINTER_BUTTON_STATE_PRESSED)
     {
+        cursor_valid = wayland_pointer_get_screen_point(&cursor);
+        nonclient = FALSE;
+        if (button == BTN_LEFT && cursor_valid &&
+            (root = wayland_get_native_frame_root(hwnd)))
+        {
+            hit = wayland_native_frame_hit_test(hwnd, cursor);
+            if (hit == HTCAPTION)
+                nonclient = wayland_surface_begin_move_resize(hwnd, root, SC_MOVE, 0, serial);
+            else if (hit == HTMINBUTTON || hit == HTMAXBUTTON || hit == HTCLOSE)
+                nonclient = TRUE;
+            if (nonclient)
+            {
+                pthread_mutex_lock(&pointer->mutex);
+                owner = wayland_pointer_find_button_locked(pointer, button, FALSE);
+                if (owner)
+                {
+                    owner->root_hwnd = root;
+                    owner->native_frame_hit = hit;
+                    wayland_pointer_update_button_compat_locked(pointer);
+                }
+                pthread_mutex_unlock(&pointer->mutex);
+                TRACE("native frame button hwnd=%p root=%p hit=%ld screen=%d,%d serial=%u\n",
+                        hwnd, root, (long)hit, cursor.x, cursor.y, serial);
+                return;
+            }
+        }
+
         resize_hwnd = pointer_get_resize_hwnd(hwnd);
         resize_surface_hwnd = pointer_get_resize_surface_hwnd(hwnd, resize_hwnd);
 
-        if (button == BTN_LEFT && resize_surface_hwnd &&
-            (resize_edge = pointer_get_resize_edge(resize_hwnd, hwnd, resize_surface_hwnd)) &&
+        if (button == BTN_LEFT && cursor_valid && resize_surface_hwnd &&
+            (resize_edge = pointer_get_resize_edge(resize_hwnd, hwnd,
+                                                   resize_surface_hwnd, cursor)) &&
             wayland_surface_begin_move_resize(resize_surface_hwnd, resize_hwnd,
                                               SC_SIZE, resize_edge, serial))
         {
@@ -946,6 +1076,7 @@ void wayland_pointer_init(struct wl_pointer *wl_pointer)
     pointer->wl_pointer = wl_pointer;
     pointer->focused_hwnd = NULL;
     pointer->enter_serial = 0;
+    pointer->screen_valid = FALSE;
     memset(pointer->buttons, 0, sizeof(pointer->buttons));
     wayland_pointer_update_button_compat_locked(pointer);
     pthread_mutex_unlock(&pointer->mutex);
@@ -994,6 +1125,7 @@ void wayland_pointer_deinit(void)
     pointer->wl_pointer = NULL;
     pointer->focused_hwnd = NULL;
     pointer->enter_serial = 0;
+    pointer->screen_valid = FALSE;
     pthread_mutex_unlock(&pointer->mutex);
 }
 

--- a/dlls/winewayland.drv/wayland_pointer.c
+++ b/dlls/winewayland.drv/wayland_pointer.c
@@ -63,8 +63,6 @@ static const WCHAR dcomp_caption_rtl_prop[] =
     {'_','_','w','i','n','e','_','d','c','o','m','p','_','c','a','p','t','i','o','n','_','r','t','l',0};
 static const WCHAR dcomp_native_frame_prop[] =
     {'_','_','w','i','n','e','_','d','c','o','m','p','_','n','a','t','i','v','e','_','f','r','a','m','e',0};
-static const WCHAR dcomp_task_delegated_prop[] =
-    {'_','_','w','i','n','e','_','d','c','o','m','p','_','t','a','s','k','_','d','e','l','e','g','a','t','e','d',0};
 
 enum dcomp_caption_part
 {
@@ -283,7 +281,7 @@ static HWND wayland_get_native_frame_root(HWND hwnd)
         !(target = NtUserGetProp(hwnd, dcomp_detached_window_prop)) ||
         NtUserGetProp(target, dcomp_base_presentation_prop) != hwnd ||
         !(root = NtUserGetAncestor(target, GA_ROOT)) ||
-        NtUserGetProp(root, dcomp_task_delegated_prop) != hwnd)
+        !wayland_window_is_dcomp_task_delegate(root, hwnd))
         return NULL;
     return root;
 }

--- a/dlls/winewayland.drv/wayland_surface.c
+++ b/dlls/winewayland.drv/wayland_surface.c
@@ -214,8 +214,7 @@ static void xdg_surface_handle_configure(void *private, struct xdg_surface *xdg_
         root = target ? NtUserGetAncestor(target, GA_ROOT) : NULL;
         configure_directly = surface->resize_target && surface->resize_target == root &&
                              NtUserGetProp(hwnd, dcomp_native_frame_prop) &&
-                             NtUserGetProp(target, dcomp_base_presentation_prop) == hwnd &&
-                             NtUserGetProp(root, dcomp_task_delegated_prop) == hwnd;
+                             wayland_window_is_dcomp_task_delegate(root, hwnd);
         if (configure_directly && !surface->configure_worker_pending)
         {
             surface->configure_worker_pending = TRUE;

--- a/dlls/winewayland.drv/wayland_surface.c
+++ b/dlls/winewayland.drv/wayland_surface.c
@@ -169,12 +169,37 @@ BOOL wayland_surface_import_toplevel(struct wayland_surface *surface, ATOM atom)
 
 static RECT wayland_surface_get_presentation_rect(struct wayland_surface *surface);
 
+static void *configure_window_worker(void *arg)
+{
+    HWND hwnd = arg;
+
+    for (;;)
+    {
+        struct wayland_win_data *data;
+        struct wayland_surface *surface;
+        BOOL repeat = FALSE;
+
+        wayland_configure_window(hwnd);
+        if (!(data = wayland_win_data_get(hwnd))) break;
+        if ((surface = data->wayland_surface))
+        {
+            repeat = wayland_surface_is_toplevel(surface) && !!surface->requested.serial;
+            if (!repeat) surface->configure_worker_pending = FALSE;
+        }
+        wayland_win_data_release(data);
+        if (!repeat) break;
+    }
+    return NULL;
+}
+
 static void xdg_surface_handle_configure(void *private, struct xdg_surface *xdg_surface,
                                          uint32_t serial)
 {
     struct wayland_surface *surface;
     BOOL should_post = FALSE, configure_directly = FALSE, expose_contents = FALSE;
+    BOOL start_worker = FALSE;
     struct wayland_win_data *data;
+    pthread_t worker;
     HWND hwnd = private, target, root;
 
     TRACE("serial=%u\n", serial);
@@ -205,13 +230,33 @@ static void xdg_surface_handle_configure(void *private, struct xdg_surface *xdg_
                              NtUserGetProp(hwnd, dcomp_native_frame_prop) &&
                              NtUserGetProp(target, dcomp_base_presentation_prop) == hwnd &&
                              NtUserGetProp(root, dcomp_task_delegated_prop) == hwnd;
+        if (configure_directly && !surface->configure_worker_pending)
+        {
+            surface->configure_worker_pending = TRUE;
+            start_worker = TRUE;
+        }
     }
 
     wayland_win_data_release(data);
 
-    /* Chromium GPU presentation threads don't pump Win32 configure messages. */
-    if (configure_directly) wayland_configure_window(hwnd);
-    else if (should_post) NtUserPostMessage(hwnd, WM_WAYLAND_CONFIGURE, 0, 0);
+    /* Chromium GPU presentation threads don't pump Win32 configure messages.
+     * Use a worker so a hung resize target cannot block Wayland event dispatch. */
+    if (start_worker)
+    {
+        if (!pthread_create(&worker, NULL, configure_window_worker, hwnd))
+            pthread_detach(worker);
+        else
+        {
+            if ((data = wayland_win_data_get(hwnd)))
+            {
+                if ((surface = data->wayland_surface)) surface->configure_worker_pending = FALSE;
+                wayland_win_data_release(data);
+            }
+            NtUserPostMessage(hwnd, WM_WAYLAND_CONFIGURE, 0, 0);
+        }
+    }
+    else if (!configure_directly && should_post)
+        NtUserPostMessage(hwnd, WM_WAYLAND_CONFIGURE, 0, 0);
 
     /* Flush the window surface in case there is content that we weren't
      * able to flush before due to the lack of the initial configure. */

--- a/dlls/winewayland.drv/wayland_surface.c
+++ b/dlls/winewayland.drv/wayland_surface.c
@@ -54,6 +54,8 @@ static const WCHAR dcomp_caption_rtl_prop[] =
     {'_','_','w','i','n','e','_','d','c','o','m','p','_','c','a','p','t','i','o','n','_','r','t','l',0};
 static const WCHAR dcomp_task_minimized_prop[] =
     {'_','_','w','i','n','e','_','d','c','o','m','p','_','t','a','s','k','_','m','i','n','i','m','i','z','e','d',0};
+static const WCHAR dcomp_native_frame_prop[] =
+    {'_','_','w','i','n','e','_','d','c','o','m','p','_','n','a','t','i','v','e','_','f','r','a','m','e',0};
 
 static void dcomp_exported_handle(void *data, struct zxdg_exported_v2 *exported,
                                   const char *handle)
@@ -171,9 +173,9 @@ static void xdg_surface_handle_configure(void *private, struct xdg_surface *xdg_
                                          uint32_t serial)
 {
     struct wayland_surface *surface;
-    BOOL should_post = FALSE, expose_contents = FALSE;
+    BOOL should_post = FALSE, configure_directly = FALSE, expose_contents = FALSE;
     struct wayland_win_data *data;
-    HWND hwnd = private;
+    HWND hwnd = private, target, root;
 
     TRACE("serial=%u\n", serial);
 
@@ -196,11 +198,20 @@ static void xdg_surface_handle_configure(void *private, struct xdg_surface *xdg_
         surface->pending.serial = serial;
         surface->requested = surface->pending;
         memset(&surface->pending, 0, sizeof(surface->pending));
+
+        target = NtUserGetProp(hwnd, dcomp_detached_window_prop);
+        root = target ? NtUserGetAncestor(target, GA_ROOT) : NULL;
+        configure_directly = surface->resize_target && surface->resize_target == root &&
+                             NtUserGetProp(hwnd, dcomp_native_frame_prop) &&
+                             NtUserGetProp(target, dcomp_base_presentation_prop) == hwnd &&
+                             NtUserGetProp(root, dcomp_task_delegated_prop) == hwnd;
     }
 
     wayland_win_data_release(data);
 
-    if (should_post) NtUserPostMessage(hwnd, WM_WAYLAND_CONFIGURE, 0, 0);
+    /* Chromium GPU presentation threads don't pump Win32 configure messages. */
+    if (configure_directly) wayland_configure_window(hwnd);
+    else if (should_post) NtUserPostMessage(hwnd, WM_WAYLAND_CONFIGURE, 0, 0);
 
     /* Flush the window surface in case there is content that we weren't
      * able to flush before due to the lack of the initial configure. */
@@ -270,7 +281,7 @@ static void xdg_toplevel_handle_configure(void *private,
     }
 
     wayland_win_data_release(data);
-    if (restore_root) NtUserShowWindow(restore_root, SW_RESTORE);
+    if (restore_root) NtUserPostMessage(restore_root, WM_SYSCOMMAND, SC_RESTORE, 0);
 }
 
 static void xdg_toplevel_handle_close(void *data, struct xdg_toplevel *xdg_toplevel)
@@ -1754,17 +1765,22 @@ static const struct wl_buffer_listener dummy_buffer_listener =
 void wayland_surface_ensure_contents(struct wayland_surface *surface)
 {
     struct wayland_shm_buffer *dummy_shm_buffer;
+    RECT presentation_rect;
     ULONG_PTR backdrop;
     uint32_t format;
     HRGN damage;
-    int width, height;
+    int width, height, content_width, content_height;
     BOOL needs_contents;
 
     width = surface->window.rect.right - surface->window.rect.left;
     height = surface->window.rect.bottom - surface->window.rect.top;
+    if (width <= 0 || height <= 0) return;
+    presentation_rect = wayland_surface_get_presentation_rect(surface);
+    content_width = max(1, min(presentation_rect.right - presentation_rect.left, width));
+    content_height = max(1, min(presentation_rect.bottom - presentation_rect.top, height));
     needs_contents = surface->window.visible &&
-                     (surface->content_width != width ||
-                      surface->content_height != height);
+                     (surface->content_width != content_width ||
+                      surface->content_height != content_height);
 
     TRACE("surface=%p hwnd=%p needs_contents=%d\n",
           surface, surface->hwnd, needs_contents);

--- a/dlls/winewayland.drv/waylanddrv.h
+++ b/dlls/winewayland.drv/waylanddrv.h
@@ -353,6 +353,7 @@ struct wayland_surface
     ATOM dcomp_foreign_atom;
 
     struct wayland_surface_config pending, requested, processing, current;
+    BOOL configure_worker_pending;
     BOOL resizing;
     BOOL plasma_positioned;
     BOOL dcomp_overlay;

--- a/dlls/winewayland.drv/waylanddrv.h
+++ b/dlls/winewayland.drv/waylanddrv.h
@@ -127,6 +127,7 @@ struct wayland_pointer_button
     HWND input_hwnd;
     DWORD up_flags;
     DWORD mouse_data;
+    INT native_frame_hit;
     BOOL pressed;
     BOOL injected;
     BOOL edge_resize;
@@ -146,6 +147,8 @@ struct wayland_pointer
     BOOL pending_warp;
     uint32_t enter_serial;
     uint32_t button_serial;
+    POINT screen;
+    BOOL screen_valid;
     struct wayland_pointer_button buttons[WAYLAND_POINTER_BUTTON_COUNT];
     struct wayland_cursor cursor;
     double accum_x;
@@ -389,6 +392,7 @@ void wayland_surface_set_toplevel_parent(struct wayland_surface *surface,
                                          struct wayland_surface *parent);
 BOOL wayland_surface_begin_move_resize(HWND surface_hwnd, HWND target_hwnd,
                                        WPARAM command, UINT edge, uint32_t serial);
+void wayland_configure_window(HWND hwnd);
 void wayland_surface_make_subsurface(struct wayland_surface *surface,
                                      struct wayland_surface *parent);
 void wayland_surface_clear_role(struct wayland_surface *surface);

--- a/dlls/winewayland.drv/waylanddrv.h
+++ b/dlls/winewayland.drv/waylanddrv.h
@@ -478,6 +478,7 @@ void wayland_reapply_cursor_clipping(HWND hwnd);
 void wayland_restack_after_surface_flush(HWND owner);
 void wayland_window_surface_presented(HWND hwnd);
 BOOL wayland_window_is_dcomp_task_delegated(HWND root);
+BOOL wayland_window_is_dcomp_task_delegate(HWND root, HWND delegate);
 void wayland_window_init(void);
 
 /**********************************************************************

--- a/dlls/winewayland.drv/window.c
+++ b/dlls/winewayland.drv/window.c
@@ -51,6 +51,8 @@ static const WCHAR dcomp_base_presentation_prop[] =
     {'_','_','w','i','n','e','_','d','c','o','m','p','_','b','a','s','e','_','p','r','e','s','e','n','t','a','t','i','o','n',0};
 static const WCHAR dcomp_task_delegate_timer_prop[] =
     {'_','_','w','i','n','e','_','d','c','o','m','p','_','t','a','s','k','_','d','e','l','e','g','a','t','e','_','t','i','m','e','r',0};
+static const WCHAR dcomp_native_frame_prop[] =
+    {'_','_','w','i','n','e','_','d','c','o','m','p','_','n','a','t','i','v','e','_','f','r','a','m','e',0};
 
 static BOOL wayland_dcomp_task_delegated(HWND root)
 {
@@ -394,17 +396,21 @@ static void wayland_win_data_get_config(struct wayland_win_data *data,
 
     conf->minimized = !!(style & WS_MINIMIZE);
 
-    /* The fullscreen state is implied by the window position and style. */
-    if (data->is_fullscreen)
+    /* DComp task presentations follow the logical root geometry. */
+    if (!data->dcomp_base_presentation)
     {
-        if ((style & WS_MAXIMIZE) && (style & WS_CAPTION) == WS_CAPTION)
+        /* The fullscreen state is implied by the window position and style. */
+        if (data->is_fullscreen)
+        {
+            if ((style & WS_MAXIMIZE) && (style & WS_CAPTION) == WS_CAPTION)
+                window_state |= WAYLAND_SURFACE_CONFIG_STATE_MAXIMIZED;
+            else if (!(style & WS_MINIMIZE))
+                window_state |= WAYLAND_SURFACE_CONFIG_STATE_FULLSCREEN;
+        }
+        else if (style & WS_MAXIMIZE)
+        {
             window_state |= WAYLAND_SURFACE_CONFIG_STATE_MAXIMIZED;
-        else if (!(style & WS_MINIMIZE))
-            window_state |= WAYLAND_SURFACE_CONFIG_STATE_FULLSCREEN;
-    }
-    else if (style & WS_MAXIMIZE)
-    {
-        window_state |= WAYLAND_SURFACE_CONFIG_STATE_MAXIMIZED;
+        }
     }
 
     conf->resizeable = data->resizeable;
@@ -462,7 +468,8 @@ static BOOL wayland_win_data_create_wayland_surface(struct wayland_win_data *dat
     if (!visible || wayland_dcomp_task_delegated(data->hwnd) ||
         (data->dcomp_only_host && (state->exstyle & WS_EX_NOREDIRECTIONBITMAP)))
         role = WAYLAND_SURFACE_ROLE_NONE;
-    else if (owner_surface) role = WAYLAND_SURFACE_ROLE_SUBSURFACE;
+    else if (owner_surface && !data->dcomp_base_presentation)
+        role = WAYLAND_SURFACE_ROLE_SUBSURFACE;
     else role = WAYLAND_SURFACE_ROLE_TOPLEVEL;
 
     /* we can temporarily clear the role of a surface but cannot assign a different one after it's set */
@@ -503,7 +510,8 @@ static BOOL wayland_win_data_create_wayland_surface(struct wayland_win_data *dat
     switch (role)
     {
     case WAYLAND_SURFACE_ROLE_NONE:
-        wayland_surface_clear_role(surface);
+        if (surface->role != WAYLAND_SURFACE_ROLE_NONE)
+            wayland_surface_clear_role(surface);
         break;
     case WAYLAND_SURFACE_ROLE_TOPLEVEL:
         wayland_surface_make_toplevel(surface, state->title);
@@ -828,6 +836,26 @@ BOOL WAYLAND_WindowPosChanging(HWND hwnd, UINT swp_flags, BOOL shaped, const str
     return TRUE;
 }
 
+static HICON get_icon_info(HICON icon, ICONINFO *ii)
+{
+    return icon && NtUserGetIconInfo(icon, ii, NULL, NULL, NULL, 0) ? icon : NULL;
+}
+
+static HICON get_window_icon(HWND hwnd, UINT type, ICONINFO *ret)
+{
+    HICON icon;
+
+    if ((icon = get_icon_info((HICON)send_message(hwnd, WM_GETICON, type, 0), ret))) return icon;
+    if ((icon = get_icon_info((HICON)NtUserGetClassLongPtrW(hwnd, GCLP_HICON), ret))) return icon;
+    if (type == ICON_BIG)
+    {
+        icon = LoadImageW(0, (const WCHAR *)IDI_WINLOGO, IMAGE_ICON, 0, 0,
+                          LR_SHARED | LR_DEFAULTSIZE);
+        return get_icon_info(icon, ret);
+    }
+    return NULL;
+}
+
 /***********************************************************************
  *           WAYLAND_WindowPosChanged
  */
@@ -841,11 +869,11 @@ void WAYLAND_WindowPosChanged(HWND hwnd, HWND insert_after, HWND owner_hint, UIN
     struct wayland_surface *owner_surface, *transient_parent_surface;
     struct wayland_win_data *data, *owner_data, *transient_owner_data;
     BOOL managed, retry_client_surfaces = FALSE, surface_recreated = FALSE;
-    BOOL notification;
+    BOOL notification, needs_icon = FALSE;
     BOOL reapply_clip = FALSE;
     BOOL fullscreen = swp_flags & WINE_SWP_FULLSCREEN;
     struct wayland_window_state state;
-    HWND client_restack_toplevel = 0, popup_restack_owner = 0;
+    HWND client_restack_toplevel = 0, popup_restack_owner = 0, dcomp_target;
 
     TRACE("hwnd %p new_rects %s after %p flags %08x\n", hwnd, debugstr_window_rects(new_rects), insert_after, swp_flags);
 
@@ -926,12 +954,13 @@ void WAYLAND_WindowPosChanged(HWND hwnd, HWND insert_after, HWND owner_hint, UIN
     notification = is_notification_window(hwnd, swp_flags, &new_rects->window);
     data->owner = !managed && owner && owner != hwnd ? owner : NULL;
     data->dcomp_only_host = notification;
-    data->plasma_positioned = notification || NtUserGetProp(hwnd, dcomp_detached_window_prop);
-    data->dcomp_overlay = NtUserGetProp(hwnd, dcomp_detached_window_prop) &&
-                          !NtUserGetProp(hwnd, dcomp_background_prop);
+    dcomp_target = NtUserGetProp(hwnd, dcomp_detached_window_prop);
+    data->plasma_positioned = notification || dcomp_target;
+    data->dcomp_overlay = dcomp_target && !NtUserGetProp(hwnd, dcomp_background_prop);
     data->dcomp_notification = data->dcomp_overlay && is_dcomp_notification_window(hwnd);
-    data->dcomp_base_presentation = NtUserGetProp(hwnd, dcomp_detached_window_prop) &&
-                                    NtUserGetProp(hwnd, dcomp_background_prop);
+    data->dcomp_base_presentation = dcomp_target && NtUserIsWindow(dcomp_target) &&
+                                    NtUserGetProp(hwnd, dcomp_background_prop) &&
+                                    NtUserGetProp(dcomp_target, dcomp_base_presentation_prop) == hwnd;
 
     if (!surface)
     {
@@ -961,8 +990,28 @@ void WAYLAND_WindowPosChanged(HWND hwnd, HWND insert_after, HWND owner_hint, UIN
         data->wayland_surface->role == WAYLAND_SURFACE_ROLE_SUBSURFACE &&
         !data->wayland_surface->stacked)
         popup_restack_owner = data->wayland_surface->owner_hwnd;
+    needs_icon = process_wayland.xdg_toplevel_icon_manager_v1 && data->wayland_surface &&
+                 wayland_surface_is_toplevel(data->wayland_surface) &&
+                 !data->wayland_surface->big_icon_buffer;
 
     wayland_win_data_release(data);
+    if (needs_icon)
+    {
+        ICONINFO ii, ii_small;
+        HICON big = get_window_icon(hwnd, ICON_BIG, &ii);
+        HICON small = get_window_icon(hwnd, ICON_SMALL, &ii_small);
+
+        if ((data = wayland_win_data_get(hwnd)))
+        {
+            if (data->wayland_surface && wayland_surface_is_toplevel(data->wayland_surface))
+            {
+                if (big) wayland_surface_set_icon_buffer(data->wayland_surface, ICON_BIG, &ii);
+                if (small) wayland_surface_set_icon_buffer(data->wayland_surface, ICON_SMALL, &ii_small);
+                wayland_surface_assign_icon(data->wayland_surface);
+            }
+            wayland_win_data_release(data);
+        }
+    }
     if (reapply_clip) wayland_reapply_cursor_clipping(hwnd);
     if (client_restack_toplevel)
         wayland_win_data_restack_client_group(client_restack_toplevel);
@@ -975,7 +1024,7 @@ void WAYLAND_WindowPosChanged(HWND hwnd, HWND insert_after, HWND owner_hint, UIN
     }
 }
 
-static void wayland_configure_window(HWND hwnd)
+void wayland_configure_window(HWND hwnd)
 {
     struct wayland_surface *surface;
     INT width, height;
@@ -984,10 +1033,11 @@ static void wayland_configure_window(HWND hwnd)
     DWORD style;
     BOOL needs_enter_size_move = FALSE;
     BOOL needs_exit_size_move = FALSE;
-    BOOL restoring_from_minimize = FALSE;
+    BOOL restoring_from_minimize = FALSE, resize_presentation = FALSE;
+    BOOL dcomp_base_presentation = FALSE;
     struct wayland_win_data *data;
     RECT rect, surface_rect;
-    HWND resize_target = NULL;
+    HWND resize_target = NULL, surface_hwnd = hwnd, target, root;
 
     if (!(data = wayland_win_data_get(hwnd))) return;
     if (!(surface = data->wayland_surface))
@@ -1043,6 +1093,15 @@ static void wayland_configure_window(HWND hwnd)
         NtUserIsWindow(surface->resize_target))
         resize_target = surface->resize_target;
     if (!(state & WAYLAND_SURFACE_CONFIG_STATE_RESIZING)) surface->resize_target = NULL;
+
+    target = NtUserGetProp(surface_hwnd, dcomp_detached_window_prop);
+    root = target ? NtUserGetAncestor(target, GA_ROOT) : NULL;
+    dcomp_base_presentation = target &&
+                              NtUserGetProp(target, dcomp_base_presentation_prop) == surface_hwnd;
+    resize_presentation = resize_target && resize_target == root &&
+                          NtUserGetProp(surface_hwnd, dcomp_native_frame_prop) &&
+                          dcomp_base_presentation &&
+                          NtUserGetProp(root, dcomp_task_delegated_prop) == surface_hwnd;
 
     /* Transitions between normal/max/fullscreen may entail a frame change. */
     if ((state ^ surface->current.state) &
@@ -1112,8 +1171,9 @@ static void wayland_configure_window(HWND hwnd)
 
     hwnd = resize_target ? resize_target : hwnd;
     style = NtUserGetWindowLongW(hwnd, GWL_STYLE);
-    if (!(state & WAYLAND_SURFACE_CONFIG_STATE_MAXIMIZED) != !(style & WS_MAXIMIZE)
-        && !(state & WAYLAND_SURFACE_CONFIG_STATE_FULLSCREEN))
+    if (!dcomp_base_presentation &&
+        !(state & WAYLAND_SURFACE_CONFIG_STATE_MAXIMIZED) != !(style & WS_MAXIMIZE) &&
+        !(state & WAYLAND_SURFACE_CONFIG_STATE_FULLSCREEN))
         NtUserSetWindowLong(hwnd, GWL_STYLE, style ^ WS_MAXIMIZE, FALSE);
 
     /* The Wayland maximized and fullscreen states are very strict about
@@ -1128,6 +1188,11 @@ static void wayland_configure_window(HWND hwnd)
     }
 
     NtUserSetRawWindowPos(hwnd, rect, flags, FALSE);
+    if (resize_presentation)
+    {
+        NtUserSetRawWindowPos(surface_hwnd, rect, flags, FALSE);
+        NtUserExposeWindowSurface(surface_hwnd, 0, NULL);
+    }
 }
 
 /**********************************************************************
@@ -1386,27 +1451,35 @@ static void wayland_move_resize_loop(HWND hwnd)
 LRESULT WAYLAND_SysCommand(HWND hwnd, WPARAM wparam, LPARAM lparam, const POINT *pos)
 {
     BOOL move_resize_started = FALSE;
-    LRESULT ret = -1;
-    HWND button_hwnd;
+    HWND button_hwnd, surface_hwnd = hwnd, target_hwnd = hwnd;
     WPARAM command = wparam & 0xfff0;
     uint32_t button_serial;
+    HWND target, root;
+    LRESULT ret = -1;
 
     TRACE("cmd=%lx hwnd=%p, %lx, %lx\n",
           (long)command, hwnd, (long)wparam, lparam);
 
+    if (NtUserGetProp(hwnd, dcomp_native_frame_prop) &&
+        (target = NtUserGetProp(hwnd, dcomp_detached_window_prop)) &&
+        (root = NtUserGetAncestor(target, GA_ROOT)) &&
+        wayland_dcomp_task_delegated(root) &&
+        NtUserGetProp(root, dcomp_task_delegated_prop) == hwnd)
+        target_hwnd = root;
+
     pthread_mutex_lock(&process_wayland.pointer.mutex);
     button_hwnd = process_wayland.pointer.button_hwnd;
-    button_serial = button_hwnd == hwnd ? process_wayland.pointer.button_serial : 0;
+    button_serial = button_hwnd == surface_hwnd ? process_wayland.pointer.button_serial : 0;
     pthread_mutex_unlock(&process_wayland.pointer.mutex);
 
     if (command == SC_MOVE || command == SC_SIZE)
     {
-        move_resize_started = wayland_surface_begin_move_resize(hwnd, hwnd, command,
-                wparam & 0x0f, button_serial);
+        move_resize_started = wayland_surface_begin_move_resize(surface_hwnd, target_hwnd,
+                command, wparam & 0x0f, button_serial);
         ret = 0;
     }
 
-    if (move_resize_started) wayland_move_resize_loop(hwnd);
+    if (move_resize_started) wayland_move_resize_loop(surface_hwnd);
     return ret;
 }
 

--- a/dlls/winewayland.drv/window.c
+++ b/dlls/winewayland.drv/window.c
@@ -846,6 +846,9 @@ static HICON get_window_icon(HWND hwnd, UINT type, ICONINFO *ret)
     HICON icon;
 
     if ((icon = get_icon_info((HICON)send_message(hwnd, WM_GETICON, type, 0), ret))) return icon;
+    if (type == ICON_SMALL &&
+        (icon = get_icon_info((HICON)NtUserGetClassLongPtrW(hwnd, GCLP_HICONSM), ret)))
+        return icon;
     if ((icon = get_icon_info((HICON)NtUserGetClassLongPtrW(hwnd, GCLP_HICON), ret))) return icon;
     if (type == ICON_BIG)
     {
@@ -854,6 +857,12 @@ static HICON get_window_icon(HWND hwnd, UINT type, ICONINFO *ret)
         return get_icon_info(icon, ret);
     }
     return NULL;
+}
+
+static void free_icon_info(const ICONINFO *ii)
+{
+    if (ii->hbmColor) NtGdiDeleteObjectApp(ii->hbmColor);
+    if (ii->hbmMask) NtGdiDeleteObjectApp(ii->hbmMask);
 }
 
 /***********************************************************************
@@ -1011,6 +1020,8 @@ void WAYLAND_WindowPosChanged(HWND hwnd, HWND insert_after, HWND owner_hint, UIN
             }
             wayland_win_data_release(data);
         }
+        if (big) free_icon_info(&ii);
+        if (small) free_icon_info(&ii_small);
     }
     if (reapply_clip) wayland_reapply_cursor_clipping(hwnd);
     if (client_restack_toplevel)
@@ -1362,6 +1373,8 @@ void WAYLAND_SetWindowIcons(HWND hwnd, HICON icon, const ICONINFO *ii, HICON ico
             wayland_win_data_release(data);
         }
     }
+    if (icon) free_icon_info(ii);
+    if (icon_small) free_icon_info(ii_small);
 }
 
 /***********************************************************************

--- a/dlls/winewayland.drv/window.c
+++ b/dlls/winewayland.drv/window.c
@@ -65,6 +65,12 @@ BOOL wayland_window_is_dcomp_task_delegated(HWND root)
            NtUserGetProp(target, dcomp_base_presentation_prop) == delegate;
 }
 
+BOOL wayland_window_is_dcomp_task_delegate(HWND root, HWND delegate)
+{
+    return NtUserGetProp(root, dcomp_task_delegated_prop) == delegate &&
+           wayland_window_is_dcomp_task_delegated(root);
+}
+
 static void WINAPI wayland_dcomp_task_delegate_timer(HWND hwnd, UINT msg, UINT_PTR id, DWORD time)
 {
     if (wayland_window_is_dcomp_task_delegated(hwnd)) return;
@@ -1476,8 +1482,7 @@ LRESULT WAYLAND_SysCommand(HWND hwnd, WPARAM wparam, LPARAM lparam, const POINT 
     if (NtUserGetProp(hwnd, dcomp_native_frame_prop) &&
         (target = NtUserGetProp(hwnd, dcomp_detached_window_prop)) &&
         (root = NtUserGetAncestor(target, GA_ROOT)) &&
-        wayland_dcomp_task_delegated(root) &&
-        NtUserGetProp(root, dcomp_task_delegated_prop) == hwnd)
+        wayland_window_is_dcomp_task_delegate(root, hwnd))
         target_hwnd = root;
 
     pthread_mutex_lock(&process_wayland.pointer.mutex);


### PR DESCRIPTION
## Stack

PR 8 of 8. Stacked on #31; merge only after #31.

## Summary

- Keep native-frame nonclient pointer actions on the synthetic Wayland toplevel while targeting the logical root.
- Handle move, resize, minimize, maximize, restore, close, and direct configure updates through delegated task state.
- Make role clearing and dummy-buffer allocation idempotent for framed presentation surfaces.
- Publish the complete user-visible New Outlook changelog entry.

## Functional boundary

Includes final native-Wayland frame interaction, configure/resize behavior, allocation stability, task icon publication, and changelog integration.

This is the top user-visible PR; all activation, storage, DOM, manager, authorization, and base input prerequisites are isolated below it.

## User-visible result

- One native-framed New Outlook window with title, app icon, thin border, and caption controls.
- One Outlook taskbar entry with the Outlook icon.
- One Outlook system-tray entry with its Outlook context menu.
- Preserved WebView rendering, keyboard input, pointer routing, and exact mapped-client equality.

## Validation

- `git diff --check` passes.
- The top branch is byte-for-byte equivalent to all 72 changed paths in the validated final integration tree.
- x86_64 and i386 DXGI composition runs each passed 198 checks with zero failures and zero skips.
- Clean Launch 91 confirmed one Outlook taskbar icon, one tray icon, no Wine fallback icon, stable frame geometry, and no allocation loop.

## Provenance

- Base branch: `feature/outlook-new-07-dcomp-native-frame`.
- Copied exactly from the validated final dirty integration tree.
- The original source worktree remains at `cf77f3b43ce5981bac562d692d25c74dc1ed6be1` with the same dirty-diff checksum.

## Review notes

The invariant is:

```text
mapped synthetic client rectangle == mapped logical root client rectangle
```

Native framing remains conditional on the server-elected opaque presentation exactly covering a conventional root client. Custom/client-drawn captions remain unframed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Integrate native DirectComposition task windows into Wine Wayland with stable framing, delegated window management, correct input routing, and Outlook task identity.

New Features:
- Support native-framed DirectComposition task windows with delegated move, resize, minimize, maximize, restore, and close interactions.
- Publish native taskbar window icons for Wayland toplevels.
- Add initial New Outlook support with native frames, WebView2 input, and correct taskbar identity.

Bug Fixes:
- Preserve pointer routing between synthetic frames and logical roots while maintaining mapped client-rectangle equality.
- Handle DirectComposition configure and resize updates without relying on the target application's message pump.
- Prevent repeated role clearing and dummy-buffer allocation for framed presentation surfaces.

Enhancements:
- Extend DirectComposition task delegation state handling for native frame presentation surfaces.

Documentation:
- Add the user-visible New Outlook support entry to the changelog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added initial support for New Outlook on Wayland.
  - Improved native window frames, including title-bar actions, resizing, moving, and window state handling.
  - Added correct application icons for Wayland windows.
  - Improved taskbar identity and window restoration behavior.

- **Bug Fixes**
  - Fixed pointer tracking and native-frame hit testing.
  - Improved window configuration and presentation sizing for DirectComposition applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->