### PR TITLE
Manager: support exact tagged installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Show localized graceful-close and forced-kill progress while stopping the selected Wine environment.
 - Improve Wine runner and application-status translations.
 - Keep Word responsive while loading Office Click-to-Run component manifests and presenting startup frames.
+- Install exact tagged releases and safely close active Wine4Office sessions
+  before updating.
+- Let opted-in prerelease updates pass verification and installation.
 
 ## 0.2.0-beta.1 — 2026-08-19
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,17 @@ It installs `Wine4OfficeManager` in `~/.local/bin`, creates the application-menu
 shortcut, and asks whether to launch **Wine4Office Manager** immediately
 (default: Yes). The default Wine environment remains `~/.wine4office`.
 
+To install an exact published release instead of the latest stable release:
+
+```sh
+curl -fsSL https://github.com/ttv20/wine4office/releases/latest/download/install.sh | \
+  bash -s -- --tag wine4office-v0.1.10
+```
+
+The installer asks before closing an active Wine4Office Manager or Wine
+session. For unattended updates, pass `--force` to close those processes
+without prompting (and force-stop them only if graceful shutdown times out).
+
 ---
 
 ## Build It Yourself

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,8 @@
 set -euo pipefail
 umask 077
 
-METADATA_URL=${WINE4OFFICE_METADATA_URL:-https://github.com/ttv20/wine4office/releases/latest/download/release.json}
+DEFAULT_METADATA_URL=https://github.com/ttv20/wine4office/releases/latest/download/release.json
+METADATA_URL=${WINE4OFFICE_METADATA_URL:-$DEFAULT_METADATA_URL}
 DATA_HOME=${XDG_DATA_HOME:-$HOME/.local/share}
 BIN_HOME=${WINE4OFFICE_BIN_HOME:-$HOME/.local/bin}
 ROOT=${WINE4OFFICE_HOME:-$DATA_HOME/wine4office}
@@ -15,6 +16,52 @@ fail() {
 warn() {
     printf 'wine4office install warning: %s\n' "$*" >&2
 }
+usage() {
+    cat <<'EOF'
+Usage: install.sh [--tag TAG] [--force]
+
+Install the latest stable Wine4Office release, or install the exact GitHub
+release named by TAG (for example: wine4office-v0.1.10).
+
+If Wine4Office is running, the installer asks permission to close it. --force
+closes active Wine4Office processes without prompting and force-stops any that
+do not exit after the graceful shutdown period.
+EOF
+}
+
+FORCE=false
+TAGGED_RELEASE=false
+while (($#)); do
+    case $1 in
+        --tag)
+            (($# >= 2)) || fail "--tag requires an exact release tag"
+            TAG=$2
+            shift 2
+            ;;
+        --tag=*)
+            TAG=${1#--tag=}
+            shift
+            ;;
+        --force)
+            FORCE=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            fail "unknown argument: $1"
+            ;;
+    esac
+done
+if [[ -v TAG ]]; then
+    [[ $TAG =~ ^[A-Za-z0-9][A-Za-z0-9._+-]{0,127}$ ]] || \
+        fail "release tag contains unsupported characters"
+    METADATA_URL="https://github.com/ttv20/wine4office/releases/download/$TAG/release.json"
+    TAGGED_RELEASE=true
+fi
+
 prompt_and_launch_manager() {
     local manager=$1 answer
     if [[ -v WINE4OFFICE_LAUNCH_MANAGER ]]; then
@@ -45,7 +92,7 @@ prompt_and_launch_manager() {
     esac
 }
 
-for command in curl flock install python3 sha256sum stat zstd; do
+for command in curl flock install python3 readlink sha256sum stat zstd; do
     command -v "$command" >/dev/null 2>&1 || fail "$command is required"
 done
 [[ $(uname -m) == x86_64 ]] || fail "only x86_64 Linux is currently supported"
@@ -68,6 +115,68 @@ PY
 MANAGER_TARGET=$ROOT/bin/Wine4OfficeManager
 UNINSTALLER_TARGET=$ROOT/bin/wine4office-uninstall
 RUNNER_TARGET=$ROOT/runner
+
+is_active_install_pid() {
+    local pid=$1 owner executable
+    [[ $pid =~ ^[0-9]+$ && -d /proc/$pid ]] || return 1
+    owner=$(stat -c %u "/proc/$pid" 2>/dev/null) || return 1
+    [[ $owner == $EUID ]] || return 1
+    executable=$(readlink -f "/proc/$pid/exe" 2>/dev/null) || return 1
+    [[ $executable == "$ROOT"/* ]]
+}
+
+active_install_pids() {
+    local process pid
+    for process in /proc/[0-9]*; do
+        pid=${process##*/}
+        is_active_install_pid "$pid" && printf '%s\n' "$pid"
+    done
+}
+
+close_active_install_processes() {
+    local answer pid attempt
+    local -a active=()
+    mapfile -t active < <(active_install_pids)
+    ((${#active[@]})) || return 0
+    printf 'Wine4Office is currently running (processes: %s).\n' "${active[*]}" >&2
+    if ! $FORCE; then
+        if [[ -t 0 ]]; then
+            read -r -p 'Close Wine4Office and continue? [y/N] ' answer || answer=n
+        elif [[ -t 1 || -t 2 ]] && [[ -r /dev/tty ]]; then
+            read -r -p 'Close Wine4Office and continue? [y/N] ' answer \
+                </dev/tty || answer=n
+        else
+            fail "close Wine4Office first, or rerun with --force"
+        fi
+        case ${answer,,} in
+            y|yes) ;;
+            *) fail "update cancelled while Wine4Office is running" ;;
+        esac
+    fi
+
+    for pid in "${active[@]}"; do
+        is_active_install_pid "$pid" && kill -TERM "$pid" 2>/dev/null || true
+    done
+    for attempt in {1..50}; do
+        mapfile -t active < <(active_install_pids)
+        ((${#active[@]} == 0)) && return
+        sleep 0.1
+    done
+    if ! $FORCE; then
+        fail "Wine4Office did not close; rerun with --force to stop it"
+    fi
+    for pid in "${active[@]}"; do
+        is_active_install_pid "$pid" && kill -KILL "$pid" 2>/dev/null || true
+    done
+    for attempt in {1..20}; do
+        mapfile -t active < <(active_install_pids)
+        ((${#active[@]} == 0)) && return
+        sleep 0.1
+    done
+    fail "could not stop every active Wine4Office process"
+}
+
+close_active_install_processes
 
 TMP=$(mktemp -d)
 NEW_RUNNER=$ROOT/.runner.new.$$
@@ -160,20 +269,24 @@ fetch_limited() {
 
 printf 'Fetching release metadata…\n'
 fetch_limited "$METADATA_URL" "$TMP/release.json" 1048576
-mapfile -t RELEASE < <(python3 - "$METADATA_URL" "$TMP/release.json" <<'PY'
+mapfile -t RELEASE < <(python3 - "$METADATA_URL" "$TMP/release.json" \
+    "$TAGGED_RELEASE" <<'PY'
 import json
 import re
 import sys
 import urllib.parse
 
-source, path = sys.argv[1:]
+source, path, tagged_text = sys.argv[1:]
+tagged_release = tagged_text == "true"
 with open(path, "rb") as release_file:
     payload = json.load(release_file)
 if not isinstance(payload, dict) or payload.get("schema_version") != 1:
     raise SystemExit("release.json must use schema version 1")
 channel = payload.get("channel")
-if channel != "stable":
-    raise SystemExit("release.json must use the stable channel")
+allowed_channels = {"stable", "prerelease"} if tagged_release else {"stable"}
+if channel not in allowed_channels:
+    expected = "stable or prerelease" if tagged_release else "stable"
+    raise SystemExit(f"release.json must use the {expected} channel")
 
 def https_url(value, base, label):
     if not isinstance(value, str) or not value or any(ord(character) < 32 for character in value):

--- a/install.sh
+++ b/install.sh
@@ -120,7 +120,7 @@ is_active_install_pid() {
     local pid=$1 owner executable
     [[ $pid =~ ^[0-9]+$ && -d /proc/$pid ]] || return 1
     owner=$(stat -c %u "/proc/$pid" 2>/dev/null) || return 1
-    [[ $owner == $EUID ]] || return 1
+    [[ $owner == "$EUID" ]] || return 1
     executable=$(readlink -f "/proc/$pid/exe" 2>/dev/null) || return 1
     [[ $executable == "$ROOT"/* ]]
 }
@@ -134,7 +134,7 @@ active_install_pids() {
 }
 
 close_active_install_processes() {
-    local answer pid attempt
+    local answer pid
     local -a active=()
     mapfile -t active < <(active_install_pids)
     ((${#active[@]})) || return 0
@@ -157,7 +157,7 @@ close_active_install_processes() {
     for pid in "${active[@]}"; do
         is_active_install_pid "$pid" && kill -TERM "$pid" 2>/dev/null || true
     done
-    for attempt in {1..50}; do
+    for _ in {1..50}; do
         mapfile -t active < <(active_install_pids)
         ((${#active[@]} == 0)) && return
         sleep 0.1
@@ -168,15 +168,13 @@ close_active_install_processes() {
     for pid in "${active[@]}"; do
         is_active_install_pid "$pid" && kill -KILL "$pid" 2>/dev/null || true
     done
-    for attempt in {1..20}; do
+    for _ in {1..20}; do
         mapfile -t active < <(active_install_pids)
         ((${#active[@]} == 0)) && return
         sleep 0.1
     done
     fail "could not stop every active Wine4Office process"
 }
-
-close_active_install_processes
 
 TMP=$(mktemp -d)
 NEW_RUNNER=$ROOT/.runner.new.$$
@@ -596,6 +594,7 @@ chmod 0644 "$TMP/metadata"/*
 
 exec 9> "$ROOT/.wine4office-update.lock"
 flock 9
+close_active_install_processes
 trap '' INT TERM
 for path in "$RUNNER_BACKUP" "$MANAGER_BACKUP" "$UNINSTALLER_BACKUP"; do
     [[ ! -e $path && ! -L $path ]] || fail "stale installation backup exists: $path"
@@ -621,6 +620,8 @@ done
 COMMITTED=true
 trap 'exit 130' INT
 trap 'exit 143' TERM
+flock -u 9
+exec 9>&-
 
 ln -sfn "$MANAGER_TARGET" "$BIN_HOME/Wine4OfficeManager" || \
     warn "could not create $BIN_HOME/Wine4OfficeManager"

--- a/tools/wine4office-manager/tests/test_curl_install.sh
+++ b/tools/wine4office-manager/tests/test_curl_install.sh
@@ -41,8 +41,10 @@ write_metadata() {
     manager_digest=$1
     manager_version=${2:-0.1.0}
     wine_version=${3:-0.1.0}
+    release_channel=${4:-stable}
     RELEASE="$RELEASE" MANAGER_DIGEST="$manager_digest" \
-        MANAGER_VERSION="$manager_version" WINE_VERSION="$wine_version" python3 - <<'PY'
+        MANAGER_VERSION="$manager_version" WINE_VERSION="$wine_version" \
+        RELEASE_CHANNEL="$release_channel" python3 - <<'PY'
 import hashlib
 import json
 import os
@@ -52,7 +54,7 @@ manager = root / "Wine4OfficeManager"
 wine = root / "wine.tar.zst"
 payload = {
     "schema_version": 1,
-    "channel": "stable",
+    "channel": os.environ["RELEASE_CHANNEL"],
     "metadata_url": "https://example.invalid/release.json",
     "manager": {
         "version": os.environ["MANAGER_VERSION"],
@@ -86,6 +88,7 @@ while (($#)); do
     esac
 done
 [[ -n $url ]]
+printf '%s\n' "$url" >> "$FAKE_CURL_LOG"
 case $url in
     */release.json) source=$FAKE_RELEASE/release.json ;;
     */Wine4OfficeManager) source=$FAKE_RELEASE/Wine4OfficeManager ;;
@@ -100,10 +103,22 @@ export HOME=$HOME_DIR
 export XDG_DATA_HOME=$HOME_DIR/data
 export WINE4OFFICE_BIN_HOME=$HOME_DIR/bin
 export WINE4OFFICE_HOME=$HOME_DIR/data/wine4office
-export WINE4OFFICE_METADATA_URL=https://example.invalid/release.json
 export FAKE_RELEASE=$RELEASE
+export FAKE_CURL_LOG=$TMP/curl.log
 export WINE4OFFICE_TEST_MANAGER_LOG=$TMP/manager.log
-PATH="$FAKE_BIN:$PATH" "$HERE/install.sh" >/dev/null
+
+for invalid_args in "--tag" "--tag invalid/tag" "--unknown"; do
+    if PATH="$FAKE_BIN:$PATH" "$HERE/install.sh" $invalid_args >/dev/null 2>&1; then
+        echo "installer accepted invalid arguments: $invalid_args" >&2
+        exit 1
+    fi
+done
+[[ ! -e $FAKE_CURL_LOG ]]
+
+PATH="$FAKE_BIN:$PATH" "$HERE/install.sh" --tag wine4office-v0.1.10 >/dev/null
+[[ $(head -n 1 "$FAKE_CURL_LOG") == \
+   https://github.com/ttv20/wine4office/releases/download/wine4office-v0.1.10/release.json ]]
+export WINE4OFFICE_METADATA_URL=https://example.invalid/release.json
 
 [[ -x $WINE4OFFICE_HOME/bin/Wine4OfficeManager ]]
 [[ -x $WINE4OFFICE_HOME/bin/wine4office-uninstall ]]
@@ -120,6 +135,31 @@ fi
 [[ $(cat "$WINE4OFFICE_HOME/UPDATE_URL") == https://example.invalid/release.json ]]
 [[ $(cat "$WINE4OFFICE_HOME/UPDATE_CHANNEL") == stable ]]
 [[ $(cat "$WINE4OFFICE_HOME/STANDALONE") == Wine4OfficeManager ]]
+
+cp /bin/dash "$WINE4OFFICE_HOME/runner/bin/wine-active-test"
+"$WINE4OFFICE_HOME/runner/bin/wine-active-test" -c 'while :; do :; done' &
+ACTIVE_WINE=$!
+for _ in {1..50}; do
+    [[ $(readlink -f "/proc/$ACTIVE_WINE/exe" 2>/dev/null || true) == \
+       "$WINE4OFFICE_HOME/runner/bin/wine-active-test" ]] && break
+    sleep 0.02
+done
+if PATH="$FAKE_BIN:$PATH" "$HERE/install.sh" >/dev/null 2>"$TMP/active.err"; then
+    echo "installer updated while Wine4Office was active" >&2
+    exit 1
+fi
+grep -q -- 'rerun with --force' "$TMP/active.err"
+kill -0 "$ACTIVE_WINE"
+PATH="$FAKE_BIN:$PATH" "$HERE/install.sh" --force >/dev/null
+if kill -0 "$ACTIVE_WINE" 2>/dev/null; then
+    echo "installer --force left Wine4Office running" >&2
+    exit 1
+fi
+write_metadata "$MANAGER_DIGEST" 0.2.0-beta.1 0.2.0-beta.1 prerelease
+PATH="$FAKE_BIN:$PATH" "$HERE/install.sh" --tag 0.2.0-beta.1 >/dev/null
+[[ $(cat "$WINE4OFFICE_HOME/VERSION") == 0.2.0-beta.1 ]]
+[[ $(cat "$WINE4OFFICE_HOME/UPDATE_CHANNEL") == stable ]]
+write_metadata "$MANAGER_DIGEST"
 if [[ -z $REAL_MANAGER ]]; then
     [[ $(grep -c '^<launch>$' "$WINE4OFFICE_TEST_MANAGER_LOG" || true) == 0 ]]
 

--- a/tools/wine4office-manager/tests/test_curl_install.sh
+++ b/tools/wine4office-manager/tests/test_curl_install.sh
@@ -144,6 +144,13 @@ for _ in {1..50}; do
        "$WINE4OFFICE_HOME/runner/bin/wine-active-test" ]] && break
     sleep 0.02
 done
+write_metadata "$(printf '0%.0s' {1..64})"
+if PATH="$FAKE_BIN:$PATH" "$HERE/install.sh" --force >/dev/null 2>&1; then
+    echo "installer accepted invalid staging metadata" >&2
+    exit 1
+fi
+kill -0 "$ACTIVE_WINE"
+write_metadata "$MANAGER_DIGEST"
 if PATH="$FAKE_BIN:$PATH" "$HERE/install.sh" >/dev/null 2>"$TMP/active.err"; then
     echo "installer updated while Wine4Office was active" >&2
     exit 1

--- a/tools/wine4office-manager/tests/test_updater.py
+++ b/tools/wine4office-manager/tests/test_updater.py
@@ -157,8 +157,11 @@ class UpdaterTests(unittest.TestCase):
         )
 
     def test_prerelease_check_uses_discovered_metadata(self):
+        payload = self.metadata()
+        payload["channel"] = "prerelease"
         parsed = backend.parse_release_metadata(
-            self.metadata(), "https://updates.example/release.json"
+            payload, "https://updates.example/release.json",
+            expected_channel="prerelease",
         )
         source = "https://github.com/owner/repo/releases/download/v2/release.json"
         with mock.patch.object(
@@ -174,7 +177,27 @@ class UpdaterTests(unittest.TestCase):
             )
 
         discover.assert_called_once()
-        fetch.assert_called_once_with(source, None, None)
+        fetch.assert_called_once_with(source, None, ("stable", "prerelease"))
+
+    def test_prerelease_channel_requires_explicit_opt_in(self):
+        payload = self.metadata()
+        payload["channel"] = "prerelease"
+        with self.assertRaisesRegex(ValueError, "does not match expected channel"):
+            backend.parse_release_metadata(
+                payload, "https://updates.example/release.json"
+            )
+        parsed = backend.parse_release_metadata(
+            payload, "https://updates.example/release.json",
+            expected_channel=("stable", "prerelease"),
+        )
+        with mock.patch.object(backend, "current_version", return_value="1.0.0"), \
+             mock.patch.object(backend, "current_wine_version", return_value="11.1.0"):
+            self.assertEqual(
+                set(backend.available_updates(
+                    parsed, expected_channel=("stable", "prerelease")
+                )),
+                {"manager", "wine"},
+            )
 
     def test_prerelease_check_rejects_custom_metadata_provider(self):
         with self.assertRaisesRegex(ValueError, "standard GitHub"):
@@ -277,7 +300,10 @@ class UpdaterTests(unittest.TestCase):
             install.assert_not_called()
             state.start_offered_update(["manager"])
             self._wait_for(lambda: not state.snapshot()["task"]["running"])
-            install.assert_called_once()
+            self.assertEqual(
+                install.call_args.kwargs["expected_channel"],
+                ("stable", "prerelease"),
+            )
             post_install.assert_called_once()
             post_config = post_install.call_args.args[0]
             self.assertEqual(post_config["prefix"], config["prefix"])

--- a/tools/wine4office-manager/wine4office_backend.py
+++ b/tools/wine4office-manager/wine4office_backend.py
@@ -2345,31 +2345,48 @@ def _parse_component(payload: object, name: str, metadata_url: str) -> dict:
     return result
 
 
-def _expected_update_channel(expected_channel: str | None) -> str:
-    expected_channel = configured_update_channel() \
+def accepted_update_channels(
+        expected_channel: str | Iterable[str] | None = None,
+        include_prereleases: bool = False) -> tuple[str, ...]:
+    """Return the validated channels allowed by the current update consent."""
+    configured = configured_update_channel() \
         if expected_channel is None else expected_channel
-    if (not isinstance(expected_channel, str)
-            or not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,63}", expected_channel)):
+    if isinstance(configured, str):
+        values = [configured]
+    else:
+        try:
+            values = list(configured)
+        except TypeError:
+            values = [configured]
+    if include_prereleases:
+        values.append("prerelease")
+    channels = tuple(dict.fromkeys(values))
+    if not channels or any(
+        not isinstance(channel, str)
+        or not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,63}", channel)
+        for channel in channels
+    ):
         raise ValueError("Expected update channel is invalid.")
-    return expected_channel
+    return channels
 
 
-def _validate_update_channel(metadata: dict, expected_channel: str | None) -> str:
-    expected_channel = _expected_update_channel(expected_channel)
+def _validate_update_channel(
+        metadata: dict, expected_channel: str | Iterable[str] | None) -> str:
+    expected_channels = accepted_update_channels(expected_channel)
     channel = metadata.get("channel")
     if not isinstance(channel, str) or not re.fullmatch(
             r"[A-Za-z0-9][A-Za-z0-9._-]{0,63}", channel):
         raise ValueError("Release metadata has an invalid channel.")
-    if channel != expected_channel:
+    if channel not in expected_channels:
         raise ValueError(
             f"Release metadata channel {channel!r} does not match expected "
-            f"channel {expected_channel!r}."
+            f"channel {expected_channels[0]!r}."
         )
     return channel
 
 
 def parse_release_metadata(payload: bytes | str | dict, source_url: str,
-                           expected_channel: str | None = None) -> dict:
+                           expected_channel: str | Iterable[str] | None = None) -> dict:
     """Validate and normalize provider-neutral schema-v1 release metadata."""
     source_url = _https_url(source_url, "Metadata address")
     if isinstance(payload, (bytes, str)):
@@ -2406,7 +2423,7 @@ def _https_context() -> ssl.SSLContext:
 
 
 def fetch_release_metadata(metadata_url: str, output: Output | None = None,
-                           expected_channel: str | None = None) -> dict:
+                           expected_channel: str | Iterable[str] | None = None) -> dict:
     metadata_url = _https_url(metadata_url, "Metadata address")
     if output:
         output(f"Checking {metadata_url}")
@@ -2518,7 +2535,7 @@ def compare_versions(left: str, right: str) -> int:
 
 
 def available_updates(metadata: dict, skipped: dict | None = None,
-                      expected_channel: str | None = None) -> dict:
+                      expected_channel: str | Iterable[str] | None = None) -> dict:
     _validate_update_channel(metadata, expected_channel)
     skipped = skipped if isinstance(skipped, dict) else {}
     installed = {"manager": current_version(), "wine": current_wine_version()}
@@ -2540,16 +2557,19 @@ def available_updates(metadata: dict, skipped: dict | None = None,
 
 def check_for_updates(metadata_url: str, skipped: dict | None = None,
                       output: Output | None = None,
-                      expected_channel: str | None = None,
+                      expected_channel: str | Iterable[str] | None = None,
                       include_prereleases: bool = False) -> dict:
     source_url = (
         _github_latest_release_metadata_url(metadata_url)
         if include_prereleases else metadata_url
     )
-    metadata = fetch_release_metadata(source_url, output, expected_channel)
+    expected_channels = accepted_update_channels(
+        expected_channel, include_prereleases
+    )
+    metadata = fetch_release_metadata(source_url, output, expected_channels)
     return {
         "metadata": metadata,
-        "updates": available_updates(metadata, skipped, expected_channel),
+        "updates": available_updates(metadata, skipped, expected_channels),
     }
 
 
@@ -3806,7 +3826,7 @@ def _commit_update_transaction(
 
 def install_release_updates(metadata: dict, components: Iterable[str], output: Output,
                             cancel_event=None,
-                            expected_channel: str | None = None,
+                            expected_channel: str | Iterable[str] | None = None,
                             progress: Callable[[str, int | None], None] | None = None) -> str:
     """Stage every selected payload, then commit all components transactionally."""
     selected = list(dict.fromkeys(components))
@@ -3814,7 +3834,7 @@ def install_release_updates(metadata: dict, components: Iterable[str], output: O
         raise ValueError("Select at least one valid update component.")
     if not isinstance(metadata, dict):
         raise ValueError("Release metadata must be a JSON object.")
-    expected_channel = _expected_update_channel(expected_channel)
+    expected_channel = accepted_update_channels(expected_channel)
     metadata = parse_release_metadata(
         metadata, metadata.get("metadata_url", ""), expected_channel
     )

--- a/tools/wine4office-manager/wine4office_backend.py
+++ b/tools/wine4office-manager/wine4office_backend.py
@@ -3766,6 +3766,19 @@ def _install_update_lock(root: Path | None, manager_target: Path | None,
             lock.close()
 
 
+def wait_for_install_update() -> None:
+    """Wait at Manager startup until an installer commit barrier is released."""
+    root = installed_root()
+    if root is None and getattr(sys, "frozen", False):
+        executable = Path(sys.executable).expanduser().resolve()
+        if executable.name == "Wine4OfficeManager" and executable.parent.name == "bin":
+            root = executable.parent.parent
+    if root is None:
+        return
+    with _install_update_lock(root, manager_update_target(), root / "runner"):
+        pass
+
+
 def _commit_update_transaction(
         replacements: list[tuple[Path, Path]],
         text_updates: dict[Path, str],

--- a/tools/wine4office-manager/wine4office_manager.py
+++ b/tools/wine4office-manager/wine4office_manager.py
@@ -1178,6 +1178,8 @@ def main() -> int:
                         help=argparse.SUPPRESS)
     parser.add_argument("documents", nargs="*", help=argparse.SUPPRESS)
     args = parser.parse_args()
+    if FROZEN:
+        backend.wait_for_install_update()
     if args.review_incident and (
             args.target or args.documents or args.preload_service or args.preload_worker
             or args.install_shortcut or args.prepare_uninstall or args.remove_prefix

--- a/tools/wine4office-manager/wine4office_manager.py
+++ b/tools/wine4office-manager/wine4office_manager.py
@@ -677,6 +677,11 @@ class ManagerState:
                     self.output("Stopped the selected Wine environment before updating.")
                 result = backend.install_release_updates(
                     metadata, selected, self.output, self.cancel_event,
+                    expected_channel=backend.accepted_update_channels(
+                        include_prereleases=(
+                            config.get("include_prereleases") is True
+                        )
+                    ),
                     progress=self.set_progress,
                 )
                 if "wine" in selected:


### PR DESCRIPTION
## Purpose

- allow `install.sh` to install an exact GitHub release tag, including an explicitly selected prerelease
- stop active Wine4Office processes safely before replacing the Manager or runner, with an interactive prompt and `--force` for unattended updates
- carry prerelease opt-in through metadata validation and transactional installation

## Validation

- `python3 -m unittest discover -s tools/wine4office-manager/tests` (347 passed, 68 skipped)
- `bash tools/wine4office-manager/tests/test_curl_install.sh`
- physical laptop: installed `wine4office-v0.1.10`, preserved the Office prefix, then updated active Manager/runner to exact tag `0.2.0-beta.1 --force`
- launched Microsoft Word successfully with the `0.2.0-beta.1` runner

## Risks

- `--force` may send SIGKILL only to current-user processes whose executable is inside the selected Wine4Office installation root and which remain after a five-second SIGTERM grace period
- exact prerelease installs remain on the stable future-update channel; prerelease discovery remains an explicit Manager preference

## Evidence

Word was visually verified open and usable on the laptop after the beta update; local evidence is preserved in the task worktree artifacts.

## Summary by Sourcery

Enable exact tagged and opted-in prerelease installations while making Manager and runner updates safer when Wine4Office is active.

New Features:
- Support installing an exact GitHub release tag, including explicitly selected prereleases.
- Safely close active Wine4Office processes before installation, with interactive confirmation and a force option for unattended updates.

Enhancements:
- Propagate prerelease opt-in through metadata validation, update discovery, and transactional installation.
- Wait for installer commit completion when launching an updated Manager.

Documentation:
- Document exact-tag installation and forced process shutdown options.

Tests:
- Add installer coverage for tag selection, active-process handling, invalid metadata, and prerelease installation.
- Extend Manager updater tests for prerelease channel validation and propagation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Install specific Wine4Office releases using a release tag.
  * Opt in to prerelease updates during tagged installations.
  * Use `--force` for unattended updates and to close active Wine4Office sessions after graceful shutdown times out.
  * Update checks now consistently respect stable and prerelease channel selections.

* **Bug Fixes**
  * Improved validation for installer arguments and release metadata.
  * Prevented updates from proceeding while Wine4Office is active unless explicitly forced.

* **Documentation**
  * Added Quick Start and changelog guidance for tagged releases, prereleases, active sessions, and forced updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->