### PR TITLE
Fix Microsoft 365 license registration after sign-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Activate Microsoft 365 licenses after signing in to Office.
 - Prevent Word from crashing when opening Microsoft 365 sign-in.
 - Keep Word responsive and fully render its welcome screen after updating to WineHQ 11.16.
 

--- a/dlls/windows.security.authentication.onlineid/authenticator.c
+++ b/dlls/windows.security.authentication.onlineid/authenticator.c
@@ -2797,7 +2797,7 @@ static HRESULT web_token_request_result_create( INT32 status, const WCHAR *scope
     impl->status = status;
     if (!status)
     {
-        const WCHAR *path = scopes && wcsstr( scopes, L"service::officeapps.live.com" ) ?
+        const WCHAR *path = is_office_licensing_scope( scopes ) ?
                             L"C:\\wam-licensing-token.txt" : L"C:\\wam-access-token.txt";
         WCHAR *token = load_wam_token_file( path );
         if (!token) { token_result_Release( impl ); return HRESULT_FROM_WIN32( ERROR_NOT_FOUND ); }
@@ -3431,7 +3431,7 @@ static BOOL prepare_silent_wam_token(const WCHAR *scopes, const WCHAR *client_id
     ULONGLONG expiry = expires ? wcstoull( expires, NULL, 10 ) : 0;
     DWORD exit_code;
 
-    if (scopes && *scopes && !wcsstr( scopes, L"service::officeapps.live.com" ))
+    if (scopes && *scopes && !is_office_licensing_scope( scopes ))
     {
         if (!run_wine365_resource_refresh( scopes, client_id )) goto done;
         if (token) { SecureZeroMemory( token, wcslen(token) * sizeof(*token) ); free( token ); }

--- a/dlls/windows.security.authentication.onlineid/private.h
+++ b/dlls/windows.security.authentication.onlineid/private.h
@@ -21,6 +21,7 @@
 #define __WINE_ONLINEID_PRIVATE_H
 
 #include <stdarg.h>
+#include <wchar.h>
 
 #define COBJMACROS
 #include "windef.h"
@@ -39,6 +40,32 @@
 
 extern IActivationFactory *authenticator_factory;
 extern IActivationFactory *ticket_factory;
+
+static inline BOOL is_office_licensing_scope( const WCHAR *scopes )
+{
+    static const WCHAR legacy[] = L"service::officeapps.live.com";
+    static const WCHAR uri[] = L"https://officeapps.live.com";
+    const WCHAR *start, *end;
+    SIZE_T len;
+
+    if (!scopes) return FALSE;
+    for (start = scopes; *start; start = end)
+    {
+        while (*start && *start <= ' ') ++start;
+        for (end = start; *end && *end > ' '; ++end);
+        len = end - start;
+        if (len >= ARRAY_SIZE(legacy) - 1 &&
+            !wcsnicmp( start, legacy, ARRAY_SIZE(legacy) - 1 ) &&
+            (len == ARRAY_SIZE(legacy) - 1 ||
+             (start[ARRAY_SIZE(legacy) - 1] == ':' && start[ARRAY_SIZE(legacy)] == ':')))
+            return TRUE;
+        if (len >= ARRAY_SIZE(uri) - 1 &&
+            !wcsnicmp( start, uri, ARRAY_SIZE(uri) - 1 ) &&
+            (len == ARRAY_SIZE(uri) - 1 || start[ARRAY_SIZE(uri) - 1] == '/'))
+            return TRUE;
+    }
+    return FALSE;
+}
 
 #define DEFINE_IINSPECTABLE_( pfx, iface_type, impl_type, impl_from, iface_mem, expr )             \
     static inline impl_type *impl_from( iface_type *iface )                                        \

--- a/dlls/windows.security.authentication.onlineid/tests/onlineid.c
+++ b/dlls/windows.security.authentication.onlineid/tests/onlineid.c
@@ -31,9 +31,29 @@
 #define WIDL_using_Windows_Security_Authentication_OnlineId
 #include "windows.security.authentication.onlineid.h"
 
+#include "../private.h"
 #include "wine/test.h"
 
 #define check_interface( obj, iid ) check_interface_( __LINE__, obj, iid )
+
+static void test_office_licensing_scopes(void)
+{
+    ok(is_office_licensing_scope(L"service::officeapps.live.com"), "legacy licensing scope not recognized.\n");
+    ok(is_office_licensing_scope(L"SERVICE::OFFICEAPPS.LIVE.COM::MBI_SSL"),
+       "legacy licensing scope with policy not recognized.\n");
+    ok(is_office_licensing_scope(L"https://officeapps.live.com/.default offline_access openid profile"),
+       "normalized licensing scope not recognized.\n");
+    ok(is_office_licensing_scope(L"offline_access HTTPS://OFFICEAPPS.LIVE.COM/.DEFAULT"),
+       "normalized mixed-case licensing scope not recognized.\n");
+    ok(!is_office_licensing_scope(NULL), "NULL scope recognized.\n");
+    ok(!is_office_licensing_scope(L""), "empty scope recognized.\n");
+    ok(!is_office_licensing_scope(L"https://graph.microsoft.com/.default"), "Graph scope recognized.\n");
+    ok(!is_office_licensing_scope(L"https://officeapps.live.com.evil/.default"),
+       "lookalike URI licensing scope recognized.\n");
+    ok(!is_office_licensing_scope(L"xservice::officeapps.live.com"),
+       "embedded legacy licensing scope recognized.\n");
+}
+
 static void check_interface_( unsigned int line, void *obj, const IID *iid )
 {
     IUnknown *iface = obj;
@@ -715,6 +735,8 @@ done:
 START_TEST(onlineid)
 {
     HRESULT hr;
+
+    test_office_licensing_scopes();
 
     hr = RoInitialize( RO_INIT_MULTITHREADED );
     ok( hr == S_OK, "RoInitialize failed, hr %#lx\n", hr );


### PR DESCRIPTION
## Purpose

Office now requests its licensing token with the normalized `https://officeapps.live.com/.default` scope. Wine4Office only recognized the legacy `service::officeapps.live.com` form, so it returned the ordinary Office token and subscription registration did not complete.

## Changes

- recognize both legacy and normalized Office licensing scope forms
- use the same classifier for token selection and silent refresh routing
- reject embedded and lookalike hosts
- add a user-facing changelog entry

## Validation

- x86-64 OnlineId tests pass
- x86 OnlineId tests pass
- baseline isolated Office prefix: entitlement requests repeat and no vNext license is created
- patched isolated Office prefix: `%LOCALAPPDATA%\Microsoft\Office\Licenses` is populated and `LicensingNext\o365proplusretail` becomes `2`

## Risk

Low and localized to Office WAM scope classification. Exact host/token boundaries prevent unrelated resource scopes from selecting the licensing token.

## Summary by Sourcery

Fix Office licensing token handling so Microsoft 365 subscriptions register successfully after sign-in.

Bug Fixes:
- Activate Microsoft 365 licenses after Office sign-in by recognizing both legacy and normalized Office licensing scopes.

Enhancements:
- Centralize Office licensing scope classification for token selection and silent refresh routing while rejecting embedded and lookalike hosts.

Documentation:
- Add a changelog entry for Microsoft 365 license activation after Office sign-in.

Tests:
- Add OnlineId coverage for legacy, normalized, case-insensitive, unrelated, embedded, and lookalike licensing scopes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Microsoft 365 licenses can now be activated after signing in to Office.

* **Bug Fixes**
  * Improved recognition of Office licensing requests across supported sign-in formats.
  * Enhanced token selection and silent refresh for Office licensing, improving activation reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->