### PR TITLE
manager: refine background service memory display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Display background-service RAM without reclaimable inactive file cache and hide it when the service is stopped.
 - Activate Microsoft 365 licenses after signing in to Office.
 - Keep Wine environment recreation responsive and show live progress and logs in the Manager.
 - Prevent Word from crashing when opening Microsoft 365 sign-in.

--- a/tools/wine4office-manager/tests/test_backend.py
+++ b/tools/wine4office-manager/tests/test_backend.py
@@ -2558,6 +2558,7 @@ touch "$WINEPREFIX/system.reg" "$WINEPREFIX/user.reg"
         self.assertEqual(run.call_args.kwargs["timeout"], 8)
 
     def test_preload_memory_excludes_only_inactive_cgroup_file_cache(self):
+        """Subtract only inactive file cache from the service cgroup usage."""
         cgroup = self.root / "sys/fs/cgroup/user.slice/wine4office-preload.service"
         cgroup.mkdir(parents=True)
         (cgroup / "memory.current").write_text(str(700 * 1024 * 1024) + "\n")

--- a/tools/wine4office-manager/tests/test_backend.py
+++ b/tools/wine4office-manager/tests/test_backend.py
@@ -2557,16 +2557,31 @@ touch "$WINEPREFIX/system.reg" "$WINEPREFIX/user.reg"
         self.assertNotIn("shell", run.call_args.kwargs)
         self.assertEqual(run.call_args.kwargs["timeout"], 8)
 
-    def test_preload_memory_reads_only_systemd_memory_property(self):
-        completed = mock.Mock(returncode=0, stdout="637788160\n", stderr="")
+    def test_preload_memory_excludes_only_inactive_cgroup_file_cache(self):
+        cgroup = self.root / "sys/fs/cgroup/user.slice/wine4office-preload.service"
+        cgroup.mkdir(parents=True)
+        (cgroup / "memory.current").write_text(str(700 * 1024 * 1024) + "\n")
+        (cgroup / "memory.stat").write_text(
+            f"anon {500 * 1024 * 1024}\n"
+            f"file {180 * 1024 * 1024}\n"
+            f"active_file {120 * 1024 * 1024}\n"
+            f"inactive_file {60 * 1024 * 1024}\n"
+        )
+        completed = mock.Mock(
+            returncode=0,
+            stdout="/user.slice/wine4office-preload.service\n",
+            stderr="",
+        )
         with mock.patch.object(
+            backend, "_CGROUP2_ROOT", self.root / "sys/fs/cgroup"
+        ), mock.patch.object(
             backend, "_systemctl_user", return_value=completed
         ) as systemctl:
             memory = backend.preload_service_memory_bytes()
 
-        self.assertEqual(memory, 637788160)
+        self.assertEqual(memory, 640 * 1024 * 1024)
         systemctl.assert_called_once_with(
-            ["show", backend.PRELOAD_UNIT, "--property=MemoryCurrent", "--value"],
+            ["show", backend.PRELOAD_UNIT, "--property=ControlGroup", "--value"],
             check=False,
         )
 

--- a/tools/wine4office-manager/tests/test_qt.py
+++ b/tools/wine4office-manager/tests/test_qt.py
@@ -138,6 +138,7 @@ class QtManagerTests(unittest.TestCase):
         self.application.processEvents()
 
     def test_background_preload_controls_are_explicit_and_accessible(self):
+        """Expose only the supported background-service controls and labels."""
         self.assertEqual(self.window.preload_group.title(), "Background services")
         notice = self.window.preload_notice_label.text()
         self.assertEqual(
@@ -231,6 +232,7 @@ class QtManagerTests(unittest.TestCase):
                 )
 
     def test_background_preload_binding_mismatch_explains_both_environments(self):
+        """Explain the selected and bound environments without duplicate rows."""
         bound = str(self.home / "other-office")
         self._refresh_preload(
             state="binding_mismatch",
@@ -351,6 +353,7 @@ class QtManagerTests(unittest.TestCase):
         self.assertTrue(all(not button.isEnabled() for button in buttons))
 
     def test_background_preload_refresh_changes_only_ram_number(self):
+        """Refresh the visible RAM value without changing service controls."""
         values = {
             "state": "active",
             "installed": True,
@@ -374,6 +377,7 @@ class QtManagerTests(unittest.TestCase):
         self.assertEqual(self.window.preload_stop_button.isEnabled(), stop_enabled)
 
     def test_background_preload_hides_ram_row_when_service_is_inactive(self):
+        """Hide the RAM row when the preload service is inactive."""
         self._refresh_preload(
             installed=True,
             enabled=True,

--- a/tools/wine4office-manager/tests/test_qt.py
+++ b/tools/wine4office-manager/tests/test_qt.py
@@ -157,8 +157,8 @@ class QtManagerTests(unittest.TestCase):
                 self.assertTrue(button.toolTip())
         self.assertFalse(hasattr(self.window, "preload_disable_button"))
         self.assertFalse(hasattr(self.window, "preload_start_button"))
-        self.assertTrue(self.window.preload_selected_label.accessibleName())
-        self.assertTrue(self.window.preload_binding_label.accessibleName())
+        self.assertFalse(hasattr(self.window, "preload_selected_label"))
+        self.assertFalse(hasattr(self.window, "preload_binding_label"))
         self.assertFalse(hasattr(self.window, "preload_state_label"))
         self.assertFalse(any(
             "immediate" in checkbox.text().lower()
@@ -230,7 +230,7 @@ class QtManagerTests(unittest.TestCase):
                     enabled,
                 )
 
-    def test_background_preload_binding_mismatch_shows_both_environments(self):
+    def test_background_preload_binding_mismatch_explains_both_environments(self):
         bound = str(self.home / "other-office")
         self._refresh_preload(
             state="binding_mismatch",
@@ -241,8 +241,6 @@ class QtManagerTests(unittest.TestCase):
             selected_matches=False,
         )
 
-        self.assertEqual(self.window.preload_selected_label.text(), self.config["prefix"])
-        self.assertEqual(self.window.preload_binding_label.text(), bound)
         self.assertIn(self.config["prefix"], self.window.preload_detail_label.text())
         self.assertIn(bound, self.window.preload_detail_label.text())
         self.assertIn("Stop & disable", self.window.preload_detail_label.text())
@@ -366,6 +364,7 @@ class QtManagerTests(unittest.TestCase):
         }
         self._refresh_preload(memory_bytes=600 * 1024 * 1024, **values)
         stop_enabled = self.window.preload_stop_button.isEnabled()
+        self.assertTrue(self.window.preload_form.isRowVisible(self.window.preload_memory_label))
 
         self._refresh_preload(
             checking=True, memory_bytes=612 * 1024 * 1024, **values
@@ -373,6 +372,17 @@ class QtManagerTests(unittest.TestCase):
 
         self.assertEqual(self.window.preload_memory_label.text(), "612 MB")
         self.assertEqual(self.window.preload_stop_button.isEnabled(), stop_enabled)
+
+    def test_background_preload_hides_ram_row_when_service_is_inactive(self):
+        self._refresh_preload(
+            installed=True,
+            enabled=True,
+            active=False,
+            state="inactive",
+            memory_bytes=600 * 1024 * 1024,
+        )
+
+        self.assertFalse(self.window.preload_form.isRowVisible(self.window.preload_memory_label))
 
     def test_background_preload_buttons_dispatch_exact_manager_actions(self):
         controls = (

--- a/tools/wine4office-manager/wine4office_backend.py
+++ b/tools/wine4office-manager/wine4office_backend.py
@@ -4050,6 +4050,7 @@ _PRELOAD_VOIP_TIMEOUT = 15
 _PRELOAD_VOIP_STOP_TIMEOUT = 5
 _PRELOAD_HEARTBEAT_MAX_AGE = 20
 _PRELOAD_UNIT_MARKER = "# Managed by Wine4OfficeManager: preload-service-v1"
+_CGROUP2_ROOT = Path("/sys/fs/cgroup")
 _AUTOMATIC_UPDATE_UNIT_MARKER = (
     "# Managed by Wine4OfficeManager: automatic-update-check-v1"
 )
@@ -4239,20 +4240,44 @@ def _systemctl_property(command: str) -> tuple[bool, str]:
     return value in {"active", "reloading", "activating", "deactivating"}, detail
 
 
-def preload_service_memory_bytes() -> int | None:
-    """Return current cgroup memory without refreshing service state."""
+def _preload_service_cgroup_path() -> Path | None:
     result = _systemctl_user(
-        ["show", PRELOAD_UNIT, "--property=MemoryCurrent", "--value"],
+        ["show", PRELOAD_UNIT, "--property=ControlGroup", "--value"],
         check=False,
     )
     value = result.stdout.strip()
-    if result.returncode or not value or value in {"[not set]", "infinity"}:
+    if result.returncode or not value or value in {"-", "[not set]"}:
+        return None
+    if not value.startswith("/") or "\0" in value:
+        raise RuntimeError("Cannot determine the background-service cgroup.")
+    parts = value.split("/")
+    if any(not part or part in {".", ".."} for part in parts[1:]):
+        raise RuntimeError("The background-service cgroup path is invalid.")
+    if value == "/":
+        raise RuntimeError("The background-service cgroup path is invalid.")
+    return _CGROUP2_ROOT.joinpath(*parts[1:])
+
+
+def preload_service_memory_bytes() -> int | None:
+    """Return service memory excluding inactive cached filesystem data."""
+    cgroup = _preload_service_cgroup_path()
+    if cgroup is None:
         return None
     try:
-        memory = int(value)
-    except ValueError as error:
+        memory = int(
+            (cgroup / "memory.current").read_text(encoding="ascii").strip()
+        )
+        inactive_file_cache = None
+        for line in (cgroup / "memory.stat").read_text(encoding="ascii").splitlines():
+            key, separator, raw_value = line.partition(" ")
+            if key == "inactive_file" and separator:
+                inactive_file_cache = int(raw_value.strip())
+                break
+    except (OSError, UnicodeError, ValueError) as error:
         raise RuntimeError("Cannot determine background-service RAM usage.") from error
-    return memory if memory >= 0 else None
+    if memory < 0 or inactive_file_cache is None or inactive_file_cache < 0:
+        raise RuntimeError("Cannot determine background-service RAM usage.")
+    return max(0, memory - inactive_file_cache)
 
 
 def _preload_stop_identity_matches(binding: dict) -> bool:

--- a/tools/wine4office-manager/wine4office_backend.py
+++ b/tools/wine4office-manager/wine4office_backend.py
@@ -4241,6 +4241,7 @@ def _systemctl_property(command: str) -> tuple[bool, str]:
 
 
 def _preload_service_cgroup_path() -> Path | None:
+    """Return the validated cgroup v2 path for the preload service."""
     result = _systemctl_user(
         ["show", PRELOAD_UNIT, "--property=ControlGroup", "--value"],
         check=False,

--- a/tools/wine4office-manager/wine4office_qt.py
+++ b/tools/wine4office-manager/wine4office_qt.py
@@ -427,24 +427,13 @@ class ManagerWindow(QMainWindow):
         self.preload_notice_label.setAccessibleName("Background services memory notice")
         self.preload_notice_label.setWordWrap(True)
         preload_layout.addWidget(self.preload_notice_label)
-        preload_form = self._form()
-        preload_form.setVerticalSpacing(2)
-        self.preload_selected_label = QLabel("Checking…")
-        self.preload_selected_label.setAccessibleName("Selected preload environment")
-        self.preload_selected_label.setTextInteractionFlags(
-            Qt.TextInteractionFlag.TextSelectableByMouse
-        )
-        self.preload_binding_label = QLabel("Checking…")
-        self.preload_binding_label.setAccessibleName("Bound preload environment")
-        self.preload_binding_label.setTextInteractionFlags(
-            Qt.TextInteractionFlag.TextSelectableByMouse
-        )
-        preload_form.addRow("Selected environment:", self.preload_selected_label)
-        preload_form.addRow("Bound environment:", self.preload_binding_label)
+        self.preload_form = self._form()
+        self.preload_form.setVerticalSpacing(2)
         self.preload_memory_label = QLabel("—")
         self.preload_memory_label.setAccessibleName("Background services RAM usage")
-        preload_form.addRow("RAM usage:", self.preload_memory_label)
-        preload_layout.addLayout(preload_form)
+        self.preload_form.addRow("RAM usage:", self.preload_memory_label)
+        self.preload_form.setRowVisible(self.preload_memory_label, False)
+        preload_layout.addLayout(self.preload_form)
 
         self.preload_detail_label = QLabel()
         self.preload_detail_label.setAccessibleName("Background services details")
@@ -545,6 +534,8 @@ class ManagerWindow(QMainWindow):
 
     def _update_preload_status(self, snapshot: dict) -> None:
         preload = snapshot["preload"]
+        active = bool(preload.get("active"))
+        self.preload_form.setRowVisible(self.preload_memory_label, active)
         memory = preload.get("memory_bytes")
         memory_text = (
             f"{max(1, round(int(memory) / (1024 * 1024)))} MB"
@@ -556,13 +547,10 @@ class ManagerWindow(QMainWindow):
         binding = preload.get("binding")
         bound = binding.get("prefix") if isinstance(binding, dict) else binding
         bound_text = str(bound) if bound else self._tr("Not configured")
-        self.preload_selected_label.setText(selected)
-        self.preload_binding_label.setText(bound_text)
 
         supported = bool(preload.get("supported"))
         installed = bool(preload.get("installed"))
         enabled = bool(preload.get("enabled"))
-        active = bool(preload.get("active"))
         selected_matches = bool(preload.get("selected_matches"))
         mismatch = bool(binding) and not selected_matches
         detail = str(preload.get("detail") or "").strip()

--- a/tools/wine4office-manager/wine4office_qt.py
+++ b/tools/wine4office-manager/wine4office_qt.py
@@ -275,6 +275,7 @@ class ManagerWindow(QMainWindow):
             self.statusBar().showMessage(self._tr(self.statusBar().currentMessage()))
 
     def _build_ui(self) -> None:
+        """Construct the Manager pages and background-service controls."""
         toolbar = QToolBar("Main")
         toolbar.setMovable(False)
         toolbar.setIconSize(QSize(28, 28))
@@ -533,6 +534,7 @@ class ManagerWindow(QMainWindow):
             self.show_error(detail)
 
     def _update_preload_status(self, snapshot: dict) -> None:
+        """Refresh background-service labels, controls, and RAM visibility."""
         preload = snapshot["preload"]
         active = bool(preload.get("active"))
         self.preload_form.setRowVisible(self.preload_memory_label, active)


### PR DESCRIPTION
## Summary

- Remove selected and bound environment rows from the Background services card.
- Show RAM usage only while the preload service is active.
- Report cgroup memory excluding only reclaimable inactive file cache.

## Validation

- Local manager suite: 355 passed, 71 skipped because PySide6 is unavailable locally.
- Targeted remote PySide6 tests: 3 passed.
- py_compile and git diff --check passed.

## Visual QA

- Verified the inactive Background services card in the task-owned remote Wine environment; the RAM usage row is hidden.

## Notes

- If cgroup memory data is unavailable, the RAM value remains unavailable rather than falling back to a cache-inclusive value.
- The broader remote Qt suite contains existing offscreen modal failures/hangs; the targeted tests for this change pass.

## Summary by Sourcery

Refine the Background services card to present service RAM more accurately and reduce redundant environment information.

Bug Fixes:
- Report background-service RAM after excluding reclaimable inactive file cache.
- Hide background-service RAM usage when the preload service is inactive.

Enhancements:
- Remove separate selected and bound environment rows from the Background services card while retaining mismatch details.

Documentation:
- Document the refined background-service RAM display in the unreleased changelog.

Tests:
- Update backend and Qt tests to cover cgroup-based memory reporting and conditional RAM-row visibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added RAM usage reporting for active background services.
  * RAM usage now excludes reclaimable inactive file cache for more accurate readings.
  * RAM details are hidden when the background service is stopped.
  * Simplified the preload status display by removing redundant environment labels.
  * Improved status details to clearly explain the environments involved when bindings do not match.
  * Added clearer handling for unavailable or invalid service memory information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->