### PR TITLE
Fix Word startup input latency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Keep Word responsive while loading Office Click-to-Run component manifests and presenting startup frames.
+
 ## 0.2.0-beta.1 — 2026-08-19
 
 - Let Office finish proofing-language updates without crashing Click-to-Run.

--- a/dlls/msi/registry.c
+++ b/dlls/msi/registry.c
@@ -1508,6 +1508,7 @@ static UINT enum_office_c2r_ui_qualifiers( const WCHAR *component, DWORD index, 
 #define OFFICE_C2R_MAX_XML_DEPTH 128
 #define OFFICE_C2R_MAX_COMPONENTS 4096
 #define OFFICE_C2R_MAX_PUBLISH_COMPONENTS 4096
+#define OFFICE_C2R_HASH_SIZE 8192
 
 struct office_c2r_xml_tag
 {
@@ -1545,9 +1546,11 @@ struct office_c2r_manifest
 {
     WCHAR product_code[GUID_SIZE];
     struct office_c2r_component *components;
-    DWORD component_count;
+    DWORD component_count, component_capacity;
+    DWORD *component_hash;
     struct office_c2r_publish_component *publish_components;
-    DWORD publish_component_count;
+    DWORD publish_component_count, publish_component_capacity;
+    DWORD *publish_component_hash;
 };
 
 struct office_c2r_seen_key
@@ -1745,10 +1748,18 @@ static BOOL office_c2r_valid_guid( const WCHAR *value )
            value[GUID_SIZE - 2] == '}' && SUCCEEDED( CLSIDFromString( value, &guid ) );
 }
 
+static DWORD office_c2r_hash_string( DWORD hash, const WCHAR *value )
+{
+    while (*value) hash = (hash ^ towlower( *value++ )) * 16777619;
+    return hash;
+}
+
 static void office_c2r_manifest_free( struct office_c2r_manifest *manifest )
 {
     free( manifest->components );
+    free( manifest->component_hash );
     free( manifest->publish_components );
+    free( manifest->publish_component_hash );
     memset( manifest, 0, sizeof(*manifest) );
 }
 
@@ -1758,7 +1769,7 @@ static BOOL office_c2r_manifest_add_component( struct office_c2r_manifest *manif
     WCHAR id[GUID_SIZE], keypath[1024];
     BOOL id_present, keypath_present;
     struct office_c2r_component *new_components;
-    DWORD i;
+    DWORD hash, index, new_capacity;
 
     if (!office_c2r_xml_attribute( tag, L"ComponentId", id, ARRAY_SIZE(id), &id_present ) ||
         !id_present || !office_c2r_valid_guid( id ))
@@ -1766,27 +1777,42 @@ static BOOL office_c2r_manifest_add_component( struct office_c2r_manifest *manif
     if (!office_c2r_xml_attribute( tag, L"KeyPath", keypath, ARRAY_SIZE(keypath), &keypath_present ))
         return TRUE;
 
-    for (i = 0; i < manifest->component_count; i++)
+    if (!manifest->component_hash &&
+        !(manifest->component_hash = calloc( OFFICE_C2R_HASH_SIZE,
+                                             sizeof(*manifest->component_hash) )))
+        return FALSE;
+    hash = office_c2r_hash_string( 2166136261u, id ) & (OFFICE_C2R_HASH_SIZE - 1);
+    while ((index = manifest->component_hash[hash]))
     {
-        if (wcsicmp( manifest->components[i].id, id )) continue;
-        if (!manifest->components[i].has_keypath && keypath_present && keypath[0])
+        index--;
+        if (wcsicmp( manifest->components[index].id, id ))
         {
-            lstrcpyW( manifest->components[i].keypath, keypath );
-            manifest->components[i].has_keypath = TRUE;
+            hash = (hash + 1) & (OFFICE_C2R_HASH_SIZE - 1);
+            continue;
+        }
+        if (!manifest->components[index].has_keypath && keypath_present && keypath[0])
+        {
+            lstrcpyW( manifest->components[index].keypath, keypath );
+            manifest->components[index].has_keypath = TRUE;
         }
         return TRUE;
     }
     if (manifest->component_count == OFFICE_C2R_MAX_COMPONENTS) return TRUE;
-    if (!(new_components = realloc( manifest->components,
-                                    (manifest->component_count + 1) *
-                                    sizeof(*manifest->components) )))
-        return FALSE;
-    manifest->components = new_components;
+    if (manifest->component_count == manifest->component_capacity)
+    {
+        new_capacity = manifest->component_capacity ? manifest->component_capacity * 2 : 32;
+        if (new_capacity > OFFICE_C2R_MAX_COMPONENTS) new_capacity = OFFICE_C2R_MAX_COMPONENTS;
+        if (!(new_components = realloc( manifest->components,
+                                        new_capacity * sizeof(*manifest->components) )))
+            return FALSE;
+        manifest->components = new_components;
+        manifest->component_capacity = new_capacity;
+    }
     lstrcpyW( manifest->components[manifest->component_count].id, id );
     manifest->components[manifest->component_count].has_keypath = keypath_present && keypath[0];
     if (manifest->components[manifest->component_count].has_keypath)
         lstrcpyW( manifest->components[manifest->component_count].keypath, keypath );
-    manifest->component_count++;
+    manifest->component_hash[hash] = ++manifest->component_count;
     return TRUE;
 }
 
@@ -1799,7 +1825,7 @@ static BOOL office_c2r_manifest_add_publish_component( struct office_c2r_manifes
     BOOL publish_id_present, qualifier_present, component_id_present, feature_present;
     BOOL appdata_present, keyfile_present;
     struct office_c2r_publish_component *new_publish_components;
-    DWORD i;
+    DWORD hash, index, new_capacity;
 
     if (!office_c2r_xml_attribute( tag, L"PublishComponentId", publish_component_id,
                                    ARRAY_SIZE(publish_component_id), &publish_id_present ) ||
@@ -1826,24 +1852,42 @@ static BOOL office_c2r_manifest_add_publish_component( struct office_c2r_manifes
         !office_c2r_xml_attribute( tag, L"KeyFile", keyfile, ARRAY_SIZE(keyfile), &keyfile_present ))
         return TRUE;
 
-    for (i = 0; i < manifest->publish_component_count; i++)
+    if (!manifest->publish_component_hash &&
+        !(manifest->publish_component_hash = calloc( OFFICE_C2R_HASH_SIZE,
+                                                     sizeof(*manifest->publish_component_hash) )))
+        return FALSE;
+    hash = office_c2r_hash_string( 2166136261u, publish_component_id );
+    hash = office_c2r_hash_string( hash, qualifier ) & (OFFICE_C2R_HASH_SIZE - 1);
+    while ((index = manifest->publish_component_hash[hash]))
     {
-        if (wcsicmp( manifest->publish_components[i].publish_component_id, publish_component_id ) ||
-            wcsicmp( manifest->publish_components[i].qualifier, qualifier ))
-            continue;
-        if (!manifest->publish_components[i].has_keyfile && keyfile_present && keyfile[0])
+        index--;
+        if (wcsicmp( manifest->publish_components[index].publish_component_id,
+                     publish_component_id ) ||
+            wcsicmp( manifest->publish_components[index].qualifier, qualifier ))
         {
-            lstrcpyW( manifest->publish_components[i].keyfile, keyfile );
-            manifest->publish_components[i].has_keyfile = TRUE;
+            hash = (hash + 1) & (OFFICE_C2R_HASH_SIZE - 1);
+            continue;
+        }
+        if (!manifest->publish_components[index].has_keyfile && keyfile_present && keyfile[0])
+        {
+            lstrcpyW( manifest->publish_components[index].keyfile, keyfile );
+            manifest->publish_components[index].has_keyfile = TRUE;
         }
         return TRUE;
     }
     if (manifest->publish_component_count == OFFICE_C2R_MAX_PUBLISH_COMPONENTS) return TRUE;
-    if (!(new_publish_components = realloc( manifest->publish_components,
-                                            (manifest->publish_component_count + 1) *
-                                            sizeof(*manifest->publish_components) )))
-        return FALSE;
-    manifest->publish_components = new_publish_components;
+    if (manifest->publish_component_count == manifest->publish_component_capacity)
+    {
+        new_capacity = manifest->publish_component_capacity ?
+                manifest->publish_component_capacity * 2 : 32;
+        if (new_capacity > OFFICE_C2R_MAX_PUBLISH_COMPONENTS)
+            new_capacity = OFFICE_C2R_MAX_PUBLISH_COMPONENTS;
+        if (!(new_publish_components = realloc( manifest->publish_components,
+                                                new_capacity * sizeof(*manifest->publish_components) )))
+            return FALSE;
+        manifest->publish_components = new_publish_components;
+        manifest->publish_component_capacity = new_capacity;
+    }
     lstrcpyW( manifest->publish_components[manifest->publish_component_count].publish_component_id,
               publish_component_id );
     lstrcpyW( manifest->publish_components[manifest->publish_component_count].qualifier, qualifier );
@@ -1855,7 +1899,7 @@ static BOOL office_c2r_manifest_add_publish_component( struct office_c2r_manifes
         keyfile_present && keyfile[0];
     if (manifest->publish_components[manifest->publish_component_count].has_keyfile)
         lstrcpyW( manifest->publish_components[manifest->publish_component_count].keyfile, keyfile );
-    manifest->publish_component_count++;
+    manifest->publish_component_hash[hash] = ++manifest->publish_component_count;
     return TRUE;
 }
 

--- a/dlls/wined3d/cs.c
+++ b/dlls/wined3d/cs.c
@@ -783,13 +783,6 @@ void wined3d_cs_emit_present(struct wined3d_cs *cs, struct wined3d_swapchain *sw
     }
 
     wined3d_device_context_submit(&cs->c, WINED3D_CS_QUEUE_DEFAULT);
-
-    if (!(swapchain->state.desc.flags & WINED3D_SWAPCHAIN_FRAME_LATENCY_WAITABLE_OBJECT))
-    {
-        /* Limit input latency by limiting the number of presents that we can
-         * get ahead of the worker thread. */
-        WaitForSingleObject(swapchain->frame_latency_semaphore, INFINITE);
-    }
 }
 
 static void wined3d_cs_exec_clear(struct wined3d_cs *cs, const void *data)

--- a/dlls/wined3d/swapchain.c
+++ b/dlls/wined3d/swapchain.c
@@ -243,6 +243,14 @@ HRESULT CDECL wined3d_swapchain_present(struct wined3d_swapchain *swapchain,
     if (flags)
         FIXME("Ignoring flags %#x.\n", flags);
 
+    if (!(swapchain->state.desc.flags & WINED3D_SWAPCHAIN_FRAME_LATENCY_WAITABLE_OBJECT))
+    {
+        /* Limit input latency by limiting the number of presents that we can
+         * get ahead of the worker thread. Avoid holding the D3D mutex across
+         * to not block other threads. */
+        WaitForSingleObject(swapchain->frame_latency_semaphore, INFINITE);
+    }
+
     wined3d_mutex_lock();
 
     if (!swapchain->back_buffers)

--- a/dlls/wined3d/swapchain.c
+++ b/dlls/wined3d/swapchain.c
@@ -243,14 +243,6 @@ HRESULT CDECL wined3d_swapchain_present(struct wined3d_swapchain *swapchain,
     if (flags)
         FIXME("Ignoring flags %#x.\n", flags);
 
-    if (!(swapchain->state.desc.flags & WINED3D_SWAPCHAIN_FRAME_LATENCY_WAITABLE_OBJECT))
-    {
-        /* Limit input latency by limiting the number of presents that we can
-         * get ahead of the worker thread. Avoid holding the D3D mutex across
-         * to not block other threads. */
-        WaitForSingleObject(swapchain->frame_latency_semaphore, INFINITE);
-    }
-
     wined3d_mutex_lock();
 
     if (!swapchain->back_buffers)
@@ -258,6 +250,24 @@ HRESULT CDECL wined3d_swapchain_present(struct wined3d_swapchain *swapchain,
         WARN("Swapchain doesn't have a backbuffer, returning WINED3DERR_INVALIDCALL.\n");
         wined3d_mutex_unlock();
         return WINED3DERR_INVALIDCALL;
+    }
+
+    if (!(swapchain->state.desc.flags & WINED3D_SWAPCHAIN_FRAME_LATENCY_WAITABLE_OBJECT))
+    {
+        /* Limit input latency by limiting the number of presents that we can
+         * get ahead of the worker thread. Avoid holding the D3D mutex while
+         * waiting, so other threads are not blocked. */
+        wined3d_mutex_unlock();
+        WaitForSingleObject(swapchain->frame_latency_semaphore, INFINITE);
+        wined3d_mutex_lock();
+
+        if (!swapchain->back_buffers)
+        {
+            ReleaseSemaphore(swapchain->frame_latency_semaphore, 1, NULL);
+            WARN("Swapchain doesn't have a backbuffer, returning WINED3DERR_INVALIDCALL.\n");
+            wined3d_mutex_unlock();
+            return WINED3DERR_INVALIDCALL;
+        }
     }
 
     if (!src_rect)


### PR DESCRIPTION
## Purpose

Fix Issue #2, where Word ignores or paints startup input several seconds late on both native Wayland and X11/Xwayland.

Live stack sampling found two causal stalls:

- Word held a `wwlib` critical section while an Office worker parsed large Click-to-Run manifests through `MsiProvideQualifiedComponentExW`. Wine performed a one-element `realloc()` and a linear duplicate scan for every record.
- A separate sampled stall had Word waiting for the global `wined3d` mutex while the command-stream thread waited for frame latency.

## Changes

- Grow Click-to-Run component arrays geometrically.
- Use bounded case-insensitive hash indexes for component and publish-component duplicate lookup while preserving first-record and missing-key-path merge semantics.
- Backport upstream Wine commit `0fde54a3574`, moving the frame-latency wait outside the global `wined3d` mutex.
- Add an Unreleased changelog entry.

## Validation

- Complete MSI suite: 4,760 tests executed, 43 todo, 0 flaky, **0 failures**, 0 skipped.
- Focused 32-bit and 64-bit MSI builds succeeded.
- Focused 32-bit and 64-bit `wined3d` builds succeeded.
- Real 1.1 MB Office manifest benchmark:
  - x86-64: 181.9–218.3 ms before, 21.0–24.9 ms after (about 8.5× faster).
  - i386: about 310 ms before, 31–37 ms after (about 10× faster).
- Manager-launched native Wayland Word: first character painted within 0.25 seconds after opening a blank document; the full paced string was visible within 1 second.
- X11/Xwayland Word reached the start center in about 20 seconds instead of remaining at the splash beyond 60 seconds; focused document input painted within 0.25 seconds.

## Risk

- The hash tables are fixed at 8,192 slots for bounded maximums of 4,096 component and 4,096 publish-component records, keeping load at or below 50%.
- Hash collisions are resolved with linear probing and verified with the same case-insensitive string comparisons used previously.
- Duplicate ordering and merge behavior remain covered by the existing public MSI manifest regression.

## Evidence

Task evidence and measurements are recorded in `artifacts/issue2-remote-repro-20260820/RESULTS.md` in the companion workspace. The remote patched environment remains available on `keremreim-bardugonet:32808`.

## Summary by Sourcery

Improve Word startup responsiveness by removing manifest-processing and graphics synchronization stalls.

Bug Fixes:
- Keep Word responsive during startup by reducing Office Click-to-Run manifest processing stalls and avoiding input-blocking frame-latency waits.

Enhancements:
- Optimize Click-to-Run component and publish-component parsing while preserving duplicate merge behavior.
- Allow wined3d frame-latency waits to proceed without holding the global graphics mutex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved Microsoft Word responsiveness while loading Office Click-to-Run manifests and displaying startup frames.
  * Improved presentation and rendering behavior by coordinating frame-latency waits more efficiently.
* **Reliability**
  * Improved detection and updating of Office Click-to-Run components, helping ensure manifest information is processed consistently.
  * Improved handling of unavailable display resources during presentation.
* **Documentation**
  * Added an Unreleased changelog entry describing the responsiveness improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->