### PR TITLE
wined3d: remove duplicate frame-latency wait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Keep Word responsive and fully render its welcome screen after updating to WineHQ 11.16.
+
 ## 0.2.1-beta.1 — 2026-08-23
 
 - Update the Wine base to WineHQ 11.16.

--- a/dlls/wined3d/swapchain.c
+++ b/dlls/wined3d/swapchain.c
@@ -243,14 +243,6 @@ HRESULT CDECL wined3d_swapchain_present(struct wined3d_swapchain *swapchain,
     if (flags)
         FIXME("Ignoring flags %#x.\n", flags);
 
-    if (!(swapchain->state.desc.flags & WINED3D_SWAPCHAIN_FRAME_LATENCY_WAITABLE_OBJECT))
-    {
-        /* Limit input latency by limiting the number of presents that we can
-         * get ahead of the worker thread. Avoid holding the D3D mutex across
-         * to not block other threads. */
-        WaitForSingleObject(swapchain->frame_latency_semaphore, INFINITE);
-    }
-
     wined3d_mutex_lock();
 
     if (!swapchain->back_buffers)


### PR DESCRIPTION
## Purpose

Fix the Word startup regression introduced while integrating WineHQ 11.16. The merge retained two waits on the same frame-latency semaphore in `wined3d_swapchain_present()`, while the present worker releases only one token per frame. The duplicate wait drains the semaphore and blocks Word's rendering path.

This PR removes the earlier duplicate wait and keeps the existing wait after back-buffer validation, outside the WineD3D mutex.

## Validation

- Rebuilt `dlls/wined3d/x86_64-windows/wined3d.dll` from the PR worktree.
- Loaded the rebuilt DLL from an isolated runner on `elkana-scadasudo`.
- Verified from `/proc/<WINWORD.EXE>/maps` that Word loaded the isolated patched DLL.
- Word rendered the complete welcome screen and responded to keyboard navigation.
- Opened a blank document and successfully entered `Wine4Office proof`.
- `git diff --check` passes.

## Risk

Low. The change removes only the accidental duplicate semaphore wait. The remaining wait retains the intended frame-latency limit and releases the WineD3D mutex while blocking.

## Summary by Sourcery

Bug Fixes:
- Restore Word responsiveness and complete welcome-screen rendering by removing an accidental duplicate frame-latency wait.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Microsoft Word responsiveness.
  * Fixed an issue where the welcome screen could fail to render completely.
  * Improved display presentation reliability during frame-latency waits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->