### PR TITLE
manager: show recreate environment progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Activate Microsoft 365 licenses after signing in to Office.
+- Keep Wine environment recreation responsive and show live progress and logs in the Manager.
 - Prevent Word from crashing when opening Microsoft 365 sign-in.
 - Keep Word responsive and fully render its welcome screen after updating to WineHQ 11.16.
 

--- a/tools/wine4office-manager/tests/test_backend.py
+++ b/tools/wine4office-manager/tests/test_backend.py
@@ -546,6 +546,7 @@ touch "$WINEPREFIX/system.reg" "$WINEPREFIX/user.reg"
         self.assertIn(str(prefix), message)
 
     def test_stream_command_does_not_wait_for_wine_child_stdout(self):
+        """A detached Wine child must not hold the command worker open."""
         command = self.root / "holds-stdout"
         command.write_text("#!/bin/sh\n(sleep 5) &\nprintf 'ready\\n'\n")
         command.chmod(command.stat().st_mode | stat.S_IXUSR)
@@ -559,7 +560,34 @@ touch "$WINEPREFIX/system.reg" "$WINEPREFIX/user.reg"
         self.assertLess(time.monotonic() - started, 2)
         self.assertEqual(output, [f"$ {command}", "ready"])
 
+    def test_stream_command_flushes_unterminated_output_before_detached_exit(self):
+        """Flush a final partial output fragment before returning."""
+        command = self.root / "holds-stdout-fragment"
+        command.write_text("#!/bin/sh\n(sleep 5) &\nprintf partial\n")
+        command.chmod(command.stat().st_mode | stat.S_IXUSR)
+        output = []
+
+        started = time.monotonic()
+        backend._stream_command([str(command)], os.environ.copy(), output.append)
+
+        self.assertLess(time.monotonic() - started, 2)
+        self.assertEqual(output, [f"$ {command}", "partial"])
+
+    def test_stream_command_does_not_busy_loop_after_stdout_closes(self):
+        """Closed stdout must not make the worker consume a CPU core."""
+        command = self.root / "closes-stdout"
+        command.write_text("#!/bin/sh\nexec 1>&-\nsleep 1\n")
+        command.chmod(command.stat().st_mode | stat.S_IXUSR)
+        output = []
+
+        started = time.process_time()
+        backend._stream_command([str(command)], os.environ.copy(), output.append)
+
+        self.assertLess(time.process_time() - started, 0.5)
+        self.assertEqual(output, [f"$ {command}"])
+
     def test_create_environment_reports_recreate_phases(self):
+        """Recreation reports staging, initialization, cleanup, and readiness."""
         prefix = self._make_prefix(self.home / ".wine4office", "old")
         progress = []
         backend.create_environment(

--- a/tools/wine4office-manager/tests/test_backend.py
+++ b/tools/wine4office-manager/tests/test_backend.py
@@ -9,6 +9,7 @@ import signal
 import stat
 import sys
 import tempfile
+import time
 import unittest
 import zipfile
 from pathlib import Path
@@ -543,6 +544,34 @@ touch "$WINEPREFIX/system.reg" "$WINEPREFIX/user.reg"
             0o600,
         )
         self.assertIn(str(prefix), message)
+
+    def test_stream_command_does_not_wait_for_wine_child_stdout(self):
+        command = self.root / "holds-stdout"
+        command.write_text("#!/bin/sh\n(sleep 5) &\nprintf 'ready\\n'\n")
+        command.chmod(command.stat().st_mode | stat.S_IXUSR)
+        output = []
+
+        started = time.monotonic()
+        backend._stream_command(
+            [str(command)], os.environ.copy(), output.append
+        )
+
+        self.assertLess(time.monotonic() - started, 2)
+        self.assertEqual(output, [f"$ {command}", "ready"])
+
+    def test_create_environment_reports_recreate_phases(self):
+        prefix = self._make_prefix(self.home / ".wine4office", "old")
+        progress = []
+        backend.create_environment(
+            str(prefix), str(self.wine), True, lambda _line: None,
+            progress_callback=lambda label, value: progress.append((label, value)),
+        )
+
+        labels = [label for label, _value in progress]
+        self.assertIn("Stopping the existing Wine environment…", labels)
+        self.assertIn("Initializing the Wine environment…", labels)
+        self.assertIn("Removing the previous Wine environment…", labels)
+        self.assertEqual(progress[-1], ("Wine environment is ready", 100))
 
     def test_create_environment_installs_both_bundled_gecko_architectures(self):
         prefix = self.home / ".wine4office"

--- a/tools/wine4office-manager/tests/test_desktop_i18n.py
+++ b/tools/wine4office-manager/tests/test_desktop_i18n.py
@@ -185,6 +185,39 @@ class TranslationTests(unittest.TestCase):
                     if "Office" in source:
                         self.assertIn("Office", translated)
 
+    def test_environment_progress_is_localized_in_every_language(self):
+        """Every supported locale translates the environment progress UI."""
+        texts = (
+            "Applying Office compatibility settings…",
+            "Applying Office privacy settings…",
+            "Configuring Wine graphics…",
+            "Creating Wine environment",
+            "Creating Wine environment…",
+            "Initializing the Wine environment…",
+            "Installing Wine Gecko…",
+            "Installing Wine Mono…",
+            "Recreating Wine environment",
+            "Recreating Wine environment…",
+            "Removing the previous Wine environment…",
+            "Restoring the previous Wine environment…",
+            "Stopping the existing Wine environment…",
+            "Wine environment is ready",
+            "Wine environment is ready.",
+            "Wine environment operation was cancelled.",
+            "Wine environment operation failed. Review the details below.",
+        )
+        for language in i18n.SUPPORTED_LANGUAGES:
+            for source in texts:
+                with self.subTest(language=language, source=source):
+                    translated = i18n.CATALOGS[language].get(source)
+                    self.assertIsNotNone(translated)
+                    if language != "en":
+                        self.assertNotEqual(translated, source)
+                    if "Wine" in source:
+                        self.assertIn("Wine", translated)
+                    if "Office" in source:
+                        self.assertIn("Office", translated)
+
     def test_additional_language_catalogs_are_complete_and_ltr(self):
         expected = {
             "de", "es", "fr", "it", "pt", "nl", "ru", "uk", "pl", "tr",

--- a/tools/wine4office-manager/tests/test_qt.py
+++ b/tools/wine4office-manager/tests/test_qt.py
@@ -959,6 +959,7 @@ class QtManagerTests(unittest.TestCase):
             config["prefix"], config["wine"], True, self.state.output,
             cancel_event=self.state.cancel_event,
             process_callback=self.state.set_process,
+            progress_callback=self.state.set_progress,
         )
         apply.assert_called_once_with(
             config["prefix"], config["wine"], True, use_x11=True,
@@ -997,6 +998,59 @@ class QtManagerTests(unittest.TestCase):
                 time.sleep(0.01)
 
         self.assertEqual(self.state.snapshot()["task"]["status"], "completed")
+
+    def test_environment_recreation_shows_progress_popup_with_live_logs(self):
+        with mock.patch.object(
+            self.window, "save_config", return_value=dict(self.config)
+        ), mock.patch.object(
+            qt_module.QMessageBox, "warning",
+            return_value=QMessageBox.StandardButton.Yes,
+        ), mock.patch.object(
+            self.state, "start_task"
+        ) as start_task, mock.patch.object(
+            qt_module, "_create_environment_worker", return_value="environment ready"
+        ) as create:
+            self.window.environment_action(True)
+            operation = start_task.call_args.args[1]
+            operation()
+
+        self.assertEqual(start_task.call_args.args[0], "environment")
+        create.assert_called_once()
+        self.assertEqual(self.window.update_progress_task_kind, "environment")
+        self.assertEqual(
+            self.window.update_progress_dialog.windowTitle(),
+            "Recreating Wine environment",
+        )
+        self.assertTrue(self.window.update_progress_dialog.isVisible())
+
+        self.window._refresh_update_progress({
+            "kind": "environment",
+            "running": True,
+            "status": "running",
+            "log": "$ wineboot -u\nCreating registry files\n",
+            "progress_label": "Initializing the Wine environment…",
+            "progress_value": None,
+        })
+        self.assertIn(
+            "Creating registry files",
+            self.window.update_progress_log.toPlainText(),
+        )
+        self.assertIn(
+            "Initializing",
+            self.window.update_progress_status.text(),
+        )
+
+        self.window._refresh_update_progress({
+            "kind": "environment",
+            "running": False,
+            "status": "completed",
+            "log": "Wine environment is ready at /tmp/prefix\n",
+            "progress_label": "Wine environment is ready",
+            "progress_value": 100,
+        })
+        self.assertEqual(self.window.update_progress_bar.value(), 100)
+        self.assertEqual(self.window.update_progress_button.text(), "Close")
+        self.window.update_progress_dialog.accept()
 
     def test_cancel_environment_reaps_active_helper(self):
         helper = mock.Mock()

--- a/tools/wine4office-manager/tests/test_qt.py
+++ b/tools/wine4office-manager/tests/test_qt.py
@@ -945,6 +945,7 @@ class QtManagerTests(unittest.TestCase):
         )
 
     def test_environment_creation_reapplies_checked_telemetry_policy(self):
+        """Environment creation reapplies the saved privacy policy."""
         prefix = Path(self.config["prefix"])
         config = backend.set_office_telemetry_disabled(self.config, prefix, True)
         with mock.patch.object(
@@ -955,19 +956,47 @@ class QtManagerTests(unittest.TestCase):
             result = self.window._create_environment(config, True)
 
         self.assertEqual(result, "environment ready")
-        create.assert_called_once_with(
-            config["prefix"], config["wine"], True, self.state.output,
-            cancel_event=self.state.cancel_event,
-            process_callback=self.state.set_process,
-            progress_callback=self.state.set_progress,
+        create.assert_called_once()
+        self.assertEqual(
+            create.call_args.args,
+            (config["prefix"], config["wine"], True, self.state.output),
         )
+        self.assertIs(create.call_args.kwargs["cancel_event"], self.state.cancel_event)
+        self.assertEqual(create.call_args.kwargs["process_callback"], self.state.set_process)
+        self.assertTrue(callable(create.call_args.kwargs["progress_callback"]))
         apply.assert_called_once_with(
             config["prefix"], config["wine"], True, use_x11=True,
             cancel_event=self.state.cancel_event,
             process_callback=self.state.set_process,
         )
 
+    def test_environment_creation_withholds_ready_until_policy_work_finishes(self):
+        """Policy work keeps the progress state below 100% until it completes."""
+        config = backend.set_office_telemetry_disabled(
+            self.config, self.config["prefix"], True
+        )
+        observed_progress = []
+
+        def create_environment(*args, **kwargs):
+            kwargs["progress_callback"]("Wine environment is ready", 100)
+            return "environment ready"
+
+        def apply_policy(*args, **kwargs):
+            observed_progress.append(self.state.snapshot()["task"]["progress_value"])
+
+        with mock.patch.object(
+            backend, "create_environment", side_effect=create_environment
+        ), mock.patch.object(
+            backend, "apply_office_telemetry_policy", side_effect=apply_policy
+        ):
+            result = qt_module._create_environment_worker(self.state, config, True)
+
+        self.assertEqual(result, "environment ready")
+        self.assertEqual(observed_progress, [None])
+        self.assertEqual(self.state.snapshot()["task"]["progress_value"], 100)
+
     def test_environment_creation_queues_policy_work_and_keeps_qt_responsive(self):
+        """Policy application runs off the Qt thread."""
         with self.state.lock:
             self.state.config = backend.set_office_telemetry_disabled(
                 self.state.config, self.config["prefix"], True
@@ -1000,6 +1029,7 @@ class QtManagerTests(unittest.TestCase):
         self.assertEqual(self.state.snapshot()["task"]["status"], "completed")
 
     def test_environment_recreation_shows_progress_popup_with_live_logs(self):
+        """Recreation displays live task logs and a completed progress state."""
         with mock.patch.object(
             self.window, "save_config", return_value=dict(self.config)
         ), mock.patch.object(

--- a/tools/wine4office-manager/translations/ar.json
+++ b/tools/wine4office-manager/translations/ar.json
@@ -160,5 +160,22 @@
   "Wine4Office Manager": "مدير Wine4Office",
   "Wine4Office update available": "يتوفر تحديث لـWine4Office",
   "Working folder:": "مجلد العمل:",
-  "running": "قيد التشغيل"
+  "running": "قيد التشغيل",
+"Applying Office compatibility settings…": "جارٍ تطبيق إعدادات توافق Office…",
+"Applying Office privacy settings…": "جارٍ تطبيق إعدادات خصوصية Office…",
+"Configuring Wine graphics…": "جارٍ ضبط رسومات Wine…",
+"Creating Wine environment": "إنشاء بيئة Wine",
+"Creating Wine environment…": "جارٍ إنشاء بيئة Wine…",
+"Initializing the Wine environment…": "جارٍ تهيئة بيئة Wine…",
+"Installing Wine Gecko…": "جارٍ تثبيت Wine Gecko…",
+"Installing Wine Mono…": "جارٍ تثبيت Wine Mono…",
+"Recreating Wine environment": "إعادة إنشاء بيئة Wine",
+"Recreating Wine environment…": "جارٍ إعادة إنشاء بيئة Wine…",
+"Removing the previous Wine environment…": "جارٍ إزالة بيئة Wine السابقة…",
+"Restoring the previous Wine environment…": "جارٍ استعادة بيئة Wine السابقة…",
+"Stopping the existing Wine environment…": "جارٍ إيقاف بيئة Wine الحالية…",
+"Wine environment is ready": "بيئة Wine جاهزة",
+"Wine environment is ready.": "بيئة Wine جاهزة.",
+"Wine environment operation was cancelled.": "أُلغيت عملية بيئة Wine.",
+"Wine environment operation failed. Review the details below.": "فشلت عملية بيئة Wine. راجع التفاصيل أدناه."
 }

--- a/tools/wine4office-manager/translations/bg.json
+++ b/tools/wine4office-manager/translations/bg.json
@@ -61,5 +61,22 @@
   "Wine shutdown is finishing; the Manager will close when it completes.": "Изключването на Wine завършва; мениджърът ще затвори, когато приключи.",
   "Wine shutdown was interrupted.": "Изключването на Wine бе прекъснато.",
   "Wine tools": "Инструменти на Wine",
-  "Wine4Office Manager": "Мениджър на Wine4Office"
+  "Wine4Office Manager": "Мениджър на Wine4Office",
+"Applying Office compatibility settings…": "Прилагат се настройките за съвместимост на Office…",
+"Applying Office privacy settings…": "Прилагат се настройките за поверителност на Office…",
+"Configuring Wine graphics…": "Графиката на Wine се конфигурира…",
+"Creating Wine environment": "Създаване на среда Wine",
+"Creating Wine environment…": "Средата Wine се създава…",
+"Initializing the Wine environment…": "Средата Wine се инициализира…",
+"Installing Wine Gecko…": "Wine Gecko се инсталира…",
+"Installing Wine Mono…": "Wine Mono се инсталира…",
+"Recreating Wine environment": "Повторно създаване на среда Wine",
+"Recreating Wine environment…": "Средата Wine се създава повторно…",
+"Removing the previous Wine environment…": "Предишната среда Wine се премахва…",
+"Restoring the previous Wine environment…": "Предишната среда Wine се възстановява…",
+"Stopping the existing Wine environment…": "Съществуващата среда Wine се спира…",
+"Wine environment is ready": "Средата Wine е готова",
+"Wine environment is ready.": "Средата Wine е готова.",
+"Wine environment operation was cancelled.": "Операцията със средата Wine е отменена.",
+"Wine environment operation failed. Review the details below.": "Операцията със средата Wine се провали. Вижте подробностите по-долу."
 }

--- a/tools/wine4office-manager/translations/bn.json
+++ b/tools/wine4office-manager/translations/bn.json
@@ -61,5 +61,22 @@
   "Wine shutdown is finishing; the Manager will close when it completes.": "Wine শাটডাউন শেষ হচ্ছে; এটি সম্পূর্ণ হলে ম্যানেজার বন্ধ হয়ে যাবে।",
   "Wine shutdown was interrupted.": "Wine শাটডাউন বাধাপ্রাপ্ত হয়েছে।",
   "Wine tools": "Wine সরঞ্জাম",
-  "Wine4Office Manager": "Wine4Office ব্যবস্থাপক"
+  "Wine4Office Manager": "Wine4Office ব্যবস্থাপক",
+"Applying Office compatibility settings…": "Office-এর সামঞ্জস্য সেটিং প্রয়োগ করা হচ্ছে…",
+"Applying Office privacy settings…": "Office-এর গোপনীয়তা সেটিং প্রয়োগ করা হচ্ছে…",
+"Configuring Wine graphics…": "Wine-এর গ্রাফিক্স কনফিগার করা হচ্ছে…",
+"Creating Wine environment": "Wine পরিবেশ তৈরি করুন",
+"Creating Wine environment…": "Wine পরিবেশ তৈরি করা হচ্ছে…",
+"Initializing the Wine environment…": "Wine পরিবেশ আরম্ভ করা হচ্ছে…",
+"Installing Wine Gecko…": "Wine Gecko ইনস্টল করা হচ্ছে…",
+"Installing Wine Mono…": "Wine Mono ইনস্টল করা হচ্ছে…",
+"Recreating Wine environment": "Wine পরিবেশ পুনরায় তৈরি করুন",
+"Recreating Wine environment…": "Wine পরিবেশ পুনরায় তৈরি করা হচ্ছে…",
+"Removing the previous Wine environment…": "আগের Wine পরিবেশ সরানো হচ্ছে…",
+"Restoring the previous Wine environment…": "আগের Wine পরিবেশ পুনরুদ্ধার করা হচ্ছে…",
+"Stopping the existing Wine environment…": "বিদ্যমান Wine পরিবেশ বন্ধ করা হচ্ছে…",
+"Wine environment is ready": "Wine পরিবেশ প্রস্তুত",
+"Wine environment is ready.": "Wine পরিবেশ প্রস্তুত।",
+"Wine environment operation was cancelled.": "Wine পরিবেশের কাজ বাতিল করা হয়েছে।",
+"Wine environment operation failed. Review the details below.": "Wine পরিবেশের কাজ ব্যর্থ হয়েছে। নিচের বিবরণ দেখুন।"
 }

--- a/tools/wine4office-manager/translations/ca.json
+++ b/tools/wine4office-manager/translations/ca.json
@@ -65,5 +65,22 @@
   "Wine shutdown was interrupted.": "L'aturada de Wine s'ha interromput.",
   "Wine tools": "Eines del Wine",
   "Wine4Office Manager": "Gestor del Wine4Office",
-  "Working folder:": "Carpeta de treball:"
+  "Working folder:": "Carpeta de treball:",
+"Applying Office compatibility settings…": "S'apliquen els paràmetres de compatibilitat de l'Office…",
+"Applying Office privacy settings…": "S'apliquen els paràmetres de privadesa de l'Office…",
+"Configuring Wine graphics…": "Es configuren els gràfics del Wine…",
+"Creating Wine environment": "Crea l'entorn del Wine",
+"Creating Wine environment…": "S'està creant l'entorn del Wine…",
+"Initializing the Wine environment…": "S'està inicialitzant l'entorn del Wine…",
+"Installing Wine Gecko…": "S'està instal·lant el Wine Gecko…",
+"Installing Wine Mono…": "S'està instal·lant el Wine Mono…",
+"Recreating Wine environment": "Recrea l'entorn del Wine",
+"Recreating Wine environment…": "S'està recreant l'entorn del Wine…",
+"Removing the previous Wine environment…": "S'està eliminant l'entorn del Wine anterior…",
+"Restoring the previous Wine environment…": "S'està restaurant l'entorn del Wine anterior…",
+"Stopping the existing Wine environment…": "S'està aturant l'entorn del Wine existent…",
+"Wine environment is ready": "L'entorn del Wine està a punt",
+"Wine environment is ready.": "L'entorn del Wine està a punt.",
+"Wine environment operation was cancelled.": "L'operació de l'entorn del Wine s'ha cancel·lat.",
+"Wine environment operation failed. Review the details below.": "L'operació de l'entorn del Wine ha fallat. Consulteu els detalls següents."
 }

--- a/tools/wine4office-manager/translations/cs.json
+++ b/tools/wine4office-manager/translations/cs.json
@@ -65,5 +65,22 @@
   "Wine shutdown was interrupted.": "Vypínání Wine bylo přerušeno.",
   "Wine tools": "Nástroje Wine",
   "Wine4Office Manager": "Správce Wine4Office",
-  "Working folder:": "Pracovní složka:"
+  "Working folder:": "Pracovní složka:",
+"Applying Office compatibility settings…": "Používání nastavení kompatibility Office…",
+"Applying Office privacy settings…": "Používání nastavení soukromí Office…",
+"Configuring Wine graphics…": "Konfigurace grafiky Wine…",
+"Creating Wine environment": "Vytvořit prostředí Wine",
+"Creating Wine environment…": "Vytváření prostředí Wine…",
+"Initializing the Wine environment…": "Inicializace prostředí Wine…",
+"Installing Wine Gecko…": "Instalace Wine Gecko…",
+"Installing Wine Mono…": "Instalace Wine Mono…",
+"Recreating Wine environment": "Znovu vytvořit prostředí Wine",
+"Recreating Wine environment…": "Opětovné vytváření prostředí Wine…",
+"Removing the previous Wine environment…": "Odebírání předchozího prostředí Wine…",
+"Restoring the previous Wine environment…": "Obnovování předchozího prostředí Wine…",
+"Stopping the existing Wine environment…": "Zastavování existujícího prostředí Wine…",
+"Wine environment is ready": "Prostředí Wine je připravené",
+"Wine environment is ready.": "Prostředí Wine je připravené.",
+"Wine environment operation was cancelled.": "Operace prostředí Wine byla zrušena.",
+"Wine environment operation failed. Review the details below.": "Operace prostředí Wine se nezdařila. Prohlédněte si podrobnosti níže."
 }

--- a/tools/wine4office-manager/translations/da.json
+++ b/tools/wine4office-manager/translations/da.json
@@ -65,5 +65,22 @@
   "Wine shutdown was interrupted.": "Wine nedlukning blev afbrudt.",
   "Wine tools": "Wine-værktøjer",
   "Wine4Office Manager": "Wine4Office-administration",
-  "Working folder:": "Arbejdsmappe:"
+  "Working folder:": "Arbejdsmappe:",
+"Applying Office compatibility settings…": "Anvender Office-kompatibilitetsindstillinger…",
+"Applying Office privacy settings…": "Anvender Office-privatlivsindstillinger…",
+"Configuring Wine graphics…": "Konfigurerer Wine-grafik…",
+"Creating Wine environment": "Opret Wine-miljø",
+"Creating Wine environment…": "Opretter Wine-miljø…",
+"Initializing the Wine environment…": "Initialiserer Wine-miljø…",
+"Installing Wine Gecko…": "Installerer Wine Gecko…",
+"Installing Wine Mono…": "Installerer Wine Mono…",
+"Recreating Wine environment": "Opret Wine-miljø igen",
+"Recreating Wine environment…": "Opretter Wine-miljø igen…",
+"Removing the previous Wine environment…": "Fjerner det tidligere Wine-miljø…",
+"Restoring the previous Wine environment…": "Gendanner det tidligere Wine-miljø…",
+"Stopping the existing Wine environment…": "Stopper det eksisterende Wine-miljø…",
+"Wine environment is ready": "Wine-miljøet er klar",
+"Wine environment is ready.": "Wine-miljøet er klar.",
+"Wine environment operation was cancelled.": "Handlingen for Wine-miljøet blev annulleret.",
+"Wine environment operation failed. Review the details below.": "Handlingen for Wine-miljøet mislykkedes. Se detaljerne nedenfor."
 }

--- a/tools/wine4office-manager/translations/de.json
+++ b/tools/wine4office-manager/translations/de.json
@@ -99,5 +99,22 @@
   "Wine shutdown was interrupted.": "Das Herunterfahren von Wine wurde unterbrochen.",
   "Wine tools": "Wine-Werkzeuge",
   "Wine4Office Manager": "Wine4Office-Verwaltung",
-  "Working folder:": "Arbeitsordner:"
+  "Working folder:": "Arbeitsordner:",
+"Applying Office compatibility settings…": "Office-Kompatibilitätseinstellungen werden angewendet…",
+"Applying Office privacy settings…": "Office-Datenschutzeinstellungen werden angewendet…",
+"Configuring Wine graphics…": "Wine-Grafik wird konfiguriert…",
+"Creating Wine environment": "Wine-Umgebung erstellen",
+"Creating Wine environment…": "Wine-Umgebung wird erstellt…",
+"Initializing the Wine environment…": "Wine-Umgebung wird initialisiert…",
+"Installing Wine Gecko…": "Wine Gecko wird installiert…",
+"Installing Wine Mono…": "Wine Mono wird installiert…",
+"Recreating Wine environment": "Wine-Umgebung neu erstellen",
+"Recreating Wine environment…": "Wine-Umgebung wird neu erstellt…",
+"Removing the previous Wine environment…": "Vorherige Wine-Umgebung wird entfernt…",
+"Restoring the previous Wine environment…": "Vorherige Wine-Umgebung wird wiederhergestellt…",
+"Stopping the existing Wine environment…": "Vorhandene Wine-Umgebung wird gestoppt…",
+"Wine environment is ready": "Wine-Umgebung ist bereit",
+"Wine environment is ready.": "Wine-Umgebung ist bereit.",
+"Wine environment operation was cancelled.": "Vorgang für die Wine-Umgebung wurde abgebrochen.",
+"Wine environment operation failed. Review the details below.": "Vorgang für die Wine-Umgebung fehlgeschlagen. Details siehe unten."
 }

--- a/tools/wine4office-manager/translations/el.json
+++ b/tools/wine4office-manager/translations/el.json
@@ -65,5 +65,22 @@
   "Wine shutdown was interrupted.": "Ο τερματισμός λειτουργίας Wine διακόπηκε.",
   "Wine tools": "Εργαλεία Wine",
   "Wine4Office Manager": "Διαχείριση Wine4Office",
-  "Working folder:": "Φάκελος εργασίας:"
+  "Working folder:": "Φάκελος εργασίας:",
+"Applying Office compatibility settings…": "Εφαρμογή ρυθμίσεων συμβατότητας του Office…",
+"Applying Office privacy settings…": "Εφαρμογή ρυθμίσεων απορρήτου του Office…",
+"Configuring Wine graphics…": "Διαμόρφωση γραφικών του Wine…",
+"Creating Wine environment": "Δημιουργία περιβάλλοντος Wine",
+"Creating Wine environment…": "Δημιουργία περιβάλλοντος Wine…",
+"Initializing the Wine environment…": "Αρχικοποίηση περιβάλλοντος Wine…",
+"Installing Wine Gecko…": "Εγκατάσταση Wine Gecko…",
+"Installing Wine Mono…": "Εγκατάσταση Wine Mono…",
+"Recreating Wine environment": "Επαναδημιουργία περιβάλλοντος Wine",
+"Recreating Wine environment…": "Επαναδημιουργία περιβάλλοντος Wine…",
+"Removing the previous Wine environment…": "Αφαίρεση του προηγούμενου περιβάλλοντος Wine…",
+"Restoring the previous Wine environment…": "Επαναφορά του προηγούμενου περιβάλλοντος Wine…",
+"Stopping the existing Wine environment…": "Διακοπή του υπάρχοντος περιβάλλοντος Wine…",
+"Wine environment is ready": "Το περιβάλλον Wine είναι έτοιμο",
+"Wine environment is ready.": "Το περιβάλλον Wine είναι έτοιμο.",
+"Wine environment operation was cancelled.": "Η λειτουργία του περιβάλλοντος Wine ακυρώθηκε.",
+"Wine environment operation failed. Review the details below.": "Η λειτουργία του περιβάλλοντος Wine απέτυχε. Δείτε τις λεπτομέρειες παρακάτω."
 }

--- a/tools/wine4office-manager/translations/en.json
+++ b/tools/wine4office-manager/translations/en.json
@@ -161,5 +161,22 @@
   "Wine4Office Manager": "Wine4Office Manager",
   "Wine4Office update available": "Wine4Office update available",
   "Working folder:": "Working folder:",
-  "running": "running"
+  "running": "running",
+"Applying Office compatibility settings…": "Applying Office compatibility settings…",
+"Applying Office privacy settings…": "Applying Office privacy settings…",
+"Configuring Wine graphics…": "Configuring Wine graphics…",
+"Creating Wine environment": "Creating Wine environment",
+"Creating Wine environment…": "Creating Wine environment…",
+"Initializing the Wine environment…": "Initializing the Wine environment…",
+"Installing Wine Gecko…": "Installing Wine Gecko…",
+"Installing Wine Mono…": "Installing Wine Mono…",
+"Recreating Wine environment": "Recreating Wine environment",
+"Recreating Wine environment…": "Recreating Wine environment…",
+"Removing the previous Wine environment…": "Removing the previous Wine environment…",
+"Restoring the previous Wine environment…": "Restoring the previous Wine environment…",
+"Stopping the existing Wine environment…": "Stopping the existing Wine environment…",
+"Wine environment is ready": "Wine environment is ready",
+"Wine environment is ready.": "Wine environment is ready.",
+"Wine environment operation was cancelled.": "Wine environment operation was cancelled.",
+"Wine environment operation failed. Review the details below.": "Wine environment operation failed. Review the details below."
 }

--- a/tools/wine4office-manager/translations/es.json
+++ b/tools/wine4office-manager/translations/es.json
@@ -99,5 +99,22 @@
   "Wine shutdown was interrupted.": "Se interrumpió el cierre de Wine.",
   "Wine tools": "Herramientas de Wine",
   "Wine4Office Manager": "Administrador de Wine4Office",
-  "Working folder:": "Carpeta de trabajo:"
+  "Working folder:": "Carpeta de trabajo:",
+"Applying Office compatibility settings…": "Aplicando la configuración de compatibilidad de Office…",
+"Applying Office privacy settings…": "Aplicando la configuración de privacidad de Office…",
+"Configuring Wine graphics…": "Configurando los gráficos de Wine…",
+"Creating Wine environment": "Crear entorno de Wine",
+"Creating Wine environment…": "Creando entorno de Wine…",
+"Initializing the Wine environment…": "Inicializando el entorno de Wine…",
+"Installing Wine Gecko…": "Instalando Wine Gecko…",
+"Installing Wine Mono…": "Instalando Wine Mono…",
+"Recreating Wine environment": "Recrear entorno de Wine",
+"Recreating Wine environment…": "Recreando el entorno de Wine…",
+"Removing the previous Wine environment…": "Eliminando el entorno de Wine anterior…",
+"Restoring the previous Wine environment…": "Restaurando el entorno de Wine anterior…",
+"Stopping the existing Wine environment…": "Deteniendo el entorno de Wine existente…",
+"Wine environment is ready": "El entorno de Wine está listo",
+"Wine environment is ready.": "El entorno de Wine está listo.",
+"Wine environment operation was cancelled.": "La operación del entorno de Wine se canceló.",
+"Wine environment operation failed. Review the details below.": "La operación del entorno de Wine falló. Revise los detalles siguientes."
 }

--- a/tools/wine4office-manager/translations/et.json
+++ b/tools/wine4office-manager/translations/et.json
@@ -61,5 +61,22 @@
   "Wine shutdown is finishing; the Manager will close when it completes.": "Wine seiskamine on lõppemas; haldur sulgub, kui see on lõpetatud.",
   "Wine shutdown was interrupted.": "Wine seiskamine katkestati.",
   "Wine tools": "Wine'i tööriistad",
-  "Wine4Office Manager": "Wine4Office haldur"
+  "Wine4Office Manager": "Wine4Office haldur",
+"Applying Office compatibility settings…": "Office'i ühilduvusseadeid rakendatakse…",
+"Applying Office privacy settings…": "Office'i privaatsusseadeid rakendatakse…",
+"Configuring Wine graphics…": "Wine'i graafikat konfigureeritakse…",
+"Creating Wine environment": "Loo Wine'i keskkond",
+"Creating Wine environment…": "Wine'i keskkonda luuakse…",
+"Initializing the Wine environment…": "Wine'i keskkonda lähtestatakse…",
+"Installing Wine Gecko…": "Wine Gecko paigaldatakse…",
+"Installing Wine Mono…": "Wine Mono paigaldatakse…",
+"Recreating Wine environment": "Loo Wine'i keskkond uuesti",
+"Recreating Wine environment…": "Wine'i keskkonda luuakse uuesti…",
+"Removing the previous Wine environment…": "Eelmine Wine'i keskkond eemaldatakse…",
+"Restoring the previous Wine environment…": "Eelmine Wine'i keskkond taastatakse…",
+"Stopping the existing Wine environment…": "Olemasolev Wine'i keskkond peatatakse…",
+"Wine environment is ready": "Wine'i keskkond on valmis",
+"Wine environment is ready.": "Wine'i keskkond on valmis.",
+"Wine environment operation was cancelled.": "Wine'i keskkonna toiming tühistati.",
+"Wine environment operation failed. Review the details below.": "Wine'i keskkonna toiming nurjus. Vaadake allolevaid üksikasju."
 }

--- a/tools/wine4office-manager/translations/fa.json
+++ b/tools/wine4office-manager/translations/fa.json
@@ -65,5 +65,22 @@
   "Wine shutdown was interrupted.": "خاموش شدن Wine قطع شد.",
   "Wine tools": "ابزارهای Wine",
   "Wine4Office Manager": "مدیر Wine4Office",
-  "Working folder:": "پوشه کاری:"
+  "Working folder:": "پوشه کاری:",
+"Applying Office compatibility settings…": "اعمال تنظیمات سازگاری Office…",
+"Applying Office privacy settings…": "اعمال تنظیمات حریم خصوصی Office…",
+"Configuring Wine graphics…": "پیکربندی گرافیک Wine…",
+"Creating Wine environment": "ایجاد محیط Wine",
+"Creating Wine environment…": "در حال ایجاد محیط Wine…",
+"Initializing the Wine environment…": "در حال آماده‌سازی محیط Wine…",
+"Installing Wine Gecko…": "در حال نصب Wine Gecko…",
+"Installing Wine Mono…": "در حال نصب Wine Mono…",
+"Recreating Wine environment": "ایجاد دوباره محیط Wine",
+"Recreating Wine environment…": "در حال ایجاد دوباره محیط Wine…",
+"Removing the previous Wine environment…": "در حال حذف محیط قبلی Wine…",
+"Restoring the previous Wine environment…": "در حال بازیابی محیط قبلی Wine…",
+"Stopping the existing Wine environment…": "در حال توقف محیط موجود Wine…",
+"Wine environment is ready": "محیط Wine آماده است",
+"Wine environment is ready.": "محیط Wine آماده است.",
+"Wine environment operation was cancelled.": "عملیات محیط Wine لغو شد.",
+"Wine environment operation failed. Review the details below.": "عملیات محیط Wine ناموفق بود. جزئیات زیر را بررسی کنید."
 }

--- a/tools/wine4office-manager/translations/fi.json
+++ b/tools/wine4office-manager/translations/fi.json
@@ -65,5 +65,22 @@
   "Wine shutdown was interrupted.": "Wine:n sammutus keskeytettiin.",
   "Wine tools": "Wine-työkalut",
   "Wine4Office Manager": "Wine4Office-hallinta",
-  "Working folder:": "Työkansio:"
+  "Working folder:": "Työkansio:",
+"Applying Office compatibility settings…": "Käytetään Officen yhteensopivuusasetuksia…",
+"Applying Office privacy settings…": "Käytetään Officen yksityisyysasetuksia…",
+"Configuring Wine graphics…": "Määritetään Winen grafiikkaa…",
+"Creating Wine environment": "Luo Wine-ympäristö",
+"Creating Wine environment…": "Wine-ympäristöä luodaan…",
+"Initializing the Wine environment…": "Wine-ympäristöä alustetaan…",
+"Installing Wine Gecko…": "Wine Geckoa asennetaan…",
+"Installing Wine Mono…": "Wine Monoa asennetaan…",
+"Recreating Wine environment": "Luo Wine-ympäristö uudelleen",
+"Recreating Wine environment…": "Wine-ympäristöä luodaan uudelleen…",
+"Removing the previous Wine environment…": "Edellistä Wine-ympäristöä poistetaan…",
+"Restoring the previous Wine environment…": "Edellistä Wine-ympäristöä palautetaan…",
+"Stopping the existing Wine environment…": "Nykyistä Wine-ympäristöä pysäytetään…",
+"Wine environment is ready": "Wine-ympäristö on valmis",
+"Wine environment is ready.": "Wine-ympäristö on valmis.",
+"Wine environment operation was cancelled.": "Wine-ympäristön toiminto peruutettiin.",
+"Wine environment operation failed. Review the details below.": "Wine-ympäristön toiminto epäonnistui. Katso lisätiedot alta."
 }

--- a/tools/wine4office-manager/translations/fil.json
+++ b/tools/wine4office-manager/translations/fil.json
@@ -61,5 +61,22 @@
   "Wine shutdown is finishing; the Manager will close when it completes.": "Wine shutdown ay nagtatapos; ang Manager ay magsasara kapag ito ay nakumpleto.",
   "Wine shutdown was interrupted.": "Naantala ang Wine shutdown.",
   "Wine tools": "Mga tool ng Wine",
-  "Wine4Office Manager": "Tagapamahala ng Wine4Office"
+  "Wine4Office Manager": "Tagapamahala ng Wine4Office",
+"Applying Office compatibility settings…": "Inilalapat ang mga setting ng compatibility ng Office…",
+"Applying Office privacy settings…": "Inilalapat ang mga setting ng privacy ng Office…",
+"Configuring Wine graphics…": "Kino-configure ang graphics ng Wine…",
+"Creating Wine environment": "Lumikha ng environment ng Wine",
+"Creating Wine environment…": "Lumilikha ng environment ng Wine…",
+"Initializing the Wine environment…": "Sinisimulan ang environment ng Wine…",
+"Installing Wine Gecko…": "Ini-install ang Wine Gecko…",
+"Installing Wine Mono…": "Ini-install ang Wine Mono…",
+"Recreating Wine environment": "Lumikha muli ng environment ng Wine",
+"Recreating Wine environment…": "Muling nililikha ang environment ng Wine…",
+"Removing the previous Wine environment…": "Inaalis ang dating environment ng Wine…",
+"Restoring the previous Wine environment…": "Ibinabalik ang dating environment ng Wine…",
+"Stopping the existing Wine environment…": "Itinitigil ang kasalukuyang environment ng Wine…",
+"Wine environment is ready": "Handa na ang environment ng Wine",
+"Wine environment is ready.": "Handa na ang environment ng Wine.",
+"Wine environment operation was cancelled.": "Kinansela ang operasyon ng environment ng Wine.",
+"Wine environment operation failed. Review the details below.": "Nabigo ang operasyon ng environment ng Wine. Suriin ang mga detalye sa ibaba."
 }

--- a/tools/wine4office-manager/translations/fr.json
+++ b/tools/wine4office-manager/translations/fr.json
@@ -99,5 +99,22 @@
   "Wine shutdown was interrupted.": "L'arrêt de Wine a été interrompu.",
   "Wine tools": "Outils Wine",
   "Wine4Office Manager": "Gestionnaire Wine4Office",
-  "Working folder:": "Dossier de travail :"
+  "Working folder:": "Dossier de travail :",
+"Applying Office compatibility settings…": "Application des paramètres de compatibilité d’Office…",
+"Applying Office privacy settings…": "Application des paramètres de confidentialité d’Office…",
+"Configuring Wine graphics…": "Configuration des graphiques de Wine…",
+"Creating Wine environment": "Créer l’environnement Wine",
+"Creating Wine environment…": "Création de l’environnement Wine…",
+"Initializing the Wine environment…": "Initialisation de l’environnement Wine…",
+"Installing Wine Gecko…": "Installation de Wine Gecko…",
+"Installing Wine Mono…": "Installation de Wine Mono…",
+"Recreating Wine environment": "Recréer l’environnement Wine",
+"Recreating Wine environment…": "Recréation de l’environnement Wine…",
+"Removing the previous Wine environment…": "Suppression de l’environnement Wine précédent…",
+"Restoring the previous Wine environment…": "Restauration de l’environnement Wine précédent…",
+"Stopping the existing Wine environment…": "Arrêt de l’environnement Wine existant…",
+"Wine environment is ready": "L’environnement Wine est prêt",
+"Wine environment is ready.": "L’environnement Wine est prêt.",
+"Wine environment operation was cancelled.": "L’opération de l’environnement Wine a été annulée.",
+"Wine environment operation failed. Review the details below.": "L’opération de l’environnement Wine a échoué. Consultez les détails ci-dessous."
 }

--- a/tools/wine4office-manager/translations/he.json
+++ b/tools/wine4office-manager/translations/he.json
@@ -160,5 +160,22 @@
   "Wine4Office Manager": "מנהל Wine4Office",
   "Wine4Office update available": "עדכון Wine4Office זמין",
   "Working folder:": "תיקיית עבודה:",
-  "running": "פועל"
+  "running": "פועל",
+"Applying Office compatibility settings…": "החלת הגדרות התאימות של Office…",
+"Applying Office privacy settings…": "החלת הגדרות הפרטיות של Office…",
+"Configuring Wine graphics…": "מגדיר גרפיקה של Wine…",
+"Creating Wine environment": "יצירת סביבת Wine",
+"Creating Wine environment…": "יוצר סביבת Wine…",
+"Initializing the Wine environment…": "מאתחל את סביבת Wine…",
+"Installing Wine Gecko…": "מתקין את Wine Gecko…",
+"Installing Wine Mono…": "מתקין את Wine Mono…",
+"Recreating Wine environment": "יצירה מחדש של סביבת Wine",
+"Recreating Wine environment…": "יוצר מחדש את סביבת Wine…",
+"Removing the previous Wine environment…": "מסיר את סביבת Wine הקודמת…",
+"Restoring the previous Wine environment…": "משחזר את סביבת Wine הקודמת…",
+"Stopping the existing Wine environment…": "עוצר את סביבת Wine הקיימת…",
+"Wine environment is ready": "סביבת Wine מוכנה",
+"Wine environment is ready.": "סביבת Wine מוכנה.",
+"Wine environment operation was cancelled.": "פעולת סביבת Wine בוטלה.",
+"Wine environment operation failed. Review the details below.": "פעולת סביבת Wine נכשלה. יש לעיין בפרטים שלהלן."
 }

--- a/tools/wine4office-manager/translations/hi.json
+++ b/tools/wine4office-manager/translations/hi.json
@@ -65,5 +65,22 @@
   "Wine shutdown was interrupted.": "Wine शटडाउन बाधित हुआ.",
   "Wine tools": "Wine उपकरण",
   "Wine4Office Manager": "Wine4Office प्रबंधक",
-  "Working folder:": "कार्य फ़ोल्डर:"
+  "Working folder:": "कार्य फ़ोल्डर:",
+"Applying Office compatibility settings…": "Office संगतता सेटिंग लागू की जा रही हैं…",
+"Applying Office privacy settings…": "Office गोपनीयता सेटिंग लागू की जा रही हैं…",
+"Configuring Wine graphics…": "Wine ग्राफ़िक्स कॉन्फ़िगर किए जा रहे हैं…",
+"Creating Wine environment": "Wine वातावरण बनाएँ",
+"Creating Wine environment…": "Wine वातावरण बनाया जा रहा है…",
+"Initializing the Wine environment…": "Wine वातावरण आरंभ किया जा रहा है…",
+"Installing Wine Gecko…": "Wine Gecko इंस्टॉल किया जा रहा है…",
+"Installing Wine Mono…": "Wine Mono इंस्टॉल किया जा रहा है…",
+"Recreating Wine environment": "Wine वातावरण फिर से बनाएँ",
+"Recreating Wine environment…": "Wine वातावरण फिर से बनाया जा रहा है…",
+"Removing the previous Wine environment…": "पिछला Wine वातावरण हटाया जा रहा है…",
+"Restoring the previous Wine environment…": "पिछला Wine वातावरण पुनर्स्थापित किया जा रहा है…",
+"Stopping the existing Wine environment…": "मौजूदा Wine वातावरण रोका जा रहा है…",
+"Wine environment is ready": "Wine वातावरण तैयार है",
+"Wine environment is ready.": "Wine वातावरण तैयार है।",
+"Wine environment operation was cancelled.": "Wine वातावरण का ऑपरेशन रद्द कर दिया गया।",
+"Wine environment operation failed. Review the details below.": "Wine वातावरण का ऑपरेशन विफल हुआ। नीचे दिए गए विवरण देखें।"
 }

--- a/tools/wine4office-manager/translations/hr.json
+++ b/tools/wine4office-manager/translations/hr.json
@@ -61,5 +61,22 @@
   "Wine shutdown is finishing; the Manager will close when it completes.": "Isključivanje Wine se završava; upravitelj će se zatvoriti kada završi.",
   "Wine shutdown was interrupted.": "Isključivanje Wine je prekinuto.",
   "Wine tools": "Wine alati",
-  "Wine4Office Manager": "Wine4Office upravitelj"
+  "Wine4Office Manager": "Wine4Office upravitelj",
+"Applying Office compatibility settings…": "Primjenjuju se postavke kompatibilnosti sustava Office…",
+"Applying Office privacy settings…": "Primjenjuju se postavke privatnosti sustava Office…",
+"Configuring Wine graphics…": "Konfigurira se grafika Winea…",
+"Creating Wine environment": "Stvori okruženje Wine",
+"Creating Wine environment…": "Stvara se okruženje Wine…",
+"Initializing the Wine environment…": "Pokreće se okruženje Wine…",
+"Installing Wine Gecko…": "Instalira se Wine Gecko…",
+"Installing Wine Mono…": "Instalira se Wine Mono…",
+"Recreating Wine environment": "Ponovno stvori okruženje Wine",
+"Recreating Wine environment…": "Ponovno se stvara okruženje Wine…",
+"Removing the previous Wine environment…": "Uklanja se prethodno okruženje Wine…",
+"Restoring the previous Wine environment…": "Vraća se prethodno okruženje Wine…",
+"Stopping the existing Wine environment…": "Zaustavlja se postojeće okruženje Wine…",
+"Wine environment is ready": "Okruženje Wine je spremno",
+"Wine environment is ready.": "Okruženje Wine je spremno.",
+"Wine environment operation was cancelled.": "Operacija okruženja Wine je otkazana.",
+"Wine environment operation failed. Review the details below.": "Operacija okruženja Wine nije uspjela. Pogledajte pojedinosti u nastavku."
 }

--- a/tools/wine4office-manager/translations/hu.json
+++ b/tools/wine4office-manager/translations/hu.json
@@ -65,5 +65,22 @@
   "Wine shutdown was interrupted.": "A Wine leállítása megszakadt.",
   "Wine tools": "Wine-eszközök",
   "Wine4Office Manager": "Wine4Office-kezelő",
-  "Working folder:": "Munkamappa:"
+  "Working folder:": "Munkamappa:",
+"Applying Office compatibility settings…": "Az Office kompatibilitási beállításainak alkalmazása…",
+"Applying Office privacy settings…": "Az Office adatvédelmi beállításainak alkalmazása…",
+"Configuring Wine graphics…": "A Wine grafika beállítása…",
+"Creating Wine environment": "Wine-környezet létrehozása",
+"Creating Wine environment…": "Wine-környezet létrehozása…",
+"Initializing the Wine environment…": "Wine-környezet inicializálása…",
+"Installing Wine Gecko…": "Wine Gecko telepítése…",
+"Installing Wine Mono…": "Wine Mono telepítése…",
+"Recreating Wine environment": "Wine-környezet újbóli létrehozása",
+"Recreating Wine environment…": "Wine-környezet újbóli létrehozása…",
+"Removing the previous Wine environment…": "Az előző Wine-környezet eltávolítása…",
+"Restoring the previous Wine environment…": "Az előző Wine-környezet visszaállítása…",
+"Stopping the existing Wine environment…": "A meglévő Wine-környezet leállítása…",
+"Wine environment is ready": "A Wine-környezet kész",
+"Wine environment is ready.": "A Wine-környezet kész.",
+"Wine environment operation was cancelled.": "A Wine-környezet művelete megszakítva.",
+"Wine environment operation failed. Review the details below.": "A Wine-környezet művelete sikertelen. Tekintse meg az alábbi részleteket."
 }

--- a/tools/wine4office-manager/translations/id.json
+++ b/tools/wine4office-manager/translations/id.json
@@ -65,5 +65,22 @@
   "Wine shutdown was interrupted.": "Penonaktifan Wine terhenti.",
   "Wine tools": "Alat Wine",
   "Wine4Office Manager": "Pengelola Wine4Office",
-  "Working folder:": "Folder kerja:"
+  "Working folder:": "Folder kerja:",
+"Applying Office compatibility settings…": "Menerapkan pengaturan kompatibilitas Office…",
+"Applying Office privacy settings…": "Menerapkan pengaturan privasi Office…",
+"Configuring Wine graphics…": "Mengonfigurasi grafis Wine…",
+"Creating Wine environment": "Buat lingkungan Wine",
+"Creating Wine environment…": "Membuat lingkungan Wine…",
+"Initializing the Wine environment…": "Menginisialisasi lingkungan Wine…",
+"Installing Wine Gecko…": "Menginstal Wine Gecko…",
+"Installing Wine Mono…": "Menginstal Wine Mono…",
+"Recreating Wine environment": "Buat ulang lingkungan Wine",
+"Recreating Wine environment…": "Membuat ulang lingkungan Wine…",
+"Removing the previous Wine environment…": "Menghapus lingkungan Wine sebelumnya…",
+"Restoring the previous Wine environment…": "Memulihkan lingkungan Wine sebelumnya…",
+"Stopping the existing Wine environment…": "Menghentikan lingkungan Wine yang ada…",
+"Wine environment is ready": "Lingkungan Wine siap",
+"Wine environment is ready.": "Lingkungan Wine siap.",
+"Wine environment operation was cancelled.": "Operasi lingkungan Wine dibatalkan.",
+"Wine environment operation failed. Review the details below.": "Operasi lingkungan Wine gagal. Lihat detail di bawah."
 }

--- a/tools/wine4office-manager/translations/is.json
+++ b/tools/wine4office-manager/translations/is.json
@@ -74,9 +74,9 @@
 "Recreating Wine environment…": "Wine-umhverfi er búið til aftur…",
 "Removing the previous Wine environment…": "Fyrra Wine-umhverfi er fjarlægt…",
 "Restoring the previous Wine environment…": "Fyrra Wine-umhverfi er endurheimt…",
-"Stopping the existing Wine environment…": "Virkjað Wine-umhverfi er stöðvað…",
+"Stopping the existing Wine environment…": "Núverandi Wine-umhverfi er stöðvað…",
 "Wine environment is ready": "Wine-umhverfið er tilbúið",
 "Wine environment is ready.": "Wine-umhverfið er tilbúið.",
-"Wine environment operation was cancelled.": "Stöðvun Wine-umhverfis var hætt við.",
+"Wine environment operation was cancelled.": "Hætt var við aðgerð Wine-umhverfis.",
 "Wine environment operation failed. Review the details below.": "Aðgerð Wine-umhverfis mistókst. Skoðaðu upplýsingarnar hér að neðan."
 }

--- a/tools/wine4office-manager/translations/is.json
+++ b/tools/wine4office-manager/translations/is.json
@@ -61,5 +61,22 @@
   "Wine shutdown is finishing; the Manager will close when it completes.": "Lokun Wine er að ljúka; framkvæmdastjórinn mun loka þegar því er lokið.",
   "Wine shutdown was interrupted.": "Lokun Wine var rofin.",
   "Wine tools": "Wine-verkfæri",
-  "Wine4Office Manager": "Wine4Office-stjóri"
+  "Wine4Office Manager": "Wine4Office-stjóri",
+"Applying Office compatibility settings…": "Samhæfnisstillingar Office eru notaðar…",
+"Applying Office privacy settings…": "Persónuverndarstillingar Office eru notaðar…",
+"Configuring Wine graphics…": "Myndgæði Wine eru stillt…",
+"Creating Wine environment": "Búa til Wine-umhverfi",
+"Creating Wine environment…": "Wine-umhverfi er búið til…",
+"Initializing the Wine environment…": "Wine-umhverfi er frumstillt…",
+"Installing Wine Gecko…": "Wine Gecko er sett upp…",
+"Installing Wine Mono…": "Wine Mono er sett upp…",
+"Recreating Wine environment": "Búa til Wine-umhverfi aftur",
+"Recreating Wine environment…": "Wine-umhverfi er búið til aftur…",
+"Removing the previous Wine environment…": "Fyrra Wine-umhverfi er fjarlægt…",
+"Restoring the previous Wine environment…": "Fyrra Wine-umhverfi er endurheimt…",
+"Stopping the existing Wine environment…": "Virkjað Wine-umhverfi er stöðvað…",
+"Wine environment is ready": "Wine-umhverfið er tilbúið",
+"Wine environment is ready.": "Wine-umhverfið er tilbúið.",
+"Wine environment operation was cancelled.": "Stöðvun Wine-umhverfis var hætt við.",
+"Wine environment operation failed. Review the details below.": "Aðgerð Wine-umhverfis mistókst. Skoðaðu upplýsingarnar hér að neðan."
 }

--- a/tools/wine4office-manager/translations/it.json
+++ b/tools/wine4office-manager/translations/it.json
@@ -99,5 +99,22 @@
   "Wine shutdown was interrupted.": "L'arresto di Wine è stato interrotto.",
   "Wine tools": "Strumenti Wine",
   "Wine4Office Manager": "Gestore Wine4Office",
-  "Working folder:": "Cartella di lavoro:"
+  "Working folder:": "Cartella di lavoro:",
+"Applying Office compatibility settings…": "Applicazione delle impostazioni di compatibilità di Office…",
+"Applying Office privacy settings…": "Applicazione delle impostazioni di privacy di Office…",
+"Configuring Wine graphics…": "Configurazione della grafica di Wine…",
+"Creating Wine environment": "Creazione dell’ambiente Wine",
+"Creating Wine environment…": "Creazione dell’ambiente Wine in corso…",
+"Initializing the Wine environment…": "Inizializzazione dell’ambiente Wine…",
+"Installing Wine Gecko…": "Installazione di Wine Gecko…",
+"Installing Wine Mono…": "Installazione di Wine Mono…",
+"Recreating Wine environment": "Ricreazione dell’ambiente Wine",
+"Recreating Wine environment…": "Ricreazione dell’ambiente Wine in corso…",
+"Removing the previous Wine environment…": "Rimozione dell’ambiente Wine precedente…",
+"Restoring the previous Wine environment…": "Ripristino dell’ambiente Wine precedente…",
+"Stopping the existing Wine environment…": "Arresto dell’ambiente Wine esistente…",
+"Wine environment is ready": "L’ambiente Wine è pronto",
+"Wine environment is ready.": "L’ambiente Wine è pronto.",
+"Wine environment operation was cancelled.": "L’operazione dell’ambiente Wine è stata annullata.",
+"Wine environment operation failed. Review the details below.": "L’operazione dell’ambiente Wine non è riuscita. Consultare i dettagli sotto."
 }

--- a/tools/wine4office-manager/translations/ja.json
+++ b/tools/wine4office-manager/translations/ja.json
@@ -99,5 +99,22 @@
   "Wine shutdown was interrupted.": "Wine のシャットダウンが中断されました。",
   "Wine tools": "Wine ツール",
   "Wine4Office Manager": "Wine4Office マネージャー",
-  "Working folder:": "作業フォルダー:"
+  "Working folder:": "作業フォルダー:",
+"Applying Office compatibility settings…": "Office の互換性設定を適用中…",
+"Applying Office privacy settings…": "Office のプライバシー設定を適用中…",
+"Configuring Wine graphics…": "Wine のグラフィックを設定中…",
+"Creating Wine environment": "Wine 環境を作成",
+"Creating Wine environment…": "Wine 環境を作成中…",
+"Initializing the Wine environment…": "Wine 環境を初期化中…",
+"Installing Wine Gecko…": "Wine Gecko をインストール中…",
+"Installing Wine Mono…": "Wine Mono をインストール中…",
+"Recreating Wine environment": "Wine 環境を再作成",
+"Recreating Wine environment…": "Wine 環境を再作成中…",
+"Removing the previous Wine environment…": "以前の Wine 環境を削除中…",
+"Restoring the previous Wine environment…": "以前の Wine 環境を復元中…",
+"Stopping the existing Wine environment…": "既存の Wine 環境を停止中…",
+"Wine environment is ready": "Wine 環境の準備が完了しました",
+"Wine environment is ready.": "Wine 環境の準備が完了しました。",
+"Wine environment operation was cancelled.": "Wine 環境の操作はキャンセルされました。",
+"Wine environment operation failed. Review the details below.": "Wine 環境の操作に失敗しました。以下の詳細を確認してください。"
 }

--- a/tools/wine4office-manager/translations/ko.json
+++ b/tools/wine4office-manager/translations/ko.json
@@ -99,5 +99,22 @@
   "Wine shutdown was interrupted.": "Wine 종료가 중단되었습니다.",
   "Wine tools": "Wine 도구",
   "Wine4Office Manager": "Wine4Office 관리자",
-  "Working folder:": "작업 폴더:"
+  "Working folder:": "작업 폴더:",
+"Applying Office compatibility settings…": "Office 호환성 설정 적용 중…",
+"Applying Office privacy settings…": "Office 개인정보 설정 적용 중…",
+"Configuring Wine graphics…": "Wine 그래픽 구성 중…",
+"Creating Wine environment": "Wine 환경 만들기",
+"Creating Wine environment…": "Wine 환경 만드는 중…",
+"Initializing the Wine environment…": "Wine 환경 초기화 중…",
+"Installing Wine Gecko…": "Wine Gecko 설치 중…",
+"Installing Wine Mono…": "Wine Mono 설치 중…",
+"Recreating Wine environment": "Wine 환경 다시 만들기",
+"Recreating Wine environment…": "Wine 환경 다시 만드는 중…",
+"Removing the previous Wine environment…": "이전 Wine 환경 제거 중…",
+"Restoring the previous Wine environment…": "이전 Wine 환경 복원 중…",
+"Stopping the existing Wine environment…": "기존 Wine 환경 중지 중…",
+"Wine environment is ready": "Wine 환경이 준비되었습니다",
+"Wine environment is ready.": "Wine 환경이 준비되었습니다.",
+"Wine environment operation was cancelled.": "Wine 환경 작업이 취소되었습니다.",
+"Wine environment operation failed. Review the details below.": "Wine 환경 작업에 실패했습니다. 아래 세부 정보를 확인하세요."
 }

--- a/tools/wine4office-manager/translations/lt.json
+++ b/tools/wine4office-manager/translations/lt.json
@@ -61,5 +61,22 @@
   "Wine shutdown is finishing; the Manager will close when it completes.": "Wine išjungimas baigiamas; vadybininkas užsidarys, kai jis bus baigtas.",
   "Wine shutdown was interrupted.": "Wine išjungimas buvo nutrauktas.",
   "Wine tools": "Wine įrankiai",
-  "Wine4Office Manager": "Wine4Office tvarkytuvė"
+  "Wine4Office Manager": "Wine4Office tvarkytuvė",
+"Applying Office compatibility settings…": "Taikomi Office suderinamumo nustatymai…",
+"Applying Office privacy settings…": "Taikomi Office privatumo nustatymai…",
+"Configuring Wine graphics…": "Konfigūruojama Wine grafika…",
+"Creating Wine environment": "Sukurti Wine aplinką",
+"Creating Wine environment…": "Kuriama Wine aplinka…",
+"Initializing the Wine environment…": "Inicializuojama Wine aplinka…",
+"Installing Wine Gecko…": "Diegiamas Wine Gecko…",
+"Installing Wine Mono…": "Diegiamas Wine Mono…",
+"Recreating Wine environment": "Kurti Wine aplinką iš naujo",
+"Recreating Wine environment…": "Iš naujo kuriama Wine aplinka…",
+"Removing the previous Wine environment…": "Šalinama ankstesnė Wine aplinka…",
+"Restoring the previous Wine environment…": "Atkuriama ankstesnė Wine aplinka…",
+"Stopping the existing Wine environment…": "Stabdoma esama Wine aplinka…",
+"Wine environment is ready": "Wine aplinka paruošta",
+"Wine environment is ready.": "Wine aplinka paruošta.",
+"Wine environment operation was cancelled.": "Wine aplinkos operacija atšaukta.",
+"Wine environment operation failed. Review the details below.": "Wine aplinkos operacija nepavyko. Peržiūrėkite toliau pateiktą informaciją."
 }

--- a/tools/wine4office-manager/translations/lv.json
+++ b/tools/wine4office-manager/translations/lv.json
@@ -61,5 +61,22 @@
   "Wine shutdown is finishing; the Manager will close when it completes.": "Wine izslēgšana tiek pabeigta; pārvaldnieks tiks aizvērts, kad tas būs pabeigts.",
   "Wine shutdown was interrupted.": "Wine izslēgšana tika pārtraukta.",
   "Wine tools": "Wine rīki",
-  "Wine4Office Manager": "Wine4Office pārvaldnieks"
+  "Wine4Office Manager": "Wine4Office pārvaldnieks",
+"Applying Office compatibility settings…": "Tiek lietoti Office saderības iestatījumi…",
+"Applying Office privacy settings…": "Tiek lietoti Office konfidencialitātes iestatījumi…",
+"Configuring Wine graphics…": "Tiek konfigurēta Wine grafika…",
+"Creating Wine environment": "Izveidot Wine vidi",
+"Creating Wine environment…": "Wine vide tiek izveidota…",
+"Initializing the Wine environment…": "Wine vide tiek inicializēta…",
+"Installing Wine Gecko…": "Wine Gecko tiek instalēts…",
+"Installing Wine Mono…": "Wine Mono tiek instalēts…",
+"Recreating Wine environment": "Atkārtoti izveidot Wine vidi",
+"Recreating Wine environment…": "Wine vide tiek izveidota atkārtoti…",
+"Removing the previous Wine environment…": "Iepriekšējā Wine vide tiek noņemta…",
+"Restoring the previous Wine environment…": "Iepriekšējā Wine vide tiek atjaunota…",
+"Stopping the existing Wine environment…": "Esošā Wine vide tiek apturēta…",
+"Wine environment is ready": "Wine vide ir gatava",
+"Wine environment is ready.": "Wine vide ir gatava.",
+"Wine environment operation was cancelled.": "Wine vides darbība tika atcelta.",
+"Wine environment operation failed. Review the details below.": "Wine vides darbība neizdevās. Skatiet tālāk sniegto informāciju."
 }

--- a/tools/wine4office-manager/translations/mr.json
+++ b/tools/wine4office-manager/translations/mr.json
@@ -61,5 +61,22 @@
   "Wine shutdown is finishing; the Manager will close when it completes.": "Wine शटडाउन पूर्ण होत आहे; ते पूर्ण झाल्यावर व्यवस्थापक बंद होईल.",
   "Wine shutdown was interrupted.": "Wine बंद करण्यात व्यत्यय आला.",
   "Wine tools": "Wine साधने",
-  "Wine4Office Manager": "Wine4Office व्यवस्थापक"
+  "Wine4Office Manager": "Wine4Office व्यवस्थापक",
+"Applying Office compatibility settings…": "Office सुसंगतता सेटिंग्ज लागू करत आहे…",
+"Applying Office privacy settings…": "Office गोपनीयता सेटिंग्ज लागू करत आहे…",
+"Configuring Wine graphics…": "Wine ग्राफिक्स कॉन्फिगर करत आहे…",
+"Creating Wine environment": "Wine वातावरण तयार करा",
+"Creating Wine environment…": "Wine वातावरण तयार करत आहे…",
+"Initializing the Wine environment…": "Wine वातावरण सुरू करत आहे…",
+"Installing Wine Gecko…": "Wine Gecko इंस्टॉल करत आहे…",
+"Installing Wine Mono…": "Wine Mono इंस्टॉल करत आहे…",
+"Recreating Wine environment": "Wine वातावरण पुन्हा तयार करा",
+"Recreating Wine environment…": "Wine वातावरण पुन्हा तयार करत आहे…",
+"Removing the previous Wine environment…": "मागील Wine वातावरण काढत आहे…",
+"Restoring the previous Wine environment…": "मागील Wine वातावरण पुनर्संचयित करत आहे…",
+"Stopping the existing Wine environment…": "विद्यमान Wine वातावरण थांबवत आहे…",
+"Wine environment is ready": "Wine वातावरण तयार आहे",
+"Wine environment is ready.": "Wine वातावरण तयार आहे.",
+"Wine environment operation was cancelled.": "Wine वातावरणाचे ऑपरेशन रद्द केले.",
+"Wine environment operation failed. Review the details below.": "Wine वातावरणाचे ऑपरेशन अयशस्वी झाले. खालील तपशील पाहा."
 }

--- a/tools/wine4office-manager/translations/ms.json
+++ b/tools/wine4office-manager/translations/ms.json
@@ -61,5 +61,22 @@
   "Wine shutdown is finishing; the Manager will close when it completes.": "Wine penutupan sedang tamat; Pengurus akan ditutup apabila ia selesai.",
   "Wine shutdown was interrupted.": "Wine penutupan telah terganggu.",
   "Wine tools": "Alat Wine",
-  "Wine4Office Manager": "Pengurus Wine4Office"
+  "Wine4Office Manager": "Pengurus Wine4Office",
+"Applying Office compatibility settings…": "Sedang menggunakan tetapan keserasian Office…",
+"Applying Office privacy settings…": "Sedang menggunakan tetapan privasi Office…",
+"Configuring Wine graphics…": "Sedang mengkonfigurasi grafik Wine…",
+"Creating Wine environment": "Cipta persekitaran Wine",
+"Creating Wine environment…": "Sedang mencipta persekitaran Wine…",
+"Initializing the Wine environment…": "Sedang memulakan persekitaran Wine…",
+"Installing Wine Gecko…": "Sedang memasang Wine Gecko…",
+"Installing Wine Mono…": "Sedang memasang Wine Mono…",
+"Recreating Wine environment": "Cipta semula persekitaran Wine",
+"Recreating Wine environment…": "Sedang mencipta semula persekitaran Wine…",
+"Removing the previous Wine environment…": "Sedang mengalih keluar persekitaran Wine sebelumnya…",
+"Restoring the previous Wine environment…": "Sedang memulihkan persekitaran Wine sebelumnya…",
+"Stopping the existing Wine environment…": "Sedang menghentikan persekitaran Wine sedia ada…",
+"Wine environment is ready": "Persekitaran Wine sudah sedia",
+"Wine environment is ready.": "Persekitaran Wine sudah sedia.",
+"Wine environment operation was cancelled.": "Operasi persekitaran Wine dibatalkan.",
+"Wine environment operation failed. Review the details below.": "Operasi persekitaran Wine gagal. Semak butiran di bawah."
 }

--- a/tools/wine4office-manager/translations/nb.json
+++ b/tools/wine4office-manager/translations/nb.json
@@ -65,5 +65,22 @@
   "Wine shutdown was interrupted.": "Wine nedleggelse ble avbrutt.",
   "Wine tools": "Wine-verktøy",
   "Wine4Office Manager": "Wine4Office-behandling",
-  "Working folder:": "Arbeidsmappe:"
+  "Working folder:": "Arbeidsmappe:",
+"Applying Office compatibility settings…": "Bruker kompatibilitetsinnstillinger for Office…",
+"Applying Office privacy settings…": "Bruker personverninnstillinger for Office…",
+"Configuring Wine graphics…": "Konfigurerer Wine-grafikk…",
+"Creating Wine environment": "Opprett Wine-miljø",
+"Creating Wine environment…": "Oppretter Wine-miljø…",
+"Initializing the Wine environment…": "Initialiserer Wine-miljø…",
+"Installing Wine Gecko…": "Installerer Wine Gecko…",
+"Installing Wine Mono…": "Installerer Wine Mono…",
+"Recreating Wine environment": "Opprett Wine-miljø på nytt",
+"Recreating Wine environment…": "Oppretter Wine-miljø på nytt…",
+"Removing the previous Wine environment…": "Fjerner det forrige Wine-miljøet…",
+"Restoring the previous Wine environment…": "Gjenoppretter det forrige Wine-miljøet…",
+"Stopping the existing Wine environment…": "Stopper det eksisterende Wine-miljøet…",
+"Wine environment is ready": "Wine-miljøet er klart",
+"Wine environment is ready.": "Wine-miljøet er klart.",
+"Wine environment operation was cancelled.": "Handlingen for Wine-miljøet ble avbrutt.",
+"Wine environment operation failed. Review the details below.": "Handlingen for Wine-miljøet mislyktes. Se detaljene nedenfor."
 }

--- a/tools/wine4office-manager/translations/nl.json
+++ b/tools/wine4office-manager/translations/nl.json
@@ -99,5 +99,22 @@
   "Wine shutdown was interrupted.": "Het afsluiten van Wine is onderbroken.",
   "Wine tools": "Wine-hulpmiddelen",
   "Wine4Office Manager": "Wine4Office-beheer",
-  "Working folder:": "Werkmap:"
+  "Working folder:": "Werkmap:",
+"Applying Office compatibility settings…": "Office-compatibiliteitsinstellingen worden toegepast…",
+"Applying Office privacy settings…": "Office-privacy-instellingen worden toegepast…",
+"Configuring Wine graphics…": "Wine-graphics worden geconfigureerd…",
+"Creating Wine environment": "Wine-omgeving maken",
+"Creating Wine environment…": "Wine-omgeving wordt gemaakt…",
+"Initializing the Wine environment…": "Wine-omgeving wordt geïnitialiseerd…",
+"Installing Wine Gecko…": "Wine Gecko wordt geïnstalleerd…",
+"Installing Wine Mono…": "Wine Mono wordt geïnstalleerd…",
+"Recreating Wine environment": "Wine-omgeving opnieuw maken",
+"Recreating Wine environment…": "Wine-omgeving wordt opnieuw gemaakt…",
+"Removing the previous Wine environment…": "Vorige Wine-omgeving wordt verwijderd…",
+"Restoring the previous Wine environment…": "Vorige Wine-omgeving wordt hersteld…",
+"Stopping the existing Wine environment…": "Bestaande Wine-omgeving wordt gestopt…",
+"Wine environment is ready": "Wine-omgeving is gereed",
+"Wine environment is ready.": "Wine-omgeving is gereed.",
+"Wine environment operation was cancelled.": "De bewerking van de Wine-omgeving is geannuleerd.",
+"Wine environment operation failed. Review the details below.": "De bewerking van de Wine-omgeving is mislukt. Bekijk de details hieronder."
 }

--- a/tools/wine4office-manager/translations/pl.json
+++ b/tools/wine4office-manager/translations/pl.json
@@ -99,5 +99,22 @@
   "Wine shutdown was interrupted.": "Zamknięcie Wine zostało przerwane.",
   "Wine tools": "Narzędzia Wine",
   "Wine4Office Manager": "Menedżer Wine4Office",
-  "Working folder:": "Folder roboczy:"
+  "Working folder:": "Folder roboczy:",
+"Applying Office compatibility settings…": "Stosowanie ustawień zgodności pakietu Office…",
+"Applying Office privacy settings…": "Stosowanie ustawień prywatności pakietu Office…",
+"Configuring Wine graphics…": "Konfigurowanie grafiki Wine…",
+"Creating Wine environment": "Utwórz środowisko Wine",
+"Creating Wine environment…": "Tworzenie środowiska Wine…",
+"Initializing the Wine environment…": "Inicjowanie środowiska Wine…",
+"Installing Wine Gecko…": "Instalowanie Wine Gecko…",
+"Installing Wine Mono…": "Instalowanie Wine Mono…",
+"Recreating Wine environment": "Utwórz ponownie środowisko Wine",
+"Recreating Wine environment…": "Ponowne tworzenie środowiska Wine…",
+"Removing the previous Wine environment…": "Usuwanie poprzedniego środowiska Wine…",
+"Restoring the previous Wine environment…": "Przywracanie poprzedniego środowiska Wine…",
+"Stopping the existing Wine environment…": "Zatrzymywanie istniejącego środowiska Wine…",
+"Wine environment is ready": "Środowisko Wine jest gotowe",
+"Wine environment is ready.": "Środowisko Wine jest gotowe.",
+"Wine environment operation was cancelled.": "Operacja środowiska Wine została anulowana.",
+"Wine environment operation failed. Review the details below.": "Operacja środowiska Wine nie powiodła się. Zapoznaj się ze szczegółami poniżej."
 }

--- a/tools/wine4office-manager/translations/pt.json
+++ b/tools/wine4office-manager/translations/pt.json
@@ -99,5 +99,22 @@
   "Wine shutdown was interrupted.": "O desligamento de Wine foi interrompido.",
   "Wine tools": "Ferramentas do Wine",
   "Wine4Office Manager": "Gerenciador Wine4Office",
-  "Working folder:": "Pasta de trabalho:"
+  "Working folder:": "Pasta de trabalho:",
+"Applying Office compatibility settings…": "Aplicando as configurações de compatibilidade do Office…",
+"Applying Office privacy settings…": "Aplicando as configurações de privacidade do Office…",
+"Configuring Wine graphics…": "Configurando os gráficos do Wine…",
+"Creating Wine environment": "Criar ambiente Wine",
+"Creating Wine environment…": "Criando ambiente Wine…",
+"Initializing the Wine environment…": "Inicializando o ambiente Wine…",
+"Installing Wine Gecko…": "Instalando o Wine Gecko…",
+"Installing Wine Mono…": "Instalando o Wine Mono…",
+"Recreating Wine environment": "Recriar ambiente Wine",
+"Recreating Wine environment…": "Recriando o ambiente Wine…",
+"Removing the previous Wine environment…": "Removendo o ambiente Wine anterior…",
+"Restoring the previous Wine environment…": "Restaurando o ambiente Wine anterior…",
+"Stopping the existing Wine environment…": "Parando o ambiente Wine existente…",
+"Wine environment is ready": "O ambiente Wine está pronto",
+"Wine environment is ready.": "O ambiente Wine está pronto.",
+"Wine environment operation was cancelled.": "A operação do ambiente Wine foi cancelada.",
+"Wine environment operation failed. Review the details below.": "A operação do ambiente Wine falhou. Consulte os detalhes abaixo."
 }

--- a/tools/wine4office-manager/translations/ro.json
+++ b/tools/wine4office-manager/translations/ro.json
@@ -65,5 +65,22 @@
   "Wine shutdown was interrupted.": "Închiderea Wine a fost întreruptă.",
   "Wine tools": "Instrumente Wine",
   "Wine4Office Manager": "Manager Wine4Office",
-  "Working folder:": "Dosar de lucru:"
+  "Working folder:": "Dosar de lucru:",
+"Applying Office compatibility settings…": "Se aplică setările de compatibilitate Office…",
+"Applying Office privacy settings…": "Se aplică setările de confidențialitate Office…",
+"Configuring Wine graphics…": "Se configurează grafica Wine…",
+"Creating Wine environment": "Creează mediul Wine",
+"Creating Wine environment…": "Se creează mediul Wine…",
+"Initializing the Wine environment…": "Se inițializează mediul Wine…",
+"Installing Wine Gecko…": "Se instalează Wine Gecko…",
+"Installing Wine Mono…": "Se instalează Wine Mono…",
+"Recreating Wine environment": "Recreează mediul Wine",
+"Recreating Wine environment…": "Se recreează mediul Wine…",
+"Removing the previous Wine environment…": "Se elimină mediul Wine anterior…",
+"Restoring the previous Wine environment…": "Se restaurează mediul Wine anterior…",
+"Stopping the existing Wine environment…": "Se oprește mediul Wine existent…",
+"Wine environment is ready": "Mediul Wine este gata",
+"Wine environment is ready.": "Mediul Wine este gata.",
+"Wine environment operation was cancelled.": "Operația mediului Wine a fost anulată.",
+"Wine environment operation failed. Review the details below.": "Operația mediului Wine a eșuat. Consultați detaliile de mai jos."
 }

--- a/tools/wine4office-manager/translations/ru.json
+++ b/tools/wine4office-manager/translations/ru.json
@@ -99,5 +99,22 @@
   "Wine shutdown was interrupted.": "Выключение Wine было прервано.",
   "Wine tools": "Инструменты Wine",
   "Wine4Office Manager": "Менеджер Wine4Office",
-  "Working folder:": "Рабочая папка:"
+  "Working folder:": "Рабочая папка:",
+"Applying Office compatibility settings…": "Применяются параметры совместимости Office…",
+"Applying Office privacy settings…": "Применяются параметры конфиденциальности Office…",
+"Configuring Wine graphics…": "Настраивается графика Wine…",
+"Creating Wine environment": "Создание среды Wine",
+"Creating Wine environment…": "Создаётся среда Wine…",
+"Initializing the Wine environment…": "Инициализируется среда Wine…",
+"Installing Wine Gecko…": "Устанавливается Wine Gecko…",
+"Installing Wine Mono…": "Устанавливается Wine Mono…",
+"Recreating Wine environment": "Пересоздание среды Wine",
+"Recreating Wine environment…": "Пересоздаётся среда Wine…",
+"Removing the previous Wine environment…": "Удаляется предыдущая среда Wine…",
+"Restoring the previous Wine environment…": "Восстанавливается предыдущая среда Wine…",
+"Stopping the existing Wine environment…": "Останавливается существующая среда Wine…",
+"Wine environment is ready": "Среда Wine готова",
+"Wine environment is ready.": "Среда Wine готова.",
+"Wine environment operation was cancelled.": "Операция со средой Wine отменена.",
+"Wine environment operation failed. Review the details below.": "Операция со средой Wine завершилась ошибкой. См. подробности ниже."
 }

--- a/tools/wine4office-manager/translations/sk.json
+++ b/tools/wine4office-manager/translations/sk.json
@@ -65,5 +65,22 @@
   "Wine shutdown was interrupted.": "Vypnutie Wine bolo prerušené.",
   "Wine tools": "Nástroje Wine",
   "Wine4Office Manager": "Správca Wine4Office",
-  "Working folder:": "Pracovný priečinok:"
+  "Working folder:": "Pracovný priečinok:",
+"Applying Office compatibility settings…": "Používajú sa nastavenia kompatibility Office…",
+"Applying Office privacy settings…": "Používajú sa nastavenia súkromia Office…",
+"Configuring Wine graphics…": "Konfiguruje sa grafika Wine…",
+"Creating Wine environment": "Vytvoriť prostredie Wine",
+"Creating Wine environment…": "Vytvára sa prostredie Wine…",
+"Initializing the Wine environment…": "Inicializuje sa prostredie Wine…",
+"Installing Wine Gecko…": "Inštaluje sa Wine Gecko…",
+"Installing Wine Mono…": "Inštaluje sa Wine Mono…",
+"Recreating Wine environment": "Znova vytvoriť prostredie Wine",
+"Recreating Wine environment…": "Znova sa vytvára prostredie Wine…",
+"Removing the previous Wine environment…": "Odstraňuje sa predchádzajúce prostredie Wine…",
+"Restoring the previous Wine environment…": "Obnovuje sa predchádzajúce prostredie Wine…",
+"Stopping the existing Wine environment…": "Zastavuje sa existujúce prostredie Wine…",
+"Wine environment is ready": "Prostredie Wine je pripravené",
+"Wine environment is ready.": "Prostredie Wine je pripravené.",
+"Wine environment operation was cancelled.": "Operácia prostredia Wine bola zrušená.",
+"Wine environment operation failed. Review the details below.": "Operácia prostredia Wine zlyhala. Podrobnosti nájdete nižšie."
 }

--- a/tools/wine4office-manager/translations/sl.json
+++ b/tools/wine4office-manager/translations/sl.json
@@ -61,5 +61,22 @@
   "Wine shutdown is finishing; the Manager will close when it completes.": "Zaustavitev Wine se končuje; upravitelj se bo zaprl, ko bo končan.",
   "Wine shutdown was interrupted.": "Zaustavitev Wine je bila prekinjena.",
   "Wine tools": "Orodja Wine",
-  "Wine4Office Manager": "Upravljalnik Wine4Office"
+  "Wine4Office Manager": "Upravljalnik Wine4Office",
+"Applying Office compatibility settings…": "Uporabljajo se nastavitve združljivosti za Office…",
+"Applying Office privacy settings…": "Uporabljajo se nastavitve zasebnosti za Office…",
+"Configuring Wine graphics…": "Konfigurira se grafika Wine…",
+"Creating Wine environment": "Ustvari okolje Wine",
+"Creating Wine environment…": "Ustvarjanje okolja Wine…",
+"Initializing the Wine environment…": "Inicializacija okolja Wine…",
+"Installing Wine Gecko…": "Nameščanje Wine Gecko…",
+"Installing Wine Mono…": "Nameščanje Wine Mono…",
+"Recreating Wine environment": "Znova ustvari okolje Wine",
+"Recreating Wine environment…": "Znova se ustvarja okolje Wine…",
+"Removing the previous Wine environment…": "Odstranjevanje prejšnjega okolja Wine…",
+"Restoring the previous Wine environment…": "Obnavljanje prejšnjega okolja Wine…",
+"Stopping the existing Wine environment…": "Ustavljanje obstoječega okolja Wine…",
+"Wine environment is ready": "Okolje Wine je pripravljeno",
+"Wine environment is ready.": "Okolje Wine je pripravljeno.",
+"Wine environment operation was cancelled.": "Operacija okolja Wine je bila preklicana.",
+"Wine environment operation failed. Review the details below.": "Operacija okolja Wine ni uspela. Oglejte si podrobnosti spodaj."
 }

--- a/tools/wine4office-manager/translations/sr_Latn.json
+++ b/tools/wine4office-manager/translations/sr_Latn.json
@@ -61,5 +61,22 @@
   "Wine shutdown is finishing; the Manager will close when it completes.": "Isključivanje Wine se završava; Menadžer će se zatvoriti kada završi.",
   "Wine shutdown was interrupted.": "Isključivanje Wine je prekinuto.",
   "Wine tools": "Wine alati",
-  "Wine4Office Manager": "Wine4Office upravljač"
+  "Wine4Office Manager": "Wine4Office upravljač",
+"Applying Office compatibility settings…": "Primena postavki kompatibilnosti sistema Office…",
+"Applying Office privacy settings…": "Primena postavki privatnosti sistema Office…",
+"Configuring Wine graphics…": "Konfigurisanje Wine grafike…",
+"Creating Wine environment": "Kreiraj Wine okruženje",
+"Creating Wine environment…": "Kreiranje Wine okruženja…",
+"Initializing the Wine environment…": "Pokretanje Wine okruženja…",
+"Installing Wine Gecko…": "Instaliranje Wine Gecko…",
+"Installing Wine Mono…": "Instaliranje Wine Mono…",
+"Recreating Wine environment": "Ponovo kreiraj Wine okruženje",
+"Recreating Wine environment…": "Ponovno kreiranje Wine okruženja…",
+"Removing the previous Wine environment…": "Uklanjanje prethodnog Wine okruženja…",
+"Restoring the previous Wine environment…": "Vraćanje prethodnog Wine okruženja…",
+"Stopping the existing Wine environment…": "Zaustavljanje postojećeg Wine okruženja…",
+"Wine environment is ready": "Wine okruženje je spremno",
+"Wine environment is ready.": "Wine okruženje je spremno.",
+"Wine environment operation was cancelled.": "Operacija Wine okruženja je otkazana.",
+"Wine environment operation failed. Review the details below.": "Operacija Wine okruženja nije uspela. Pogledajte detalje u nastavku."
 }

--- a/tools/wine4office-manager/translations/sv.json
+++ b/tools/wine4office-manager/translations/sv.json
@@ -65,5 +65,22 @@
   "Wine shutdown was interrupted.": "Wine avstängning avbröts.",
   "Wine tools": "Wine-verktyg",
   "Wine4Office Manager": "Wine4Office-hanterare",
-  "Working folder:": "Arbetsmapp:"
+  "Working folder:": "Arbetsmapp:",
+"Applying Office compatibility settings…": "Tillämpar kompatibilitetsinställningar för Office…",
+"Applying Office privacy settings…": "Tillämpar sekretessinställningar för Office…",
+"Configuring Wine graphics…": "Konfigurerar Wine-grafik…",
+"Creating Wine environment": "Skapa Wine-miljö",
+"Creating Wine environment…": "Skapar Wine-miljö…",
+"Initializing the Wine environment…": "Initierar Wine-miljö…",
+"Installing Wine Gecko…": "Installerar Wine Gecko…",
+"Installing Wine Mono…": "Installerar Wine Mono…",
+"Recreating Wine environment": "Skapa om Wine-miljö",
+"Recreating Wine environment…": "Skapar om Wine-miljö…",
+"Removing the previous Wine environment…": "Tar bort den tidigare Wine-miljön…",
+"Restoring the previous Wine environment…": "Återställer den tidigare Wine-miljön…",
+"Stopping the existing Wine environment…": "Stoppar den befintliga Wine-miljön…",
+"Wine environment is ready": "Wine-miljön är klar",
+"Wine environment is ready.": "Wine-miljön är klar.",
+"Wine environment operation was cancelled.": "Åtgärden för Wine-miljön avbröts.",
+"Wine environment operation failed. Review the details below.": "Åtgärden för Wine-miljön misslyckades. Läs informationen nedan."
 }

--- a/tools/wine4office-manager/translations/ta.json
+++ b/tools/wine4office-manager/translations/ta.json
@@ -61,5 +61,22 @@
   "Wine shutdown is finishing; the Manager will close when it completes.": "Wine பணிநிறுத்தம் முடிவடைகிறது; அது முடிந்ததும் மேலாளர் மூடுவார்.",
   "Wine shutdown was interrupted.": "Wine பணிநிறுத்தம் தடைபட்டது.",
   "Wine tools": "Wine கருவிகள்",
-  "Wine4Office Manager": "Wine4Office மேலாளர்"
+  "Wine4Office Manager": "Wine4Office மேலாளர்",
+"Applying Office compatibility settings…": "Office இணக்க அமைப்புகள் பயன்படுத்தப்படுகின்றன…",
+"Applying Office privacy settings…": "Office தனியுரிமை அமைப்புகள் பயன்படுத்தப்படுகின்றன…",
+"Configuring Wine graphics…": "Wine வரைகலை அமைக்கப்படுகிறது…",
+"Creating Wine environment": "Wine சூழலை உருவாக்கு",
+"Creating Wine environment…": "Wine சூழல் உருவாக்கப்படுகிறது…",
+"Initializing the Wine environment…": "Wine சூழல் தொடங்கப்படுகிறது…",
+"Installing Wine Gecko…": "Wine Gecko நிறுவப்படுகிறது…",
+"Installing Wine Mono…": "Wine Mono நிறுவப்படுகிறது…",
+"Recreating Wine environment": "Wine சூழலை மீண்டும் உருவாக்கு",
+"Recreating Wine environment…": "Wine சூழல் மீண்டும் உருவாக்கப்படுகிறது…",
+"Removing the previous Wine environment…": "முந்தைய Wine சூழல் அகற்றப்படுகிறது…",
+"Restoring the previous Wine environment…": "முந்தைய Wine சூழல் மீட்டமைக்கப்படுகிறது…",
+"Stopping the existing Wine environment…": "ஏற்கனவே உள்ள Wine சூழல் நிறுத்தப்படுகிறது…",
+"Wine environment is ready": "Wine சூழல் தயாராக உள்ளது",
+"Wine environment is ready.": "Wine சூழல் தயாராக உள்ளது.",
+"Wine environment operation was cancelled.": "Wine சூழல் செயல்பாடு ரத்து செய்யப்பட்டது.",
+"Wine environment operation failed. Review the details below.": "Wine சூழல் செயல்பாடு தோல்வியடைந்தது. கீழே உள்ள விவரங்களைப் பார்க்கவும்."
 }

--- a/tools/wine4office-manager/translations/te.json
+++ b/tools/wine4office-manager/translations/te.json
@@ -61,5 +61,22 @@
   "Wine shutdown is finishing; the Manager will close when it completes.": "Wine షట్‌డౌన్ ముగుస్తోంది; అది పూర్తయినప్పుడు మేనేజర్ మూసివేస్తారు.",
   "Wine shutdown was interrupted.": "Wine షట్‌డౌన్‌కు అంతరాయం కలిగింది.",
   "Wine tools": "Wine సాధనాలు",
-  "Wine4Office Manager": "Wine4Office నిర్వాహకం"
+  "Wine4Office Manager": "Wine4Office నిర్వాహకం",
+"Applying Office compatibility settings…": "Office అనుకూలత సెట్టింగ్‌లు వర్తింపజేయబడుతున్నాయి…",
+"Applying Office privacy settings…": "Office గోప్యతా సెట్టింగ్‌లు వర్తింపజేయబడుతున్నాయి…",
+"Configuring Wine graphics…": "Wine గ్రాఫిక్స్ కాన్ఫిగర్ చేయబడుతున్నాయి…",
+"Creating Wine environment": "Wine వాతావరణాన్ని సృష్టించండి",
+"Creating Wine environment…": "Wine వాతావరణం సృష్టించబడుతోంది…",
+"Initializing the Wine environment…": "Wine వాతావరణం ప్రారంభించబడుతోంది…",
+"Installing Wine Gecko…": "Wine Gecko ఇన్‌స్టాల్ చేయబడుతోంది…",
+"Installing Wine Mono…": "Wine Mono ఇన్‌స్టాల్ చేయబడుతోంది…",
+"Recreating Wine environment": "Wine వాతావరణాన్ని మళ్లీ సృష్టించండి",
+"Recreating Wine environment…": "Wine వాతావరణం మళ్లీ సృష్టించబడుతోంది…",
+"Removing the previous Wine environment…": "మునుపటి Wine వాతావరణం తొలగించబడుతోంది…",
+"Restoring the previous Wine environment…": "మునుపటి Wine వాతావరణం పునరుద్ధరించబడుతోంది…",
+"Stopping the existing Wine environment…": "ఇప్పటికే ఉన్న Wine వాతావరణం ఆపబడుతోంది…",
+"Wine environment is ready": "Wine వాతావరణం సిద్ధంగా ఉంది",
+"Wine environment is ready.": "Wine వాతావరణం సిద్ధంగా ఉంది.",
+"Wine environment operation was cancelled.": "Wine వాతావరణం ఆపరేషన్ రద్దు చేయబడింది.",
+"Wine environment operation failed. Review the details below.": "Wine వాతావరణం ఆపరేషన్ విఫలమైంది. దిగువ వివరాలను చూడండి."
 }

--- a/tools/wine4office-manager/translations/th.json
+++ b/tools/wine4office-manager/translations/th.json
@@ -65,5 +65,22 @@
   "Wine shutdown was interrupted.": "การปิดระบบ Wine ถูกขัดจังหวะ",
   "Wine tools": "เครื่องมือ Wine",
   "Wine4Office Manager": "ตัวจัดการ Wine4Office",
-  "Working folder:": "โฟลเดอร์ทำงาน:"
+  "Working folder:": "โฟลเดอร์ทำงาน:",
+"Applying Office compatibility settings…": "กำลังใช้การตั้งค่าความเข้ากันได้ของ Office…",
+"Applying Office privacy settings…": "กำลังใช้การตั้งค่าความเป็นส่วนตัวของ Office…",
+"Configuring Wine graphics…": "กำลังกำหนดค่ากราฟิกของ Wine…",
+"Creating Wine environment": "สร้างสภาพแวดล้อม Wine",
+"Creating Wine environment…": "กำลังสร้างสภาพแวดล้อม Wine…",
+"Initializing the Wine environment…": "กำลังเริ่มต้นสภาพแวดล้อม Wine…",
+"Installing Wine Gecko…": "กำลังติดตั้ง Wine Gecko…",
+"Installing Wine Mono…": "กำลังติดตั้ง Wine Mono…",
+"Recreating Wine environment": "สร้างสภาพแวดล้อม Wine ใหม่",
+"Recreating Wine environment…": "กำลังสร้างสภาพแวดล้อม Wine ใหม่…",
+"Removing the previous Wine environment…": "กำลังลบสภาพแวดล้อม Wine ก่อนหน้า…",
+"Restoring the previous Wine environment…": "กำลังกู้คืนสภาพแวดล้อม Wine ก่อนหน้า…",
+"Stopping the existing Wine environment…": "กำลังหยุดสภาพแวดล้อม Wine ที่มีอยู่…",
+"Wine environment is ready": "สภาพแวดล้อม Wine พร้อมแล้ว",
+"Wine environment is ready.": "สภาพแวดล้อม Wine พร้อมแล้ว",
+"Wine environment operation was cancelled.": "ยกเลิกการดำเนินการสภาพแวดล้อม Wine แล้ว",
+"Wine environment operation failed. Review the details below.": "การดำเนินการสภาพแวดล้อม Wine ล้มเหลว โปรดดูรายละเอียดด้านล่าง"
 }

--- a/tools/wine4office-manager/translations/tr.json
+++ b/tools/wine4office-manager/translations/tr.json
@@ -99,5 +99,22 @@
   "Wine shutdown was interrupted.": "Wine'ın kapatılması kesintiye uğradı.",
   "Wine tools": "Wine araçları",
   "Wine4Office Manager": "Wine4Office Yöneticisi",
-  "Working folder:": "Çalışma klasörü:"
+  "Working folder:": "Çalışma klasörü:",
+"Applying Office compatibility settings…": "Office uyumluluk ayarları uygulanıyor…",
+"Applying Office privacy settings…": "Office gizlilik ayarları uygulanıyor…",
+"Configuring Wine graphics…": "Wine grafikleri yapılandırılıyor…",
+"Creating Wine environment": "Wine ortamı oluştur",
+"Creating Wine environment…": "Wine ortamı oluşturuluyor…",
+"Initializing the Wine environment…": "Wine ortamı başlatılıyor…",
+"Installing Wine Gecko…": "Wine Gecko kuruluyor…",
+"Installing Wine Mono…": "Wine Mono kuruluyor…",
+"Recreating Wine environment": "Wine ortamını yeniden oluştur",
+"Recreating Wine environment…": "Wine ortamı yeniden oluşturuluyor…",
+"Removing the previous Wine environment…": "Önceki Wine ortamı kaldırılıyor…",
+"Restoring the previous Wine environment…": "Önceki Wine ortamı geri yükleniyor…",
+"Stopping the existing Wine environment…": "Mevcut Wine ortamı durduruluyor…",
+"Wine environment is ready": "Wine ortamı hazır",
+"Wine environment is ready.": "Wine ortamı hazır.",
+"Wine environment operation was cancelled.": "Wine ortamı işlemi iptal edildi.",
+"Wine environment operation failed. Review the details below.": "Wine ortamı işlemi başarısız oldu. Aşağıdaki ayrıntıları inceleyin."
 }

--- a/tools/wine4office-manager/translations/uk.json
+++ b/tools/wine4office-manager/translations/uk.json
@@ -99,5 +99,22 @@
   "Wine shutdown was interrupted.": "Вимкнення Wine було перервано.",
   "Wine tools": "Інструменти Wine",
   "Wine4Office Manager": "Менеджер Wine4Office",
-  "Working folder:": "Робоча папка:"
+  "Working folder:": "Робоча папка:",
+"Applying Office compatibility settings…": "Застосовуються параметри сумісності Office…",
+"Applying Office privacy settings…": "Застосовуються параметри конфіденційності Office…",
+"Configuring Wine graphics…": "Налаштовується графіка Wine…",
+"Creating Wine environment": "Створення середовища Wine",
+"Creating Wine environment…": "Створюється середовище Wine…",
+"Initializing the Wine environment…": "Ініціалізується середовище Wine…",
+"Installing Wine Gecko…": "Встановлюється Wine Gecko…",
+"Installing Wine Mono…": "Встановлюється Wine Mono…",
+"Recreating Wine environment": "Повторне створення середовища Wine",
+"Recreating Wine environment…": "Повторно створюється середовище Wine…",
+"Removing the previous Wine environment…": "Видаляється попереднє середовище Wine…",
+"Restoring the previous Wine environment…": "Відновлюється попереднє середовище Wine…",
+"Stopping the existing Wine environment…": "Зупиняється наявне середовище Wine…",
+"Wine environment is ready": "Середовище Wine готове",
+"Wine environment is ready.": "Середовище Wine готове.",
+"Wine environment operation was cancelled.": "Операцію із середовищем Wine скасовано.",
+"Wine environment operation failed. Review the details below.": "Операція із середовищем Wine завершилася помилкою. Перегляньте подробиці нижче."
 }

--- a/tools/wine4office-manager/translations/ur.json
+++ b/tools/wine4office-manager/translations/ur.json
@@ -61,5 +61,22 @@
   "Wine shutdown is finishing; the Manager will close when it completes.": "Wine شٹ ڈاؤن ختم ہو رہا ہے۔ مینیجر اس کے مکمل ہونے پر بند ہو جائے گا۔",
   "Wine shutdown was interrupted.": "Wine شٹ ڈاؤن میں خلل پڑا۔",
   "Wine tools": "Wine ٹولز",
-  "Wine4Office Manager": "Wine4Office منتظم"
+  "Wine4Office Manager": "Wine4Office منتظم",
+"Applying Office compatibility settings…": "Office کی مطابقت کی ترتیبات لاگو کی جا رہی ہیں…",
+"Applying Office privacy settings…": "Office کی رازداری کی ترتیبات لاگو کی جا رہی ہیں…",
+"Configuring Wine graphics…": "Wine گرافکس کی تشکیل کی جا رہی ہے…",
+"Creating Wine environment": "Wine ماحول بنائیں",
+"Creating Wine environment…": "Wine ماحول بنایا جا رہا ہے…",
+"Initializing the Wine environment…": "Wine ماحول شروع کیا جا رہا ہے…",
+"Installing Wine Gecko…": "Wine Gecko انسٹال کیا جا رہا ہے…",
+"Installing Wine Mono…": "Wine Mono انسٹال کیا جا رہا ہے…",
+"Recreating Wine environment": "Wine ماحول دوبارہ بنائیں",
+"Recreating Wine environment…": "Wine ماحول دوبارہ بنایا جا رہا ہے…",
+"Removing the previous Wine environment…": "پچھلا Wine ماحول ہٹایا جا رہا ہے…",
+"Restoring the previous Wine environment…": "پچھلا Wine ماحول بحال کیا جا رہا ہے…",
+"Stopping the existing Wine environment…": "موجودہ Wine ماحول روکا جا رہا ہے…",
+"Wine environment is ready": "Wine ماحول تیار ہے",
+"Wine environment is ready.": "Wine ماحول تیار ہے۔",
+"Wine environment operation was cancelled.": "Wine ماحول کی کارروائی منسوخ کر دی گئی۔",
+"Wine environment operation failed. Review the details below.": "Wine ماحول کی کارروائی ناکام ہو گئی۔ ذیل کی تفصیلات دیکھیں۔"
 }

--- a/tools/wine4office-manager/translations/vi.json
+++ b/tools/wine4office-manager/translations/vi.json
@@ -65,5 +65,22 @@
   "Wine shutdown was interrupted.": "Việc tắt máy Wine bị gián đoạn.",
   "Wine tools": "Công cụ Wine",
   "Wine4Office Manager": "Trình quản lý Wine4Office",
-  "Working folder:": "Thư mục làm việc:"
+  "Working folder:": "Thư mục làm việc:",
+"Applying Office compatibility settings…": "Đang áp dụng cài đặt tương thích Office…",
+"Applying Office privacy settings…": "Đang áp dụng cài đặt quyền riêng tư Office…",
+"Configuring Wine graphics…": "Đang cấu hình đồ họa Wine…",
+"Creating Wine environment": "Tạo môi trường Wine",
+"Creating Wine environment…": "Đang tạo môi trường Wine…",
+"Initializing the Wine environment…": "Đang khởi tạo môi trường Wine…",
+"Installing Wine Gecko…": "Đang cài đặt Wine Gecko…",
+"Installing Wine Mono…": "Đang cài đặt Wine Mono…",
+"Recreating Wine environment": "Tạo lại môi trường Wine",
+"Recreating Wine environment…": "Đang tạo lại môi trường Wine…",
+"Removing the previous Wine environment…": "Đang xóa môi trường Wine trước đó…",
+"Restoring the previous Wine environment…": "Đang khôi phục môi trường Wine trước đó…",
+"Stopping the existing Wine environment…": "Đang dừng môi trường Wine hiện có…",
+"Wine environment is ready": "Môi trường Wine đã sẵn sàng",
+"Wine environment is ready.": "Môi trường Wine đã sẵn sàng.",
+"Wine environment operation was cancelled.": "Thao tác môi trường Wine đã bị hủy.",
+"Wine environment operation failed. Review the details below.": "Thao tác môi trường Wine thất bại. Xem chi tiết bên dưới."
 }

--- a/tools/wine4office-manager/translations/zh.json
+++ b/tools/wine4office-manager/translations/zh.json
@@ -99,5 +99,22 @@
   "Wine shutdown was interrupted.": "Wine 关闭被中断。",
   "Wine tools": "Wine 工具",
   "Wine4Office Manager": "Wine4Office 管理器",
-  "Working folder:": "工作文件夹："
+  "Working folder:": "工作文件夹：",
+"Applying Office compatibility settings…": "正在应用 Office 兼容性设置…",
+"Applying Office privacy settings…": "正在应用 Office 隐私设置…",
+"Configuring Wine graphics…": "正在配置 Wine 图形…",
+"Creating Wine environment": "创建 Wine 环境",
+"Creating Wine environment…": "正在创建 Wine 环境…",
+"Initializing the Wine environment…": "正在初始化 Wine 环境…",
+"Installing Wine Gecko…": "正在安装 Wine Gecko…",
+"Installing Wine Mono…": "正在安装 Wine Mono…",
+"Recreating Wine environment": "重新创建 Wine 环境",
+"Recreating Wine environment…": "正在重新创建 Wine 环境…",
+"Removing the previous Wine environment…": "正在移除之前的 Wine 环境…",
+"Restoring the previous Wine environment…": "正在恢复之前的 Wine 环境…",
+"Stopping the existing Wine environment…": "正在停止现有的 Wine 环境…",
+"Wine environment is ready": "Wine 环境已准备就绪",
+"Wine environment is ready.": "Wine 环境已准备就绪。",
+"Wine environment operation was cancelled.": "Wine 环境操作已取消。",
+"Wine environment operation failed. Review the details below.": "Wine 环境操作失败。请查看下面的详细信息。"
 }

--- a/tools/wine4office-manager/translations/zh_Hant.json
+++ b/tools/wine4office-manager/translations/zh_Hant.json
@@ -99,5 +99,22 @@
   "Wine shutdown was interrupted.": "Wine 關閉被中斷。",
   "Wine tools": "Wine 工具",
   "Wine4Office Manager": "Wine4Office 管理員",
-  "Working folder:": "工作資料夾："
+  "Working folder:": "工作資料夾：",
+"Applying Office compatibility settings…": "正在套用 Office 相容性設定…",
+"Applying Office privacy settings…": "正在套用 Office 隱私設定…",
+"Configuring Wine graphics…": "正在設定 Wine 圖形…",
+"Creating Wine environment": "建立 Wine 環境",
+"Creating Wine environment…": "正在建立 Wine 環境…",
+"Initializing the Wine environment…": "正在初始化 Wine 環境…",
+"Installing Wine Gecko…": "正在安裝 Wine Gecko…",
+"Installing Wine Mono…": "正在安裝 Wine Mono…",
+"Recreating Wine environment": "重新建立 Wine 環境",
+"Recreating Wine environment…": "正在重新建立 Wine 環境…",
+"Removing the previous Wine environment…": "正在移除先前的 Wine 環境…",
+"Restoring the previous Wine environment…": "正在還原先前的 Wine 環境…",
+"Stopping the existing Wine environment…": "正在停止現有的 Wine 環境…",
+"Wine environment is ready": "Wine 環境已準備就緒",
+"Wine environment is ready.": "Wine 環境已準備就緒。",
+"Wine environment operation was cancelled.": "Wine 環境作業已取消。",
+"Wine environment operation failed. Review the details below.": "Wine 環境作業失敗。請查看下方詳細資訊。"
 }

--- a/tools/wine4office-manager/wine4office_backend.py
+++ b/tools/wine4office-manager/wine4office_backend.py
@@ -1109,13 +1109,6 @@ def _stream_command(command: list[str], env: dict[str, str], output: Output, cwd
     assert process.stdout is not None
     try:
         while True:
-            line = process.stdout.readline()
-            if line:
-                output(line.rstrip())
-            if process.poll() is not None:
-                for remaining in process.stdout:
-                    output(remaining.rstrip())
-                break
             if cancel_event is not None and cancel_event.is_set():
                 os.killpg(process.pid, signal.SIGTERM)
                 try:
@@ -1124,6 +1117,18 @@ def _stream_command(command: list[str], env: dict[str, str], output: Output, cwd
                     os.killpg(process.pid, signal.SIGKILL)
                     process.wait()
                 raise RuntimeError("Operation cancelled.")
+            readable, _writable, _exceptional = select.select(
+                [process.stdout], [], [], 0.1
+            )
+            if readable:
+                line = process.stdout.readline()
+                if line:
+                    output(line.rstrip())
+                elif process.poll() is not None:
+                    break
+                continue
+            if process.poll() is not None:
+                break
     finally:
         if process.stdout:
             process.stdout.close()
@@ -1340,7 +1345,8 @@ def install_bundled_wine_mono(prefix: Path, wine: Path, output: Output,
 
 
 def create_environment(prefix_value: str, wine_value: str, recreate: bool, output: Output,
-                       cancel_event=None, process_callback=None) -> str:
+                       cancel_event=None, process_callback=None,
+                       progress_callback: Callable[[str, int | None], None] | None = None) -> str:
     prefix = validate_prefix(prefix_value)
     wine = require_wine(wine_value)
     kind = classify_prefix(str(prefix))
@@ -1353,7 +1359,9 @@ def create_environment(prefix_value: str, wine_value: str, recreate: bool, outpu
 
     backup: Path | None = None
     if recreate and prefix.exists():
-        stop_wine(str(prefix), str(wine))
+        if progress_callback is not None:
+            progress_callback("Stopping the existing Wine environment…", None)
+        stop_wine(str(prefix), str(wine), progress_callback=progress_callback)
         backup = prefix.with_name(f".{prefix.name}.wine4office-backup-{int(time.time())}")
         if backup.exists():
             raise FileExistsError(f"Backup path already exists: {backup}")
@@ -1366,18 +1374,26 @@ def create_environment(prefix_value: str, wine_value: str, recreate: bool, outpu
         prefix.parent.mkdir(parents=True, exist_ok=True)
         wineboot = sibling_tool(wine, "wineboot")
         command = [str(wineboot), "-u"] if wineboot else [str(wine), "wineboot.exe", "-u"]
+        if progress_callback is not None:
+            progress_callback("Initializing the Wine environment…", None)
         _stream_command(
             command, wine_environment(prefix, wine, _manager_create=True), output,
             cancel_event=cancel_event, process_callback=process_callback,
         )
+        if progress_callback is not None:
+            progress_callback("Installing Wine Gecko…", None)
         install_bundled_wine_gecko(
             prefix, wine, output,
             cancel_event=cancel_event, process_callback=process_callback,
         )
+        if progress_callback is not None:
+            progress_callback("Installing Wine Mono…", None)
         install_bundled_wine_mono(
             prefix, wine, output,
             cancel_event=cancel_event, process_callback=process_callback,
         )
+        if progress_callback is not None:
+            progress_callback("Configuring Wine graphics…", None)
         _stream_command([
             str(wine), "reg", "add", r"HKCU\Software\Wine\Drivers", "/v", "Graphics",
             "/d", "x11,wayland", "/f",
@@ -1390,6 +1406,8 @@ def create_environment(prefix_value: str, wine_value: str, recreate: bool, outpu
         )
         mark_prefix_owned(prefix)
     except Exception:
+        if progress_callback is not None and backup and backup.exists():
+            progress_callback("Restoring the previous Wine environment…", None)
         if prefix.exists():
             shutil.rmtree(prefix, ignore_errors=True)
         if backup and backup.exists():
@@ -1398,8 +1416,12 @@ def create_environment(prefix_value: str, wine_value: str, recreate: bool, outpu
         raise
 
     if backup and backup.exists():
+        if progress_callback is not None:
+            progress_callback("Removing the previous Wine environment…", None)
         output("Initialization succeeded; removing the temporary backup.")
         shutil.rmtree(backup)
+    if progress_callback is not None:
+        progress_callback("Wine environment is ready", 100)
     return f"Wine environment is ready at {prefix}"
 
 

--- a/tools/wine4office-manager/wine4office_backend.py
+++ b/tools/wine4office-manager/wine4office_backend.py
@@ -1093,6 +1093,7 @@ def sibling_tool(wine: Path, name: str) -> Path | None:
 
 def _stream_command(command: list[str], env: dict[str, str], output: Output, cwd: Path | None = None,
                     cancel_event=None, process_callback=None) -> None:
+    """Stream command output without waiting on inherited descendant pipes."""
     output("$ " + " ".join(command))
     process = subprocess.Popen(
         command,
@@ -1100,13 +1101,31 @@ def _stream_command(command: list[str], env: dict[str, str], output: Output, cwd
         env=env,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
-        text=True,
-        bufsize=1,
+        text=False,
+        bufsize=0,
         start_new_session=True,
     )
     if process_callback:
         process_callback(process)
     assert process.stdout is not None
+    stdout = process.stdout
+    stdout_fd = stdout.fileno()
+    os.set_blocking(stdout_fd, False)
+    pending = bytearray()
+    stdout_open = True
+
+    def emit_lines(final: bool = False) -> None:
+        while True:
+            newline = pending.find(b"\n")
+            if newline < 0:
+                break
+            line = bytes(pending[:newline]).rstrip(b"\r")
+            del pending[:newline + 1]
+            output(line.decode("utf-8", errors="replace"))
+        if final and pending:
+            output(bytes(pending).rstrip(b"\r").decode("utf-8", errors="replace"))
+            pending.clear()
+
     try:
         while True:
             if cancel_event is not None and cancel_event.is_set():
@@ -1117,21 +1136,33 @@ def _stream_command(command: list[str], env: dict[str, str], output: Output, cwd
                     os.killpg(process.pid, signal.SIGKILL)
                     process.wait()
                 raise RuntimeError("Operation cancelled.")
-            readable, _writable, _exceptional = select.select(
-                [process.stdout], [], [], 0.1
-            )
-            if readable:
-                line = process.stdout.readline()
-                if line:
-                    output(line.rstrip())
-                elif process.poll() is not None:
+            if stdout_open:
+                readable, _writable, _exceptional = select.select(
+                    [stdout_fd], [], [], 0.1
+                )
+                if readable:
+                    try:
+                        chunk = os.read(stdout_fd, 4096)
+                    except BlockingIOError:
+                        continue
+                    if chunk:
+                        pending.extend(chunk)
+                        emit_lines()
+                    else:
+                        stdout_open = False
+                        emit_lines(final=True)
+                    continue
+                if process.poll() is not None:
+                    emit_lines(final=True)
                     break
                 continue
-            if process.poll() is not None:
-                break
+            if process.poll() is None:
+                time.sleep(0.1)
+                continue
+            emit_lines(final=True)
+            break
     finally:
-        if process.stdout:
-            process.stdout.close()
+        stdout.close()
         if process_callback:
             process_callback(None)
     if process.returncode:
@@ -1347,6 +1378,7 @@ def install_bundled_wine_mono(prefix: Path, wine: Path, output: Output,
 def create_environment(prefix_value: str, wine_value: str, recreate: bool, output: Output,
                        cancel_event=None, process_callback=None,
                        progress_callback: Callable[[str, int | None], None] | None = None) -> str:
+    """Create or replace a managed Wine prefix and report setup phases."""
     prefix = validate_prefix(prefix_value)
     wine = require_wine(wine_value)
     kind = classify_prefix(str(prefix))

--- a/tools/wine4office-manager/wine4office_qt.py
+++ b/tools/wine4office-manager/wine4office_qt.py
@@ -72,11 +72,17 @@ OFFICE_INSTALLER_STARTUP_TIMEOUT_ERROR = (
 
 def _create_environment_worker(state, config: dict, recreate: bool) -> str:
     """Create a prefix and apply its policies without a Qt object reference."""
+    def environment_progress(label: str, value: int | None = None) -> None:
+        """Forward setup phases while reserving final readiness for this worker."""
+        if label == "Wine environment is ready" and value == 100:
+            return
+        state.set_progress(label, value)
+
     result = backend.create_environment(
         config["prefix"], config["wine"], recreate, state.output,
         cancel_event=state.cancel_event,
         process_callback=state.set_process,
-        progress_callback=state.set_progress,
+        progress_callback=environment_progress,
     )
     if state.cancel_event.is_set():
         raise RuntimeError("Operation cancelled.")
@@ -1557,6 +1563,7 @@ class ManagerWindow(QMainWindow):
         return _create_environment_worker(self.state, config, recreate)
 
     def _show_environment_progress(self, config: dict, recreate: bool) -> None:
+        """Show the shared task dialog for environment create or recreate work."""
         action = "Recreating" if recreate else "Creating"
         self._show_task_progress(
             "environment",
@@ -1572,6 +1579,7 @@ class ManagerWindow(QMainWindow):
 
 
     def environment_action(self, recreate: bool) -> None:
+        """Start environment creation or replacement without blocking Qt."""
         if not self.ensure_idle():
             return
         values = self.config_values()

--- a/tools/wine4office-manager/wine4office_qt.py
+++ b/tools/wine4office-manager/wine4office_qt.py
@@ -76,10 +76,12 @@ def _create_environment_worker(state, config: dict, recreate: bool) -> str:
         config["prefix"], config["wine"], recreate, state.output,
         cancel_event=state.cancel_event,
         process_callback=state.set_process,
+        progress_callback=state.set_progress,
     )
     if state.cancel_event.is_set():
         raise RuntimeError("Operation cancelled.")
     if backend.office_telemetry_disabled(config):
+        state.set_progress("Applying Office privacy settings…")
         backend.apply_office_telemetry_policy(
             config["prefix"], config["wine"], True,
             use_x11=config.get("use_x11", True),
@@ -90,6 +92,7 @@ def _create_environment_worker(state, config: dict, recreate: bool) -> str:
         raise RuntimeError("Operation cancelled.")
     compatibility = backend.office_compatibility_settings(config)
     if any(compatibility.values()):
+        state.set_progress("Applying Office compatibility settings…")
         backend.apply_office_compatibility_policies(
             config["prefix"], config["wine"], compatibility,
             {policy_id: False for policy_id in compatibility},
@@ -99,6 +102,7 @@ def _create_environment_worker(state, config: dict, recreate: bool) -> str:
         )
     if state.cancel_event.is_set():
         raise RuntimeError("Operation cancelled.")
+    state.set_progress("Wine environment is ready", 100)
     return result
 
 
@@ -1552,6 +1556,20 @@ class ManagerWindow(QMainWindow):
         """Compatibility wrapper for tests and non-Qt callers."""
         return _create_environment_worker(self.state, config, recreate)
 
+    def _show_environment_progress(self, config: dict, recreate: bool) -> None:
+        action = "Recreating" if recreate else "Creating"
+        self._show_task_progress(
+            "environment",
+            f"{action} Wine environment",
+            str(config["prefix"]),
+            f"{action} Wine environment…",
+            {
+                "completed": "Wine environment is ready.",
+                "cancelled": "Wine environment operation was cancelled.",
+                "failed": "Wine environment operation failed. Review the details below.",
+            },
+        )
+
 
     def environment_action(self, recreate: bool) -> None:
         if not self.ensure_idle():
@@ -1582,8 +1600,10 @@ class ManagerWindow(QMainWindow):
                     self.state, self.state.update_config(values), recreate
                 ),
             )
+            self.last_task_state = "True:running"
             self.pages.setCurrentIndex(self.MAINTENANCE_PAGE)
             self.navigation.setCurrentRow(self.MAINTENANCE_PAGE)
+            self._show_environment_progress(values, recreate)
             self.notify("Environment operation started.")
             self.refresh_state()
         except Exception as error:


### PR DESCRIPTION
## Summary

- Fix the recreate-environment hang when a Wine child inherits the command stdout pipe after the Wine client exits.
- Show create/recreate work in the Manager install-style progress popup with live operation logs.
- Report initialization, Gecko/Mono, graphics, policy, restore, cleanup, cancellation, and completion phases.
- Keep the 100% ready state until all configured Office policy work finishes.
- Localize the new popup titles, status messages, and environment phases in all 47 supported languages.
- Add regression coverage for detached stdout, unterminated output, closed stdout, progress ordering, popup logs, completion, and translations.

## Review follow-ups

- FIXED: closed stdout no longer causes a busy loop; unterminated fragments are flushed without waiting for EOF.
- FIXED: backend readiness is filtered until the worker completes privacy and compatibility policy work.
- FIXED: all new environment-progress strings are present and translated in every supported catalog.

## Validation

- `python -m unittest test_backend` — 152 passed.
- `QT_QPA_PLATFORM=offscreen python -m unittest test_manager` — 45 passed.
- `python -m unittest test_desktop_i18n` — 19 passed.
- Focused Qt environment tests — 4 passed.
- Packaged `Wine4OfficeManager --smoke-test` — passed.
- Remote VNC end-to-end recreate — reached `Wine environment is ready` at 100% with logs visible in the popup.

Visual evidence is preserved at `artifacts/manager-recreate-env-20260824/23-final-ready.png`.

## Risk

The change is limited to Manager environment command streaming, task progress reporting, translations, and the existing progress-dialog UI. Recreate still stages the old prefix and restores it on initialization failure.

## Summary by Sourcery

Make Wine environment creation and recreation responsive by streaming live progress and logs while completing all setup and policy work before reporting readiness.

New Features:
- Show live progress phases and command logs for Wine environment creation and recreation in the Manager’s install-style task dialog.
- Report environment setup, policy application, cancellation, failure, restoration, cleanup, and readiness states to the UI.

Bug Fixes:
- Prevent environment operations from hanging when detached Wine children inherit stdout and avoid busy loops after stdout closes.
- Keep the environment from being reported ready until privacy and compatibility policy application is complete.

Enhancements:
- Flush unterminated command output and handle closed streams reliably during environment setup.

Tests:
- Add regression coverage for command-stream handling, environment phase ordering, progress-dialog logs and completion, readiness timing, and localization coverage.

Chores:
- Add localized environment progress messages across all supported language catalogs.
- Document the responsive environment recreation behavior in the changelog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added responsive progress reporting when creating or recreating Wine environments.
  * Added a progress dialog with live task status, logs, and setup stages.
  * Environment actions now show running status and report completion at 100%.

* **Bug Fixes**
  * Improved cancellation responsiveness when command output is idle.
  * Ensured partial and final command output is displayed reliably.

* **Localization**
  * Added translated Wine environment progress, status, cancellation, and failure messages across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->