### PR TITLE
winewayland: Refresh input language after focus changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Prevent Word from crashing when opening Microsoft 365 sign-in.
 - Keep Word responsive and fully render its welcome screen after updating to WineHQ 11.16.
 - Fix Microsoft 365 sign-in for Outlook.com accounts.
+- Keep Hebrew input synchronized when returning to Wine Wayland windows.
 
 ## 0.2.1-beta.1 — 2026-08-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Prevent Word from crashing when opening Microsoft 365 sign-in.
 - Keep Word responsive and fully render its welcome screen after updating to WineHQ 11.16.
 - Fix Microsoft 365 sign-in for Outlook.com accounts.
-- Keep Hebrew input synchronized when returning to Wine Wayland windows.
+- Keep keyboard input synchronized with the active host layout when returning to Wine Wayland windows.
 
 ## 0.2.1-beta.1 — 2026-08-23
 

--- a/dlls/win32u/input.c
+++ b/dlls/win32u/input.c
@@ -1430,12 +1430,14 @@ HKL WINAPI NtUserActivateKeyboardLayout( HKL layout, UINT flags )
 {
     struct user_thread_info *info = get_user_thread_info();
     const KBDTABLES *kbd_tables;
+    BOOL notify = flags & KLF_WINE_NOTIFY;
     HKL old_layout;
     LCID locale;
     HWND focus;
 
     TRACE_(keyboard)( "layout %p, flags %x\n", layout, flags );
 
+    flags &= ~KLF_WINE_NOTIFY;
     if (flags) FIXME_(keyboard)( "flags %x not supported\n", flags );
 
     if (layout == (HKL)HKL_NEXT || layout == (HKL)HKL_PREV)
@@ -1463,12 +1465,13 @@ HKL WINAPI NtUserActivateKeyboardLayout( HKL layout, UINT flags )
         return 0;
 
     old_layout = info->kbd_layout;
-    if (old_layout != layout)
+    if (old_layout != layout || notify)
     {
-        HWND ime_hwnd = get_default_ime_window( 0 );
+        HWND ime_hwnd = old_layout != layout ? get_default_ime_window( 0 ) : 0;
         CHARSETINFO cs = {0};
 
-        if (ime_hwnd) send_message( ime_hwnd, WM_IME_INTERNAL, IME_INTERNAL_HKL_DEACTIVATE, HandleToUlong(old_layout) );
+        if (old_layout != layout && ime_hwnd)
+            send_message( ime_hwnd, WM_IME_INTERNAL, IME_INTERNAL_HKL_DEACTIVATE, HandleToUlong(old_layout) );
 
         if (HIWORD(layout) == 0xe001)
             get_input_language_charset( LOWORD(layout), &cs );
@@ -1477,10 +1480,14 @@ HKL WINAPI NtUserActivateKeyboardLayout( HKL layout, UINT flags )
         else
             get_input_language_charset( HIWORD(layout), &cs );
 
-        info->kbd_layout = layout;
-        info->kbd_layout_id = 0;
+        if (old_layout != layout)
+        {
+            info->kbd_layout = layout;
+            info->kbd_layout_id = 0;
 
-        if (ime_hwnd) send_message( ime_hwnd, WM_IME_INTERNAL, IME_INTERNAL_HKL_ACTIVATE, HandleToUlong(layout) );
+            if (ime_hwnd)
+                send_message( ime_hwnd, WM_IME_INTERNAL, IME_INTERNAL_HKL_ACTIVATE, HandleToUlong(layout) );
+        }
 
         if ((focus = get_focus()) && get_window_thread( focus, NULL ) == GetCurrentThreadId())
             send_message( focus, WM_INPUTLANGCHANGE, cs.ciCharset, (LPARAM)layout );

--- a/dlls/winewayland.drv/wayland_keyboard.c
+++ b/dlls/winewayland.drv/wayland_keyboard.c
@@ -832,22 +832,24 @@ static void keyboard_handle_enter(void *private, struct wl_keyboard *wl_keyboard
     keyboard->focused_hwnd = hwnd;
     pthread_mutex_unlock(&keyboard->mutex);
 
-    NtUserPostMessage(keyboard->focused_hwnd, WM_WAYLAND_SET_KEYBOARD_LAYOUT, 0,
-                      (LPARAM)keyboard_hkl);
-
-    if (!(data = wayland_win_data_get(hwnd))) return;
-
-    if ((surface = data->wayland_surface))
+    if ((data = wayland_win_data_get(hwnd)))
     {
-        /* TODO: Drop the internal message and call NtUserSetForegroundWindow
-         * directly once it's updated to not explicitly deactivate the old
-         * foreground window when both the old and new foreground windows
-         * are in the same non-current thread. */
-        if (surface->window.managed)
-            NtUserPostMessage(hwnd, WM_WAYLAND_SET_FOREGROUND, 0, 0);
+        if ((surface = data->wayland_surface))
+        {
+            /* TODO: Drop the internal message and call NtUserSetForegroundWindow
+             * directly once it's updated to not explicitly deactivate the old
+             * foreground window when both the old and new foreground windows
+             * are in the same non-current thread. */
+            if (surface->window.managed)
+                NtUserPostMessage(hwnd, WM_WAYLAND_SET_FOREGROUND, 0, 0);
+        }
+
+        wayland_win_data_release(data);
     }
 
-    wayland_win_data_release(data);
+    /* Activate the host layout after the window becomes foreground so the
+     * input-language notification reaches the newly focused control. */
+    NtUserPostMessage(hwnd, WM_WAYLAND_SET_KEYBOARD_LAYOUT, TRUE, (LPARAM)keyboard_hkl);
 }
 
 struct foreground_sync

--- a/dlls/winewayland.drv/window.c
+++ b/dlls/winewayland.drv/window.c
@@ -1112,7 +1112,7 @@ LRESULT WAYLAND_WindowMessage(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp)
         return 0;
     }
     case WM_WAYLAND_SET_KEYBOARD_LAYOUT:
-        NtUserActivateKeyboardLayout((HKL)lp, 0);
+        NtUserActivateKeyboardLayout((HKL)lp, wp ? KLF_WINE_NOTIFY : 0);
         return 0;
     default:
         FIXME("got window msg %x hwnd %p wp %lx lp %lx\n", msg, hwnd, (long)wp, lp);

--- a/include/ntuser.h
+++ b/include/ntuser.h
@@ -394,6 +394,9 @@ C_ASSERT( sizeof(struct drag_drop_post_params) == offsetof(struct drag_drop_post
 #define DF_WINE_ROOT_DESKTOP      0x40000000
 #define DF_WINE_VIRTUAL_DESKTOP   0x80000000
 
+/* Internal NtUserActivateKeyboardLayout flag used by display drivers. */
+#define KLF_WINE_NOTIFY           0x80000000
+
 /* NtUserMessageCall codes */
 enum
 {


### PR DESCRIPTION
## Summary

- activate the Wayland foreground window before synchronizing the host keyboard layout
- force one `WM_INPUTLANGCHANGE` on keyboard enter even when the thread HKL is already current
- avoid unnecessary IME deactivate/reactivate cycles and duplicate notifications from the text-input path
- document the Hebrew input synchronization fix in the changelog

## Validation

- `git diff --check`
- focused combined WoW64 build (`--enable-archs=i386,x86_64`) of both win32u PE DLLs and winewayland.drv
- deterministic Win32 focus-return probe: old runner delivered 0 input-language notifications; patched runner delivered exactly 1
- physical VNC key input produced `אבגדה` in both PE32 and PE32+ probe builds after returning from a native Wayland window

## Test limitation

A direct Word rerun was blocked by the current Microsoft Click-to-Run updater/AppVIsv state in the copied test prefix. The same environmental failure reproduced with the old release runner, while the focused probe exercised and verified the repaired Wine path.

## Summary by Sourcery

Synchronize Wayland keyboard layouts after foreground activation and reliably notify focused windows of input-language changes.

Bug Fixes:
- Synchronize keyboard input language with the active host layout when focus returns to Wine Wayland windows.
- Ensure focused controls receive an input-language notification when the host layout is re-entered, even if the layout is unchanged.

Enhancements:
- Avoid unnecessary IME deactivation/reactivation during redundant keyboard-layout synchronization.

Documentation:
- Document the Wine Wayland keyboard input synchronization fix in the changelog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard layout synchronization when returning to Wine Wayland windows.
  * Ensured the correct keyboard layout is activated after a window regains focus.
  * Applications are now notified of layout activation even when the layout remains unchanged.
  * Improved IME state handling so activation and deactivation occur only when the keyboard layout changes.

* **Documentation**
  * Added an Unreleased changelog entry describing the synchronized Hebrew input behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->