### PR TITLE
user32: implement CalculatePopupWindowPosition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Prevent Word from crashing when opening Microsoft 365 sign-in.
 - Keep Word responsive and fully render its welcome screen after updating to WineHQ 11.16.
 
 ## 0.2.1-beta.1 — 2026-08-23

--- a/dlls/user32/tests/menu.c
+++ b/dlls/user32/tests/menu.c
@@ -4230,6 +4230,75 @@ if (0) /* FIXME: uncomment once Wine is fixed */ {
     DeleteObject(hbmp);
 }
 
+static void test_CalculatePopupWindowPosition(void)
+{
+    BOOL (WINAPI *calculate_popup_position)(const POINT *, const SIZE *, UINT, RECT *, RECT *);
+    MONITORINFO info = {sizeof(info)};
+    POINT anchor;
+    SIZE size;
+    RECT position, exclude, intersection;
+    HMONITOR monitor;
+    BOOL ret;
+
+    calculate_popup_position = (void *)GetProcAddress( GetModuleHandleA("user32.dll"),
+                                                       "CalculatePopupWindowPosition" );
+    if (!calculate_popup_position)
+    {
+        win_skip("CalculatePopupWindowPosition is not available\n");
+        return;
+    }
+
+    monitor = MonitorFromPoint( (POINT){0, 0}, MONITOR_DEFAULTTOPRIMARY );
+    ok( !!monitor, "MonitorFromPoint failed, error %lu\n", GetLastError() );
+    ret = GetMonitorInfoW( monitor, &info );
+    ok( ret, "GetMonitorInfoW failed, error %lu\n", GetLastError() );
+    if (!ret) return;
+
+    anchor.x = (info.rcWork.left + info.rcWork.right) / 2;
+    anchor.y = (info.rcWork.top + info.rcWork.bottom) / 2;
+    size.cx = min( 100, (info.rcWork.right - info.rcWork.left) / 4 );
+    size.cy = min( 80, (info.rcWork.bottom - info.rcWork.top) / 4 );
+
+    ret = calculate_popup_position( &anchor, &size, TPM_LEFTALIGN | TPM_TOPALIGN,
+                                    NULL, &position );
+    ok( ret, "CalculatePopupWindowPosition failed, error %lu\n", GetLastError() );
+    ok( position.left == anchor.x && position.top == anchor.y &&
+        position.right == anchor.x + size.cx && position.bottom == anchor.y + size.cy,
+        "unexpected left/top aligned position %s\n", wine_dbgstr_rect( &position ) );
+
+    ret = calculate_popup_position( &anchor, &size, TPM_RIGHTALIGN | TPM_BOTTOMALIGN,
+                                    NULL, &position );
+    ok( ret, "CalculatePopupWindowPosition failed, error %lu\n", GetLastError() );
+    ok( position.left == anchor.x - size.cx && position.top == anchor.y - size.cy &&
+        position.right == anchor.x && position.bottom == anchor.y,
+        "unexpected right/bottom aligned position %s\n", wine_dbgstr_rect( &position ) );
+
+    ret = calculate_popup_position( &anchor, &size, TPM_CENTERALIGN | TPM_VCENTERALIGN,
+                                    NULL, &position );
+    ok( ret, "CalculatePopupWindowPosition failed, error %lu\n", GetLastError() );
+    ok( position.left == anchor.x - size.cx / 2 && position.top == anchor.y - size.cy / 2 &&
+        position.right == position.left + size.cx && position.bottom == position.top + size.cy,
+        "unexpected centered position %s\n", wine_dbgstr_rect( &position ) );
+
+    anchor.x = info.rcWork.right - 1;
+    anchor.y = info.rcWork.bottom - 1;
+    ret = calculate_popup_position( &anchor, &size, TPM_WORKAREA, NULL, &position );
+    ok( ret, "CalculatePopupWindowPosition failed, error %lu\n", GetLastError() );
+    ok( position.right == info.rcWork.right && position.bottom == info.rcWork.bottom,
+        "popup was not clamped to work area, got %s work area %s\n",
+        wine_dbgstr_rect( &position ), wine_dbgstr_rect( &info.rcWork ) );
+
+    anchor.x = (info.rcWork.left + info.rcWork.right) / 2;
+    anchor.y = (info.rcWork.top + info.rcWork.bottom) / 2;
+    SetRect( &exclude, anchor.x - 10, anchor.y - 10, anchor.x + 10, anchor.y + 10 );
+    ret = calculate_popup_position( &anchor, &size, TPM_HORIZONTAL | TPM_WORKAREA,
+                                    &exclude, &position );
+    ok( ret, "CalculatePopupWindowPosition failed, error %lu\n", GetLastError() );
+    ok( !IntersectRect( &intersection, &exclude, &position ),
+        "popup %s overlaps exclude rect %s\n",
+        wine_dbgstr_rect( &position ), wine_dbgstr_rect( &exclude ) );
+}
+
 START_TEST(menu)
 {
     register_menu_check_class();
@@ -4262,4 +4331,5 @@ START_TEST(menu)
     test_menu_circref();
     test_emptypopup();
     test_AppendMenu();
+    test_CalculatePopupWindowPosition();
 }

--- a/dlls/user32/user32.spec
+++ b/dlls/user32/user32.spec
@@ -244,7 +244,7 @@
 # @ stub BuildReasonArray
 @ stdcall CalcChildScroll(long long)
 @ stdcall CalcMenuBar(long long long long ptr) CalcMenuBar
-# @ stub CalculatePopupWindowPosition
+@ stdcall CalculatePopupWindowPosition(ptr ptr long ptr ptr) NtUserCalculatePopupWindowPosition
 @ stdcall CallMsgFilter(ptr long) NtUserCallMsgFilter
 @ stdcall CallMsgFilterA(ptr long) NtUserCallMsgFilter
 @ stdcall CallMsgFilterW(ptr long) NtUserCallMsgFilter

--- a/dlls/win32u/menu.c
+++ b/dlls/win32u/menu.c
@@ -3133,6 +3133,123 @@ static BOOL show_popup( HWND owner, HMENU hmenu, UINT id, UINT flags,
     return TRUE;
 }
 
+static BOOL popup_position_overlaps( const RECT *exclude, int x, int y, int width, int height )
+{
+    return exclude && x + width > exclude->left && x < exclude->right &&
+           y + height > exclude->top && y < exclude->bottom;
+}
+
+static BOOL popup_position_fits( const RECT *bounds, const RECT *exclude,
+                                 int x, int y, int width, int height )
+{
+    if (x < bounds->left || y < bounds->top ||
+        x + width > bounds->right || y + height > bounds->bottom)
+        return FALSE;
+
+    return !popup_position_overlaps( exclude, x, y, width, height );
+}
+
+static BOOL try_popup_position( const RECT *bounds, const RECT *exclude, RECT *position,
+                                int x, int y, int width, int height )
+{
+    if (!popup_position_fits( bounds, exclude, x, y, width, height )) return FALSE;
+    SetRect( position, x, y, x + width, y + height );
+    return TRUE;
+}
+
+static BOOL try_popup_horizontal( const RECT *bounds, const RECT *exclude, RECT *position,
+                                  int y, int width, int height, UINT flags )
+{
+    int left = exclude->left - width, right = exclude->right;
+
+    if (flags & TPM_RIGHTALIGN)
+    {
+        if (try_popup_position( bounds, exclude, position, left, y, width, height )) return TRUE;
+        return try_popup_position( bounds, exclude, position, right, y, width, height );
+    }
+
+    if (try_popup_position( bounds, exclude, position, right, y, width, height )) return TRUE;
+    return try_popup_position( bounds, exclude, position, left, y, width, height );
+}
+
+static BOOL try_popup_vertical( const RECT *bounds, const RECT *exclude, RECT *position,
+                                int x, int width, int height, UINT flags )
+{
+    int top = exclude->top - height, bottom = exclude->bottom;
+
+    if (flags & TPM_BOTTOMALIGN)
+    {
+        if (try_popup_position( bounds, exclude, position, x, top, width, height )) return TRUE;
+        return try_popup_position( bounds, exclude, position, x, bottom, width, height );
+    }
+
+    if (try_popup_position( bounds, exclude, position, x, bottom, width, height )) return TRUE;
+    return try_popup_position( bounds, exclude, position, x, top, width, height );
+}
+
+/**********************************************************************
+ *           NtUserCalculatePopupWindowPosition   (win32u.@)
+ */
+BOOL WINAPI NtUserCalculatePopupWindowPosition( const POINT *anchor, const SIZE *size,
+                                                UINT flags, RECT *exclude, RECT *position )
+{
+    MONITORINFO info;
+    RECT anchor_rect, bounds, normalized_exclude;
+    int x, y;
+
+    if (!anchor || !size || !position)
+    {
+        RtlSetLastWin32Error( ERROR_INVALID_PARAMETER );
+        return FALSE;
+    }
+
+    SetRect( &anchor_rect, anchor->x, anchor->y, anchor->x, anchor->y );
+    info = monitor_info_from_rect( anchor_rect, get_thread_dpi() );
+    bounds = ((flags & TPM_WORKAREA) || PtInRect( &info.rcWork, *anchor ))
+             ? info.rcWork : info.rcMonitor;
+
+    if (flags & TPM_LAYOUTRTL) flags ^= TPM_RIGHTALIGN;
+    x = anchor->x;
+    y = anchor->y;
+    if (flags & TPM_RIGHTALIGN) x -= size->cx;
+    else if (flags & TPM_CENTERALIGN) x -= size->cx / 2;
+    if (flags & TPM_BOTTOMALIGN) y -= size->cy;
+    else if (flags & TPM_VCENTERALIGN) y -= size->cy / 2;
+
+    if (exclude)
+    {
+        normalized_exclude.left = min( exclude->left, exclude->right );
+        normalized_exclude.top = min( exclude->top, exclude->bottom );
+        normalized_exclude.right = max( exclude->left, exclude->right );
+        normalized_exclude.bottom = max( exclude->top, exclude->bottom );
+
+        if (popup_position_overlaps( &normalized_exclude, x, y, size->cx, size->cy ))
+        {
+            if (flags & TPM_VERTICAL)
+            {
+                if (try_popup_vertical( &bounds, &normalized_exclude, position,
+                                        x, size->cx, size->cy, flags ) ||
+                    try_popup_horizontal( &bounds, &normalized_exclude, position,
+                                          y, size->cx, size->cy, flags ))
+                    return TRUE;
+            }
+            else if (try_popup_horizontal( &bounds, &normalized_exclude, position,
+                                           y, size->cx, size->cy, flags ) ||
+                     try_popup_vertical( &bounds, &normalized_exclude, position,
+                                         x, size->cx, size->cy, flags ))
+                return TRUE;
+        }
+    }
+
+    if (x + size->cx > bounds.right) x = bounds.right - size->cx;
+    if (x < bounds.left) x = bounds.left;
+    if (y + size->cy > bounds.bottom) y = bounds.bottom - size->cy;
+    if (y < bounds.top) y = bounds.top;
+
+    SetRect( position, x, y, x + size->cx, y + size->cy );
+    return TRUE;
+}
+
 static void ensure_menu_item_visible( struct menu *menu, UINT index, HDC hdc )
 {
     if (menu->bScrolling)

--- a/dlls/win32u/win32syscalls.h
+++ b/dlls/win32u/win32syscalls.h
@@ -818,7 +818,7 @@
     SYSCALL_ENTRY( 0x132e, NtUserBuildNameList, 16 ) \
     SYSCALL_ENTRY( 0x132f, NtUserBuildPropList, 16 ) \
     SYSCALL_ENTRY( 0x1330, NtUserCalcMenuBar, 0 ) \
-    SYSCALL_ENTRY( 0x1331, NtUserCalculatePopupWindowPosition, 0 ) \
+    SYSCALL_ENTRY( 0x1331, NtUserCalculatePopupWindowPosition, 20 ) \
     SYSCALL_ENTRY( 0x1332, NtUserCallHwnd, 8 ) \
     SYSCALL_ENTRY( 0x1333, NtUserCallHwndLock, 0 ) \
     SYSCALL_ENTRY( 0x1334, NtUserCallHwndLockSafe, 0 ) \
@@ -2360,7 +2360,7 @@
     SYSCALL_ENTRY( 0x132e, NtUserBuildNameList, 32 ) \
     SYSCALL_ENTRY( 0x132f, NtUserBuildPropList, 32 ) \
     SYSCALL_ENTRY( 0x1330, NtUserCalcMenuBar, 0 ) \
-    SYSCALL_ENTRY( 0x1331, NtUserCalculatePopupWindowPosition, 0 ) \
+    SYSCALL_ENTRY( 0x1331, NtUserCalculatePopupWindowPosition, 40 ) \
     SYSCALL_ENTRY( 0x1332, NtUserCallHwnd, 16 ) \
     SYSCALL_ENTRY( 0x1333, NtUserCallHwndLock, 0 ) \
     SYSCALL_ENTRY( 0x1334, NtUserCallHwndLockSafe, 0 ) \
@@ -3682,7 +3682,6 @@
     SYSCALL_STUB( NtUserBroadcastImeShowStatusChange ) \
     SYSCALL_STUB( NtUserBroadcastThemeChangeEvent ) \
     SYSCALL_STUB( NtUserCalcMenuBar ) \
-    SYSCALL_STUB( NtUserCalculatePopupWindowPosition ) \
     SYSCALL_STUB( NtUserCallHwndLock ) \
     SYSCALL_STUB( NtUserCallHwndLockSafe ) \
     SYSCALL_STUB( NtUserCallHwndOpt ) \

--- a/dlls/win32u/win32u.spec
+++ b/dlls/win32u/win32u.spec
@@ -816,7 +816,7 @@
 @ stdcall -syscall NtUserBuildNameList(long long ptr ptr)
 @ stdcall -syscall NtUserBuildPropList(long long ptr ptr)
 @ stub -syscall NtUserCalcMenuBar
-@ stub -syscall NtUserCalculatePopupWindowPosition
+@ stdcall -syscall NtUserCalculatePopupWindowPosition(ptr ptr long ptr ptr)
 @ stdcall -syscall NtUserCallHwnd(long long)
 @ stub -syscall NtUserCallHwndLock
 @ stub -syscall NtUserCallHwndLockSafe

--- a/dlls/wow64win/user.c
+++ b/dlls/wow64win/user.c
@@ -1661,6 +1661,17 @@ NTSTATUS WINAPI wow64_NtUserBuildPropList( UINT *args )
     return NtUserBuildPropList( hwnd, count, props, ret_count );
 }
 
+NTSTATUS WINAPI wow64_NtUserCalculatePopupWindowPosition( UINT *args )
+{
+    const POINT *anchor = get_ptr( &args );
+    const SIZE *size = get_ptr( &args );
+    UINT flags = get_ulong( &args );
+    RECT *exclude = get_ptr( &args );
+    RECT *position = get_ptr( &args );
+
+    return NtUserCalculatePopupWindowPosition( anchor, size, flags, exclude, position );
+}
+
 NTSTATUS WINAPI wow64_NtUserCallHwnd( UINT *args )
 {
     HWND hwnd = get_handle( &args );

--- a/include/ntuser.h
+++ b/include/ntuser.h
@@ -758,6 +758,8 @@ W32KAPI NTSTATUS WINAPI NtUserBuildHwndList( HDESK desktop, HWND hwnd, BOOL chil
                                              ULONG thread_id, ULONG count, HWND *buffer, ULONG *size );
 W32KAPI NTSTATUS WINAPI NtUserBuildNameList( HWINSTA winsta, ULONG size, struct ntuser_name_list *buffer, ULONG *ret_size );
 W32KAPI NTSTATUS WINAPI NtUserBuildPropList( HWND hwnd, ULONG count, struct ntuser_property_list *buffer, ULONG *ret_count );
+W32KAPI BOOL    WINAPI NtUserCalculatePopupWindowPosition( const POINT *anchor, const SIZE *size,
+                                                           UINT flags, RECT *exclude, RECT *position );
 W32KAPI ULONG_PTR WINAPI NtUserCallHwnd( HWND hwnd, DWORD code );
 W32KAPI ULONG_PTR WINAPI NtUserCallHwndParam( HWND hwnd, DWORD_PTR param, DWORD code );
 W32KAPI LRESULT WINAPI NtUserCallNextHookEx( HHOOK hhook, INT code, WPARAM wparam, LPARAM lparam );

--- a/include/winuser.h
+++ b/include/winuser.h
@@ -1652,6 +1652,7 @@ typedef struct tagACCEL
 #define TPM_VERNEGANIMATION 0x2000
 #define TPM_NOANIMATION     0x4000
 #define TPM_LAYOUTRTL       0x8000
+#define TPM_WORKAREA       0x10000
 
 typedef struct tagTPMPARAMS
 {
@@ -3915,6 +3916,7 @@ WINUSERAPI LONG        WINAPI BroadcastSystemMessageExA(DWORD,LPDWORD,UINT,WPARA
 WINUSERAPI LONG        WINAPI BroadcastSystemMessageExW(DWORD,LPDWORD,UINT,WPARAM,LPARAM,PBSMINFO);
 #define                       BroadcastSystemMessageEx WINELIB_NAME_AW(BroadcastSystemMessageEx)
 WINUSERAPI void        WINAPI CalcChildScroll(HWND, INT);
+WINUSERAPI BOOL        WINAPI CalculatePopupWindowPosition(const POINT*,const SIZE*,UINT,RECT*,RECT*);
 WINUSERAPI BOOL        WINAPI CallMsgFilterA(LPMSG,INT);
 WINUSERAPI BOOL        WINAPI CallMsgFilterW(LPMSG,INT);
 #define                       CallMsgFilter WINELIB_NAME_AW(CallMsgFilter)


### PR DESCRIPTION
## Summary

- implement `CalculatePopupWindowPosition` in win32u and export it from USER32
- wire the native syscall, generated syscall metadata, and WoW64 thunk
- add the public declaration, `TPM_WORKAREA`, and focused USER32 tests

## Cause

Word delay-loads `USER32!CalculatePopupWindowPosition` when opening Microsoft 365 sign-in. Wine exposed no implementation, so the delay-load helper raised `0xc06d007f` with `ERROR_PROC_NOT_FOUND`.

## Validation

- built the affected x86-64 win32u, USER32, WoW64, and USER32 test targets
- built the affected i386 win32u, USER32, and USER32 test targets
- focused public-API smoke tests pass in x86-64 and i386
- Word remains alive after opening Sign In on the Intel laptop; the final trace contains no unhandled exception, `0xc06d007f`, or missing `CalculatePopupWindowPosition`
- `git diff --check` passes

The complete `user32:menu` binary currently aborts before reaching the added test at the pre-existing assertion in `menu.c:2708`; this is unrelated to the new API test.

## Summary by Sourcery

Implement and expose CalculatePopupWindowPosition to support applications that rely on the USER32 popup-placement API.

New Features:
- Expose and implement the USER32 CalculatePopupWindowPosition API with monitor, work-area, alignment, and exclusion-rectangle handling.
- Add the TPM_WORKAREA flag and WoW64 syscall support for the new API.

Bug Fixes:
- Prevent Word from crashing when opening Microsoft 365 sign-in due to the missing USER32 API.

Tests:
- Add focused USER32 coverage for popup alignment, work-area clamping, and exclusion handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for calculating popup-menu positions, including alignment, right-to-left layouts, work-area boundaries, and exclusion rectangles.
  - Added the public `CalculatePopupWindowPosition` API and `TPM_WORKAREA` option.

- **Bug Fixes**
  - Fixed a crash when opening Microsoft 365 sign-in in Word.

- **Tests**
  - Added coverage for popup placement, centering, boundary clamping, and exclusion handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->