### PR TITLE
Fix blank Microsoft 365 sign-in window in Word

### DIFF
--- a/.github/workflows/wine4office-release.yml
+++ b/.github/workflows/wine4office-release.yml
@@ -115,6 +115,8 @@ jobs:
         run: tools/wine4office-manager/tests/test_curl_install.sh
       - name: Test release archive packaging
         run: tools/wine4office-manager/tests/test_release_artifacts.sh
+      - name: Test OAuth helper source contracts
+        run: python3 programs/wine4officeauth/tests/test_authorize_url.py
 
       - name: Configure and build Wine4Office
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Open Microsoft 365 sign-in pages correctly in Word.
 - Allow 60 seconds for the Office installer to open and report startup timeouts clearly.
 - Show localized graceful-close and forced-kill progress while stopping the selected Wine environment.
 - Improve Wine runner and application-status translations.

--- a/programs/wine4officeauth/tests/test_authorize_url.py
+++ b/programs/wine4officeauth/tests/test_authorize_url.py
@@ -10,11 +10,14 @@ class AuthorizeUrlSourceTest(unittest.TestCase):
         build = source.index('authorize_url = "https://login.microsoftonline.com/"')
         convert = source.index("authorize_url_w = utf8_to_wide(authorize_url);", build)
         validate = source.index("if (authorize_url_w.empty()) return false;", convert)
+        create_browser = source.index("CoCreateInstance(CLSID_WebBrowser", validate)
         allocate = source.index("url = SysAllocString(authorize_url_w.c_str());", validate)
         navigate = source.index("hr = browser->Navigate(url,", allocate)
 
         self.assertLess(build, convert)
         self.assertLess(convert, validate)
+        self.assertLess(validate, create_browser)
+        self.assertLess(create_browser, allocate)
         self.assertLess(validate, allocate)
         self.assertLess(allocate, navigate)
 

--- a/programs/wine4officeauth/tests/test_authorize_url.py
+++ b/programs/wine4officeauth/tests/test_authorize_url.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+import pathlib
+import unittest
+
+
+class AuthorizeUrlSourceTest(unittest.TestCase):
+    def test_browser_navigates_to_converted_authorize_url(self):
+        source = (pathlib.Path(__file__).parents[1] / "wine4officeauth.cpp").read_text()
+        build = source.index('authorize_url = "https://login.microsoftonline.com/"')
+        convert = source.index("authorize_url_w = utf8_to_wide(authorize_url);", build)
+        validate = source.index("if (authorize_url_w.empty()) return false;", convert)
+        navigate = source.index("url = SysAllocString(authorize_url_w.c_str());", validate)
+
+        self.assertLess(build, convert)
+        self.assertLess(convert, validate)
+        self.assertLess(validate, navigate)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/programs/wine4officeauth/tests/test_authorize_url.py
+++ b/programs/wine4officeauth/tests/test_authorize_url.py
@@ -10,11 +10,13 @@ class AuthorizeUrlSourceTest(unittest.TestCase):
         build = source.index('authorize_url = "https://login.microsoftonline.com/"')
         convert = source.index("authorize_url_w = utf8_to_wide(authorize_url);", build)
         validate = source.index("if (authorize_url_w.empty()) return false;", convert)
-        navigate = source.index("url = SysAllocString(authorize_url_w.c_str());", validate)
+        allocate = source.index("url = SysAllocString(authorize_url_w.c_str());", validate)
+        navigate = source.index("hr = browser->Navigate(url,", allocate)
 
         self.assertLess(build, convert)
         self.assertLess(convert, validate)
-        self.assertLess(validate, navigate)
+        self.assertLess(validate, allocate)
+        self.assertLess(allocate, navigate)
 
 
 if __name__ == "__main__":

--- a/programs/wine4officeauth/wine4officeauth.cpp
+++ b/programs/wine4officeauth/wine4officeauth.cpp
@@ -1739,6 +1739,8 @@ static bool run_owned_oauth(HINSTANCE instance, HWND owner, const std::string &l
         url_encode(requested_redirect_uri) + "&scope=" + url_encode(requested_scope) +
         "&code_challenge=" + challenge + "&code_challenge_method=S256&state=" + oauth_state;
     if (!login_hint.empty()) authorize_url += "&login_hint=" + url_encode(login_hint);
+    authorize_url_w = utf8_to_wide(authorize_url);
+    if (authorize_url_w.empty()) return false;
 
     window_class.lpfnWndProc = window_proc;
     window_class.hInstance = instance;


### PR DESCRIPTION
## Summary

- convert the constructed OAuth authorization URL to UTF-16 before passing it to `IWebBrowser2::Navigate`
- fail cleanly if URL conversion unexpectedly produces an empty value
- add a focused source-contract regression to the release CI workflow
- document the Word sign-in repair in the changelog

## Cause

The authorization URL was assembled as UTF-8, but the wide string passed to the embedded browser was never populated. `Navigate` therefore received an empty BSTR and opened a blank Microsoft 365 sign-in window.

## Validation

- `python3 programs/wine4officeauth/tests/test_authorize_url.py`
- `make -j4 programs/wine4officeauth/i386-windows/wine4officeauth.exe`
- `git diff --check`
- installed the focused 32-bit helper build in the isolated `word-sso-root-20260820` environment
- confirmed the Microsoft sign-in page renders, federated school SSO opens, and the user completed Word sign-in successfully

## Risk

Low. The runtime change only converts and validates the already-constructed authorization URL before the existing browser navigation call. The regression is a source-contract test because the end-to-end browser path requires Microsoft Office and external identity-provider interaction.

## Summary by Sourcery

Ensure Word opens Microsoft 365 sign-in pages correctly and guard the OAuth navigation flow with release CI coverage.

Bug Fixes:
- Fix blank Microsoft 365 sign-in windows in Word by ensuring the OAuth authorization URL is converted and validated before browser navigation.

CI:
- Add an OAuth helper source-contract regression test to the release workflow.

Documentation:
- Document the Microsoft 365 Word sign-in fix in the changelog.

Tests:
- Add a focused regression test covering authorization URL conversion, validation, and navigation ordering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Microsoft 365 sign-in pages now open correctly in Word.
  * Sign-in navigation is prevented when the authorization URL cannot be converted properly.

* **Tests**
  * Added automated coverage to verify authorization URLs are prepared and opened correctly.

* **Documentation**
  * Added an Unreleased changelog entry describing the sign-in improvement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->