### PR TITLE
onlineid: acquire silent tokens asynchronously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Keep Word responsive while Microsoft 365 tokens are checked or refreshed in the background.
+- Keep Microsoft 365 account and token data consistent when sign-in and background refresh overlap.
 - Build Wine4Office releases and agent runners from the same reproducible 18-job environment.
 - Display background-service RAM without reclaimable inactive file cache and hide it when the service is stopped.
 - Activate Microsoft 365 licenses after signing in to Office.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Keep Word responsive while Microsoft 365 tokens are checked or refreshed in the background.
 - Display background-service RAM without reclaimable inactive file cache and hide it when the service is stopped.
 - Activate Microsoft 365 licenses after signing in to Office.
 - Keep Wine environment recreation responsive and show live progress and logs in the Manager.

--- a/dlls/windows.security.authentication.onlineid/authenticator.c
+++ b/dlls/windows.security.authentication.onlineid/authenticator.c
@@ -2994,20 +2994,7 @@ static enum helper_result onlineid_run_test_helper( HANDLE cancel_event, DWORD t
         return HELPER_COMPLETED;
     }
     if (wcscmp( mode, L"block" ) && wcscmp( mode, L"gated-block" ) &&
-        wcscmp( mode, L"timeout" ) && wcscmp( mode, L"missing" ) &&
-        wcscmp( mode, L"shutdown" ))
-    {
-        onlineid_signal_test_event( completed_name );
-        return HELPER_FAILED;
-    }
-
-    if (!wcscmp( mode, L"missing" ))
-    {
-        onlineid_signal_test_event( completed_name );
-        return HELPER_FAILED;
-    }
-
-    if (!wcscmp( mode, L"shutdown" ))
+        wcscmp( mode, L"timeout" ))
     {
         onlineid_signal_test_event( completed_name );
         return HELPER_FAILED;

--- a/dlls/windows.security.authentication.onlineid/authenticator.c
+++ b/dlls/windows.security.authentication.onlineid/authenticator.c
@@ -3045,13 +3045,19 @@ static enum helper_result onlineid_wait_for_helper( HANDLE process, HANDLE cance
     if (cancel_event && wait == WAIT_OBJECT_0 + 1)
     {
         TerminateProcess( process, ERROR_CANCELLED );
-        WaitForSingleObject( process, 5000 );
+        /* Do not release the refresh mutex while a canceled helper may still
+         * be writing the shared token generation.  The async operation has
+         * already transitioned to Canceled, so this wait does not block its
+         * caller or completion callback. */
+        WaitForSingleObject( process, INFINITE );
         return HELPER_CANCELED;
     }
     if (wait == WAIT_TIMEOUT)
     {
         TerminateProcess( process, WAIT_TIMEOUT );
-        WaitForSingleObject( process, 5000 );
+        /* The next waiter may start another helper as soon as this function
+         * returns.  Keep serialization until the timed-out process is gone. */
+        WaitForSingleObject( process, INFINITE );
         return HELPER_TIMED_OUT;
     }
     if (wait != WAIT_OBJECT_0 || !GetExitCodeProcess( process, exit_code )) return HELPER_FAILED;

--- a/dlls/windows.security.authentication.onlineid/authenticator.c
+++ b/dlls/windows.security.authentication.onlineid/authenticator.c
@@ -3605,6 +3605,33 @@ static BOOL silent_cancel_requested( HANDLE cancel_event )
     return cancel_event && WaitForSingleObject( cancel_event, 0 ) == WAIT_OBJECT_0;
 }
 
+static HANDLE silent_acquire_cache_mutex( HANDLE cancel_event, BOOL *canceled )
+{
+    static const WCHAR mutex_name[] = L"Local\\Wine4OfficeWamCache";
+    WCHAR mode[64];
+    HANDLE mutex, handles[2];
+    DWORD count = 1, wait;
+
+    *canceled = FALSE;
+    if (!(mutex = CreateMutexW( NULL, FALSE, mutex_name ))) return NULL;
+    handles[0] = mutex;
+    if (cancel_event) handles[count++] = cancel_event;
+    if (onlineid_get_test_helper_mode( mode ))
+        onlineid_signal_test_event( L"Local\\WineOnlineIdTestProjectionWaiting" );
+    wait = WaitForMultipleObjects( count, handles, FALSE, INFINITE );
+    if (wait == WAIT_OBJECT_0 || wait == WAIT_ABANDONED_0) return mutex;
+    if (cancel_event && wait == WAIT_OBJECT_0 + 1) *canceled = TRUE;
+    CloseHandle( mutex );
+    return NULL;
+}
+
+static void silent_release_cache_mutex( HANDLE mutex )
+{
+    if (!mutex) return;
+    ReleaseMutex( mutex );
+    CloseHandle( mutex );
+}
+
 static BOOL silent_token_is_usable( const WCHAR *token, const WCHAR *expires )
 {
     ULONGLONG expiry = expires ? wcstoull( expires, NULL, 10 ) : 0;
@@ -3655,14 +3682,20 @@ static BOOL prepare_silent_wam_token( const WCHAR *scopes, const WCHAR *client_i
 {
     const WCHAR *token_path = scopes && is_office_licensing_scope( scopes ) ?
                               L"C:\\wam-licensing-token.txt" : L"C:\\wam-access-token.txt";
-    WCHAR *token = load_wam_token_file( token_path );
-    WCHAR *expires = load_wam_token_file( L"C:\\wam-token-expires-on.txt" );
-    WCHAR *refresh = NULL;
-    BOOL have_token = silent_token_is_usable( token, expires );
+    HANDLE cache_mutex = NULL;
+    WCHAR *token = NULL, *expires = NULL, *refresh = NULL;
+    BOOL have_token = FALSE;
     DWORD exit_code = 3, timeout = onlineid_helper_timeout();
     enum helper_result helper;
 
     *canceled = FALSE;
+    if (!(cache_mutex = silent_acquire_cache_mutex( cancel_event, canceled ))) goto done;
+    token = load_wam_token_file( token_path );
+    expires = load_wam_token_file( L"C:\\wam-token-expires-on.txt" );
+    refresh = load_wam_token_file( L"C:\\wam-refresh-token.txt" );
+    silent_release_cache_mutex( cache_mutex );
+    cache_mutex = NULL;
+    have_token = silent_token_is_usable( token, expires );
     if (silent_cancel_requested( cancel_event ))
     {
         *canceled = TRUE;
@@ -3688,14 +3721,18 @@ static BOOL prepare_silent_wam_token( const WCHAR *scopes, const WCHAR *client_i
             goto done;
         }
         if (token) { SecureZeroMemory( token, wcslen(token) * sizeof(*token) ); free( token ); }
-        token = load_wam_token_file( token_path );
+        token = NULL;
         free( expires );
+        expires = NULL;
+        if (!(cache_mutex = silent_acquire_cache_mutex( cancel_event, canceled ))) goto done;
+        token = load_wam_token_file( token_path );
         expires = load_wam_token_file( L"C:\\wam-token-expires-on.txt" );
+        silent_release_cache_mutex( cache_mutex );
+        cache_mutex = NULL;
         have_token = silent_token_is_usable( token, expires );
         goto done;
     }
     if (have_token) goto done;
-    refresh = load_wam_token_file( L"C:\\wam-refresh-token.txt" );
     if (refresh)
     {
         helper = run_wine4office_auth( NULL, NULL, FALSE, &exit_code, NULL, NULL, NULL,
@@ -3713,13 +3750,19 @@ static BOOL prepare_silent_wam_token( const WCHAR *scopes, const WCHAR *client_i
                 goto done;
             }
             if (token) { SecureZeroMemory( token, wcslen(token) * sizeof(*token) ); free( token ); }
-            token = load_wam_token_file( token_path );
+            token = NULL;
             free( expires );
+            expires = NULL;
+            if (!(cache_mutex = silent_acquire_cache_mutex( cancel_event, canceled ))) goto done;
+            token = load_wam_token_file( token_path );
             expires = load_wam_token_file( L"C:\\wam-token-expires-on.txt" );
+            silent_release_cache_mutex( cache_mutex );
+            cache_mutex = NULL;
             have_token = silent_token_is_usable( token, expires );
         }
     }
 done:
+    silent_release_cache_mutex( cache_mutex );
     if (refresh) { SecureZeroMemory( refresh, wcslen( refresh ) * sizeof(*refresh) ); free( refresh ); }
     if (token) { SecureZeroMemory( token, wcslen( token ) * sizeof(*token) ); free( token ); }
     free( expires );
@@ -3890,7 +3933,7 @@ static HRESULT WINAPI silent_async_put_Completed( IAsyncOperation_IInspectable *
             callback = silent_operation_claim_handler_locked( impl );
     }
     LeaveCriticalSection( &impl->cs );
-    if (callback) hr = silent_operation_invoke( impl, callback, status );
+    if (callback) silent_operation_invoke( impl, callback, status );
     return hr;
 }
 
@@ -4112,7 +4155,7 @@ static const IAsyncInfoVtbl silent_info_vtbl =
 static DWORD WINAPI silent_token_worker( void *parameter )
 {
     struct silent_token_operation *impl = parameter;
-    HANDLE refresh_mutex = NULL, handles[2];
+    HANDLE refresh_mutex = NULL, cache_mutex = NULL, handles[2];
     IInspectable *result = NULL;
     DWORD wait;
     BOOL owns_mutex = FALSE, canceled = FALSE, gate_canceled = FALSE;
@@ -4172,10 +4215,15 @@ finish_refresh:
     }
 
     response_status = supported && have_token ? 0 : 3;
-    hr = web_token_request_result_create( response_status,
-            WindowsGetStringRawBuffer( impl->scopes, NULL ), impl->account, &result );
-    /* Keep projection reads in the same serialized generation as refresh.
-     * A second helper may publish as soon as this mutex is released. */
+    if (!(cache_mutex = silent_acquire_cache_mutex( impl->cancel_event, &canceled )))
+        hr = canceled ? E_ABORT : E_FAIL;
+    else
+    {
+        hr = web_token_request_result_create( response_status,
+                WindowsGetStringRawBuffer( impl->scopes, NULL ), impl->account, &result );
+        silent_release_cache_mutex( cache_mutex );
+        cache_mutex = NULL;
+    }
     if (owns_mutex)
     {
         ReleaseMutex( refresh_mutex );
@@ -4183,10 +4231,12 @@ finish_refresh:
     }
     if (refresh_mutex) CloseHandle( refresh_mutex );
     refresh_mutex = NULL;
-    if (SUCCEEDED(hr)) silent_operation_complete( impl, result, Completed, S_OK );
+    if (canceled) silent_operation_complete( impl, NULL, Canceled, E_ABORT );
+    else if (SUCCEEDED(hr)) silent_operation_complete( impl, result, Completed, S_OK );
     else silent_operation_complete( impl, NULL, Error, hr );
     if (result) IInspectable_Release( result );
 done:
+    silent_release_cache_mutex( cache_mutex );
     if (owns_mutex) ReleaseMutex( refresh_mutex );
     if (refresh_mutex) CloseHandle( refresh_mutex );
     silent_signal_test_worker_finished();

--- a/dlls/windows.security.authentication.onlineid/authenticator.c
+++ b/dlls/windows.security.authentication.onlineid/authenticator.c
@@ -2882,18 +2882,215 @@ done:
     return ret;
 }
 
-static BOOL run_wine4office_auth( HWND owner, HSTRING login_hint, BOOL interactive, DWORD *exit_code,
-                                  HSTRING scopes, HSTRING resource_client_id, HSTRING resource_redirect_uri )
+enum helper_result
+{
+    HELPER_NOT_CONTROLLED,
+    HELPER_COMPLETED,
+    HELPER_CANCELED,
+    HELPER_TIMED_OUT,
+    HELPER_FAILED,
+};
+
+static DWORD onlineid_helper_timeout(void)
+{
+    WCHAR value[32];
+    WCHAR *end;
+    DWORD length;
+    ULONGLONG timeout;
+
+    length = GetEnvironmentVariableW( L"WINE_ONLINEID_HELPER_TIMEOUT_MS", value, ARRAY_SIZE(value) );
+    if (!length || length >= ARRAY_SIZE(value)) return 60000;
+    timeout = wcstoull( value, &end, 10 );
+    if (end == value || *end) return 60000;
+    return timeout < INFINITE ? (DWORD)timeout : 60000;
+}
+
+static BOOL onlineid_get_test_helper_mode( WCHAR mode[64] )
+{
+    DWORD length = GetEnvironmentVariableW( L"WINE_ONLINEID_TEST_HELPER_MODE", mode, 64 );
+    return length && length < 64;
+}
+
+static HANDLE onlineid_open_test_event( const WCHAR *name, DWORD access )
+{
+    HANDLE event = OpenEventW( access, FALSE, name );
+    if (!event) event = CreateEventW( NULL, TRUE, FALSE, name );
+    return event;
+}
+
+static void onlineid_signal_test_event( const WCHAR *name )
+{
+    HANDLE event = onlineid_open_test_event( name, EVENT_MODIFY_STATE );
+    if (event)
+    {
+        SetEvent( event );
+        CloseHandle( event );
+    }
+}
+
+static enum helper_result onlineid_wait_for_helper( HANDLE process, HANDLE cancel_event, DWORD timeout,
+                                                    DWORD *exit_code );
+
+static enum helper_result onlineid_run_real_test_helper( const WCHAR *mode, HANDLE cancel_event,
+                                                         DWORD timeout, DWORD *exit_code )
+{
+    WCHAR command[2 * MAX_PATH];
+    PROCESS_INFORMATION process = {0};
+    STARTUPINFOW startup = {sizeof(startup)};
+    enum helper_result result;
+
+    if (wcscmp(mode, L"fail") && wcscmp(mode, L"timeout") &&
+        wcscmp(mode, L"crash") && wcscmp(mode, L"shutdown"))
+        lstrcpyW(command, L"C:\\windows\\system32\\wine4officeauth-missing.exe --self-test-helper fail");
+    else if (swprintf(command, ARRAY_SIZE(command),
+                      L"\"C:\\windows\\system32\\wine4officeauth.exe\" --self-test-helper %s",
+                      mode) < 0)
+        return HELPER_FAILED;
+
+    if (!CreateProcessW(NULL, command, NULL, NULL, FALSE, 0, NULL, NULL, &startup, &process))
+    {
+        onlineid_signal_test_event(L"Local\\WineOnlineIdTestHelperCompleted");
+        return HELPER_FAILED;
+    }
+    result = onlineid_wait_for_helper(process.hProcess, cancel_event, timeout, exit_code);
+    CloseHandle(process.hThread);
+    CloseHandle(process.hProcess);
+    onlineid_signal_test_event(L"Local\\WineOnlineIdTestHelperCompleted");
+    return result;
+}
+
+/* This control is intentionally opt-in and developer-only.  It makes helper
+ * supervision testable without changing the production helper protocol. */
+static enum helper_result onlineid_run_test_helper( HANDLE cancel_event, DWORD timeout, DWORD *exit_code )
+{
+    static const WCHAR started_name[] = L"Local\\WineOnlineIdTestHelperStarted";
+    static const WCHAR release_name[] = L"Local\\WineOnlineIdTestHelperRelease";
+    static const WCHAR completed_name[] = L"Local\\WineOnlineIdTestHelperCompleted";
+    WCHAR mode[64];
+    HANDLE release, handles[2];
+    DWORD count, wait;
+
+    if (!onlineid_get_test_helper_mode( mode )) return HELPER_NOT_CONTROLLED;
+    *exit_code = 3;
+    onlineid_signal_test_event( started_name );
+    if (!wcsncmp( mode, L"real-", 5 ))
+        return onlineid_run_real_test_helper( mode + 5, cancel_event, timeout, exit_code );
+    if (!wcscmp( mode, L"success" ))
+    {
+        *exit_code = 0;
+        onlineid_signal_test_event( completed_name );
+        return HELPER_COMPLETED;
+    }
+    if (!wcscmp( mode, L"fail" ))
+    {
+        *exit_code = 7;
+        onlineid_signal_test_event( completed_name );
+        return HELPER_COMPLETED;
+    }
+    if (!wcscmp( mode, L"crash" ))
+    {
+        *exit_code = 0xc0000005;
+        onlineid_signal_test_event( completed_name );
+        return HELPER_COMPLETED;
+    }
+    if (wcscmp( mode, L"block" ) && wcscmp( mode, L"gated-block" ) &&
+        wcscmp( mode, L"timeout" ) && wcscmp( mode, L"missing" ) &&
+        wcscmp( mode, L"shutdown" ))
+    {
+        onlineid_signal_test_event( completed_name );
+        return HELPER_FAILED;
+    }
+
+    if (!wcscmp( mode, L"missing" ))
+    {
+        onlineid_signal_test_event( completed_name );
+        return HELPER_FAILED;
+    }
+
+    if (!wcscmp( mode, L"shutdown" ))
+    {
+        onlineid_signal_test_event( completed_name );
+        return HELPER_FAILED;
+    }
+
+    /* The real helper path below supervises a process with the configured
+     * deadline.  This explicit branch keeps the public mapping test
+     * deterministic and sleep-free. */
+    if (!wcscmp( mode, L"timeout" ))
+    {
+        onlineid_signal_test_event( completed_name );
+        return HELPER_TIMED_OUT;
+    }
+
+    release = onlineid_open_test_event( release_name, SYNCHRONIZE );
+    if (!release)
+    {
+        onlineid_signal_test_event( completed_name );
+        return HELPER_FAILED;
+    }
+    handles[0] = release;
+    count = 1;
+    if (cancel_event) handles[count++] = cancel_event;
+    wait = WaitForMultipleObjects( count, handles, FALSE, timeout );
+    CloseHandle( release );
+    if (wait == WAIT_OBJECT_0)
+    {
+        *exit_code = 0;
+        onlineid_signal_test_event( completed_name );
+        return HELPER_COMPLETED;
+    }
+    onlineid_signal_test_event( completed_name );
+    if (cancel_event && wait == WAIT_OBJECT_0 + 1) return HELPER_CANCELED;
+    if (wait == WAIT_TIMEOUT) return HELPER_TIMED_OUT;
+    return HELPER_FAILED;
+}
+
+static enum helper_result onlineid_wait_for_helper( HANDLE process, HANDLE cancel_event, DWORD timeout,
+                                                    DWORD *exit_code )
+{
+    HANDLE handles[2];
+    DWORD count = 1, wait;
+
+    handles[0] = process;
+    if (cancel_event) handles[count++] = cancel_event;
+    wait = cancel_event ? WaitForMultipleObjects( count, handles, FALSE, timeout ) :
+                          WaitForSingleObject( process, timeout );
+    if (cancel_event && wait == WAIT_OBJECT_0 + 1)
+    {
+        TerminateProcess( process, ERROR_CANCELLED );
+        WaitForSingleObject( process, 5000 );
+        return HELPER_CANCELED;
+    }
+    if (wait == WAIT_TIMEOUT)
+    {
+        TerminateProcess( process, WAIT_TIMEOUT );
+        WaitForSingleObject( process, 5000 );
+        return HELPER_TIMED_OUT;
+    }
+    if (wait != WAIT_OBJECT_0 || !GetExitCodeProcess( process, exit_code )) return HELPER_FAILED;
+    return HELPER_COMPLETED;
+}
+
+static enum helper_result run_wine4office_auth( HWND owner, HSTRING login_hint, BOOL interactive, DWORD *exit_code,
+                                                HSTRING scopes, HSTRING resource_client_id,
+                                                HSTRING resource_redirect_uri, HANDLE cancel_event, DWORD timeout )
 {
     WCHAR command[6 * MAX_PATH], hint_path[MAX_PATH];
     PROCESS_INFORMATION process = {0};
     STARTUPINFOW startup = {sizeof(startup)};
+    enum helper_result result;
     BOOL ret;
 
+    *exit_code = 3;
+    if (!interactive)
+    {
+        result = onlineid_run_test_helper( cancel_event, timeout, exit_code );
+        if (result != HELPER_NOT_CONTROLLED) return result;
+    }
     if (!write_login_hint_file( login_hint, hint_path ))
     {
         TRACE( "failed to create the auth helper login-hint file, error %lu.\n", GetLastError() );
-        return FALSE;
+        return HELPER_FAILED;
     }
     if (interactive)
     {
@@ -2925,38 +3122,38 @@ static BOOL run_wine4office_auth( HWND owner, HSTRING login_hint, BOOL interacti
     {
         TRACE( "failed to start the auth helper, error %lu.\n", GetLastError() );
         if (hint_path[0]) DeleteFileW( hint_path );
-        return FALSE;
+        return HELPER_FAILED;
     }
     TRACE( "started the auth helper for %s acquisition.\n", interactive ? "interactive" : "silent" );
-    WaitForSingleObject( process.hProcess, INFINITE );
-    ret = GetExitCodeProcess( process.hProcess, exit_code );
-    TRACE( "auth helper completed, query success %d, exit code %lu.\n", ret, ret ? *exit_code : 0 );
+    result = onlineid_wait_for_helper( process.hProcess, cancel_event, timeout, exit_code );
+    TRACE( "auth helper completed with result %u, exit code %lu.\n", result, *exit_code );
     CloseHandle( process.hThread );
     CloseHandle( process.hProcess );
     if (hint_path[0]) DeleteFileW( hint_path );
-    return ret;
+    return result;
 }
 
-static BOOL run_wine365_resource_refresh( const WCHAR *scope, const WCHAR *client_id )
+static enum helper_result run_wine365_resource_refresh( const WCHAR *scope, const WCHAR *client_id,
+                                                        HANDLE cancel_event, DWORD timeout, DWORD *exit_code )
 {
     WCHAR command[4 * MAX_PATH];
     PROCESS_INFORMATION process = {0};
     STARTUPINFOW startup = {sizeof(startup)};
-    DWORD exit_code = 3;
-    BOOL ret;
+    enum helper_result result;
 
+    *exit_code = 3;
     if (!scope || !*scope || wcschr( scope, '"' ) || !client_id || !*client_id ||
-        wcschr( client_id, '"' )) return FALSE;
+        wcschr( client_id, '"' )) return HELPER_FAILED;
+    result = onlineid_run_test_helper( cancel_event, timeout, exit_code );
+    if (result != HELPER_NOT_CONTROLLED) return result;
     if (swprintf( command, ARRAY_SIZE(command),
                   L"\"C:\\windows\\system32\\wine4officeauth.exe\" --refresh-resource \"%s\" \"%s\"",
-                  scope, client_id ) < 0) return FALSE;
-    ret = CreateProcessW( NULL, command, NULL, NULL, FALSE, 0, NULL, NULL, &startup, &process );
-    if (!ret) return FALSE;
-    WaitForSingleObject( process.hProcess, INFINITE );
-    ret = GetExitCodeProcess( process.hProcess, &exit_code ) && !exit_code;
+                  scope, client_id ) < 0) return HELPER_FAILED;
+    if (!CreateProcessW( NULL, command, NULL, NULL, FALSE, 0, NULL, NULL, &startup, &process )) return HELPER_FAILED;
+    result = onlineid_wait_for_helper( process.hProcess, cancel_event, timeout, exit_code );
     CloseHandle( process.hThread );
     CloseHandle( process.hProcess );
-    return ret;
+    return result;
 }
 
 static DWORD WINAPI interactive_token_worker( void *parameter )
@@ -2968,7 +3165,8 @@ static DWORD WINAPI interactive_token_worker( void *parameter )
     HRESULT hr;
 
     if (run_wine4office_auth( context->owner, context->login_hint, TRUE, &exit_code, context->scopes,
-                              context->resource_client_id, context->resource_redirect_uri ))
+                              context->resource_client_id, context->resource_redirect_uri,
+                              NULL, INFINITE ) == HELPER_COMPLETED)
     {
         if (!exit_code) response_status = 0;
         else if (exit_code == 2) response_status = 1;
@@ -3409,121 +3607,722 @@ static BOOL is_supported_resource_client( const WCHAR *client_id )
            (client_id && !wcsicmp( client_id, L"f4060917-6abe-40d7-baa6-f634c0eda4ac" ));
 }
 
-static const WCHAR *get_resource_client_id( struct web_token_request *request, HSTRING *nested_client_id )
+static BOOL silent_cancel_requested( HANDLE cancel_event )
 {
-    const WCHAR *client_id = WindowsGetStringRawBuffer( request->client_id, NULL );
-    const WCHAR *scopes = WindowsGetStringRawBuffer( request->scope, NULL );
-
-    *nested_client_id = NULL;
-    if (SUCCEEDED(token_request_get_property( request, L"nestedClientId", nested_client_id )))
-        client_id = WindowsGetStringRawBuffer( *nested_client_id, NULL );
-    else if (scopes && wcsstr( scopes, L"engage.cloud.microsoft/teams-branded-exp" ))
-        client_id = L"f4060917-6abe-40d7-baa6-f634c0eda4ac";
-    return client_id;
+    return cancel_event && WaitForSingleObject( cancel_event, 0 ) == WAIT_OBJECT_0;
 }
 
-static BOOL prepare_silent_wam_token(const WCHAR *scopes, const WCHAR *client_id)
+static BOOL silent_token_is_usable( const WCHAR *token, const WCHAR *expires )
 {
-    WCHAR *token = load_wam_token_file( L"C:\\wam-access-token.txt" );
+    ULONGLONG expiry = expires ? wcstoull( expires, NULL, 10 ) : 0;
+
+    return token && (!expiry || expiry > get_unix_time() + 300);
+}
+
+static void silent_signal_test_completion(void)
+{
+    WCHAR mode[64];
+
+    if (onlineid_get_test_helper_mode( mode ))
+        onlineid_signal_test_event( L"Local\\WineOnlineIdTestOperationCompleted" );
+}
+
+static BOOL silent_wait_test_worker_gate( HANDLE cancel_event, BOOL *canceled )
+{
+    static const WCHAR gate_name[] = L"Local\\WineOnlineIdTestWorkerGate";
+    WCHAR mode[64];
+    HANDLE gate, handles[2];
+    DWORD count = 1, wait;
+
+    *canceled = FALSE;
+    if (!onlineid_get_test_helper_mode( mode ) || wcscmp( mode, L"gated-block" )) return TRUE;
+    if (!(gate = onlineid_open_test_event( gate_name, SYNCHRONIZE ))) return TRUE;
+    handles[0] = gate;
+    if (cancel_event) handles[count++] = cancel_event;
+    wait = WaitForMultipleObjects( count, handles, FALSE, INFINITE );
+    CloseHandle( gate );
+    if (cancel_event && wait == WAIT_OBJECT_0 + 1)
+    {
+        *canceled = TRUE;
+        return FALSE;
+    }
+    return TRUE;
+}
+
+static void silent_signal_test_worker_finished(void)
+{
+    WCHAR mode[64];
+
+    if (onlineid_get_test_helper_mode( mode ))
+        onlineid_signal_test_event( L"Local\\WineOnlineIdTestWorkerFinished" );
+}
+
+static BOOL prepare_silent_wam_token( const WCHAR *scopes, const WCHAR *client_id, HANDLE cancel_event,
+                                      BOOL *canceled )
+{
+    const WCHAR *token_path = scopes && is_office_licensing_scope( scopes ) ?
+                              L"C:\\wam-licensing-token.txt" : L"C:\\wam-access-token.txt";
+    WCHAR *token = load_wam_token_file( token_path );
     WCHAR *expires = load_wam_token_file( L"C:\\wam-token-expires-on.txt" );
     WCHAR *refresh = NULL;
-    BOOL have_token = token != NULL;
-    ULONGLONG expiry = expires ? wcstoull( expires, NULL, 10 ) : 0;
-    DWORD exit_code;
+    BOOL have_token = silent_token_is_usable( token, expires );
+    DWORD exit_code = 3, timeout = onlineid_helper_timeout();
+    enum helper_result helper;
 
-    if (scopes && *scopes && !is_office_licensing_scope( scopes ))
+    *canceled = FALSE;
+    if (silent_cancel_requested( cancel_event ))
     {
-        if (!run_wine365_resource_refresh( scopes, client_id )) goto done;
-        if (token) { SecureZeroMemory( token, wcslen(token) * sizeof(*token) ); free( token ); }
-        token = load_wam_token_file( L"C:\\wam-access-token.txt" );
-        have_token = token != NULL;
+        *canceled = TRUE;
         goto done;
     }
-    if (have_token && (!expiry || expiry > get_unix_time() + 300)) goto done;
-    refresh = load_wam_token_file( L"C:\\wam-refresh-token.txt" );
-    if (refresh && run_wine4office_auth( NULL, NULL, FALSE, &exit_code, NULL, NULL, NULL ) && !exit_code)
+    if (scopes && *scopes && !is_office_licensing_scope( scopes ))
     {
+        /* The projection does not retain the resource scope or client which
+         * produced its access token.  A fresh token therefore cannot prove
+         * that it is usable for this request; preserve the resource refresh
+         * until that identity is published transactionally with the token. */
+        helper = run_wine365_resource_refresh( scopes, client_id, cancel_event, timeout, &exit_code );
+        if (helper == HELPER_CANCELED)
+        {
+            *canceled = TRUE;
+            goto done;
+        }
+        if (helper != HELPER_COMPLETED || exit_code) goto done;
+        if (silent_cancel_requested( cancel_event ))
+        {
+            *canceled = TRUE;
+            goto done;
+        }
         if (token) { SecureZeroMemory( token, wcslen(token) * sizeof(*token) ); free( token ); }
-        token = load_wam_token_file( L"C:\\wam-access-token.txt" );
-        have_token = token != NULL;
+        token = load_wam_token_file( token_path );
+        free( expires );
+        expires = load_wam_token_file( L"C:\\wam-token-expires-on.txt" );
+        have_token = silent_token_is_usable( token, expires );
+        goto done;
+    }
+    if (have_token) goto done;
+    refresh = load_wam_token_file( L"C:\\wam-refresh-token.txt" );
+    if (refresh)
+    {
+        helper = run_wine4office_auth( NULL, NULL, FALSE, &exit_code, NULL, NULL, NULL,
+                                       cancel_event, timeout );
+        if (helper == HELPER_CANCELED)
+        {
+            *canceled = TRUE;
+            goto done;
+        }
+        if (helper == HELPER_COMPLETED && !exit_code)
+        {
+            if (silent_cancel_requested( cancel_event ))
+            {
+                *canceled = TRUE;
+                goto done;
+            }
+            if (token) { SecureZeroMemory( token, wcslen(token) * sizeof(*token) ); free( token ); }
+            token = load_wam_token_file( token_path );
+            free( expires );
+            expires = load_wam_token_file( L"C:\\wam-token-expires-on.txt" );
+            have_token = silent_token_is_usable( token, expires );
+        }
     }
 done:
-    if (refresh) { SecureZeroMemory( refresh, wcslen(refresh) * sizeof(*refresh) ); free( refresh ); }
-    if (token) { SecureZeroMemory( token, wcslen(token) * sizeof(*token) ); free( token ); }
+    if (refresh) { SecureZeroMemory( refresh, wcslen( refresh ) * sizeof(*refresh) ); free( refresh ); }
+    if (token) { SecureZeroMemory( token, wcslen( token ) * sizeof(*token) ); free( token ); }
     free( expires );
     return have_token;
+}
+
+enum silent_operation_state
+{
+    SILENT_OPERATION_STARTING,
+    SILENT_OPERATION_RUNNING,
+    SILENT_OPERATION_COMPLETED,
+    SILENT_OPERATION_CANCELED,
+    SILENT_OPERATION_CLOSED,
+};
+
+struct silent_token_operation
+{
+    IAsyncOperation_IInspectable IAsyncOperation_IInspectable_iface;
+    IAsyncInfo IAsyncInfo_iface;
+    LONG ref;
+    CRITICAL_SECTION cs;
+    HSTRING scopes;
+    HSTRING client_id;
+    HSTRING resource_client_id;
+    IInspectable *account;
+    HANDLE cancel_event;
+    HANDLE worker;
+    IInspectable *result;
+    IAsyncOperationCompletedHandler_IInspectable *handler;
+    BOOL callback_claimed;
+    enum silent_operation_state state;
+    HRESULT error;
+    const struct async_operation_type *type;
+};
+
+static inline struct silent_token_operation *impl_from_silent_async( IAsyncOperation_IInspectable *iface )
+{
+    return CONTAINING_RECORD( iface, struct silent_token_operation, IAsyncOperation_IInspectable_iface );
+}
+
+static inline struct silent_token_operation *impl_from_silent_info( IAsyncInfo *iface )
+{
+    return CONTAINING_RECORD( iface, struct silent_token_operation, IAsyncInfo_iface );
+}
+
+static HRESULT WINAPI silent_async_QueryInterface( IAsyncOperation_IInspectable *iface, REFIID iid, void **out )
+{
+    struct silent_token_operation *impl = impl_from_silent_async( iface );
+
+    if (!out) return E_POINTER;
+    *out = NULL;
+    if (IsEqualGUID( iid, &IID_IAsyncInfo )) *out = &impl->IAsyncInfo_iface;
+    else if (IsEqualGUID( iid, &IID_IUnknown ) || IsEqualGUID( iid, &IID_IInspectable ) ||
+             IsEqualGUID( iid, &IID_IAgileObject ) || IsEqualGUID( iid, impl->type->iid )) *out = iface;
+    else return E_NOINTERFACE;
+    InterlockedIncrement( &impl->ref );
+    return S_OK;
+}
+
+static ULONG WINAPI silent_async_AddRef( IAsyncOperation_IInspectable *iface )
+{
+    return InterlockedIncrement( &impl_from_silent_async( iface )->ref );
+}
+
+static ULONG WINAPI silent_async_Release( IAsyncOperation_IInspectable *iface )
+{
+    struct silent_token_operation *impl = impl_from_silent_async( iface );
+    ULONG ref = InterlockedDecrement( &impl->ref );
+
+    if (!ref)
+    {
+        TRACE( "silent operation %p final release.\n", impl );
+        if (impl->handler) IAsyncOperationCompletedHandler_IInspectable_Release( impl->handler );
+        if (impl->result) IInspectable_Release( impl->result );
+        if (impl->account) IInspectable_Release( impl->account );
+        WindowsDeleteString( impl->scopes );
+        WindowsDeleteString( impl->client_id );
+        WindowsDeleteString( impl->resource_client_id );
+        if (impl->cancel_event) CloseHandle( impl->cancel_event );
+        if (impl->worker) CloseHandle( impl->worker );
+        DeleteCriticalSection( &impl->cs );
+        free( impl );
+    }
+    return ref;
+}
+
+static HRESULT WINAPI silent_async_GetIids( IAsyncOperation_IInspectable *iface, ULONG *count, IID **iids )
+{
+    struct silent_token_operation *impl = impl_from_silent_async( iface );
+
+    if (count) *count = 0;
+    if (iids) *iids = NULL;
+    if (!count || !iids) return E_POINTER;
+    *iids = CoTaskMemAlloc( 2 * sizeof(**iids) );
+    if (!*iids) return E_OUTOFMEMORY;
+    (*iids)[0] = *impl->type->iid;
+    (*iids)[1] = IID_IAsyncInfo;
+    *count = 2;
+    return S_OK;
+}
+
+static HRESULT WINAPI silent_async_GetRuntimeClassName( IAsyncOperation_IInspectable *iface, HSTRING *name )
+{
+    struct silent_token_operation *impl = impl_from_silent_async( iface );
+
+    if (!name) return E_POINTER;
+    *name = NULL;
+    return WindowsCreateString( impl->type->class_name, wcslen( impl->type->class_name ), name );
+}
+
+static HRESULT WINAPI silent_async_GetTrustLevel( IAsyncOperation_IInspectable *iface, TrustLevel *level )
+{
+    if (!level) return E_POINTER;
+    *level = BaseTrust;
+    return S_OK;
+}
+
+static HRESULT silent_operation_invoke( struct silent_token_operation *impl,
+                                        IAsyncOperationCompletedHandler_IInspectable *handler,
+                                        AsyncStatus status )
+{
+    HRESULT hr;
+
+    hr = IAsyncOperationCompletedHandler_IInspectable_Invoke( handler,
+            &impl->IAsyncOperation_IInspectable_iface, status );
+    TRACE( "silent operation %p callback status %u returned %#lx.\n", impl, status, hr );
+    IAsyncOperationCompletedHandler_IInspectable_Release( handler );
+    silent_async_Release( &impl->IAsyncOperation_IInspectable_iface );
+    return hr;
+}
+
+/* The lock-protected claim is the callback linearization point.  Close can
+ * detach the stored handler after this point, but the callback is already
+ * pinned and logically in flight; a close which wins first suppresses it. */
+static IAsyncOperationCompletedHandler_IInspectable *silent_operation_claim_handler_locked(
+        struct silent_token_operation *impl )
+{
+    IAsyncOperationCompletedHandler_IInspectable *handler;
+
+    if (impl->state == SILENT_OPERATION_CLOSED || !impl->handler || impl->callback_claimed) return NULL;
+    impl->callback_claimed = TRUE;
+    IAsyncOperationCompletedHandler_IInspectable_AddRef( handler = impl->handler );
+    silent_async_AddRef( &impl->IAsyncOperation_IInspectable_iface );
+    return handler;
+}
+
+static HRESULT WINAPI silent_async_put_Completed( IAsyncOperation_IInspectable *iface,
+        IAsyncOperationCompletedHandler_IInspectable *handler )
+{
+    struct silent_token_operation *impl = impl_from_silent_async( iface );
+    IAsyncOperationCompletedHandler_IInspectable *callback = NULL;
+    HRESULT hr = S_OK;
+    AsyncStatus status = Started;
+
+    if (!handler) return E_POINTER;
+    EnterCriticalSection( &impl->cs );
+    if (impl->state == SILENT_OPERATION_CLOSED) hr = E_ILLEGAL_METHOD_CALL;
+    else if (impl->handler) hr = E_ILLEGAL_DELEGATE_ASSIGNMENT;
+    else
+    {
+        IAsyncOperationCompletedHandler_IInspectable_AddRef( impl->handler = handler );
+        if (impl->state == SILENT_OPERATION_COMPLETED) status = impl->error == S_OK ? Completed : Error;
+        else if (impl->state == SILENT_OPERATION_CANCELED) status = Canceled;
+        else if (impl->state == SILENT_OPERATION_RUNNING || impl->state == SILENT_OPERATION_STARTING)
+            status = Started;
+        else status = Error;
+        if (status != Started)
+            callback = silent_operation_claim_handler_locked( impl );
+    }
+    LeaveCriticalSection( &impl->cs );
+    if (callback) hr = silent_operation_invoke( impl, callback, status );
+    return hr;
+}
+
+static HRESULT WINAPI silent_async_get_Completed( IAsyncOperation_IInspectable *iface,
+        IAsyncOperationCompletedHandler_IInspectable **handler )
+{
+    struct silent_token_operation *impl = impl_from_silent_async( iface );
+
+    if (!handler) return E_POINTER;
+    *handler = NULL;
+    EnterCriticalSection( &impl->cs );
+    if (impl->state == SILENT_OPERATION_CLOSED)
+    {
+        LeaveCriticalSection( &impl->cs );
+        return E_ILLEGAL_METHOD_CALL;
+    }
+    if ((*handler = impl->handler)) IAsyncOperationCompletedHandler_IInspectable_AddRef( *handler );
+    LeaveCriticalSection( &impl->cs );
+    return S_OK;
+}
+
+static HRESULT WINAPI silent_async_GetResults( IAsyncOperation_IInspectable *iface, IInspectable **result )
+{
+    struct silent_token_operation *impl = impl_from_silent_async( iface );
+    HRESULT hr = S_OK;
+
+    if (!result) return E_POINTER;
+    *result = NULL;
+    EnterCriticalSection( &impl->cs );
+    if (impl->state == SILENT_OPERATION_CLOSED || impl->state == SILENT_OPERATION_STARTING ||
+        impl->state == SILENT_OPERATION_RUNNING || impl->state == SILENT_OPERATION_CANCELED)
+        hr = E_ILLEGAL_METHOD_CALL;
+    else if (impl->state == SILENT_OPERATION_COMPLETED)
+    {
+        if (FAILED(impl->error)) hr = impl->error;
+        else if ((*result = impl->result)) IInspectable_AddRef( *result );
+    }
+    else hr = impl->error;
+    LeaveCriticalSection( &impl->cs );
+    return hr;
+}
+
+static const IAsyncOperation_IInspectableVtbl silent_async_vtbl =
+{
+    silent_async_QueryInterface, silent_async_AddRef, silent_async_Release,
+    silent_async_GetIids, silent_async_GetRuntimeClassName, silent_async_GetTrustLevel,
+    silent_async_put_Completed, silent_async_get_Completed, silent_async_GetResults,
+};
+
+static HRESULT WINAPI silent_info_QueryInterface( IAsyncInfo *iface, REFIID iid, void **out )
+{
+    return silent_async_QueryInterface( &impl_from_silent_info( iface )->IAsyncOperation_IInspectable_iface, iid, out );
+}
+
+static ULONG WINAPI silent_info_AddRef( IAsyncInfo *iface )
+{
+    return silent_async_AddRef( &impl_from_silent_info( iface )->IAsyncOperation_IInspectable_iface );
+}
+
+static ULONG WINAPI silent_info_Release( IAsyncInfo *iface )
+{
+    return silent_async_Release( &impl_from_silent_info( iface )->IAsyncOperation_IInspectable_iface );
+}
+
+static HRESULT WINAPI silent_info_GetIids( IAsyncInfo *iface, ULONG *count, IID **iids )
+{
+    return silent_async_GetIids( &impl_from_silent_info( iface )->IAsyncOperation_IInspectable_iface, count, iids );
+}
+
+static HRESULT WINAPI silent_info_GetRuntimeClassName( IAsyncInfo *iface, HSTRING *name )
+{
+    return silent_async_GetRuntimeClassName( &impl_from_silent_info( iface )->IAsyncOperation_IInspectable_iface, name );
+}
+
+static HRESULT WINAPI silent_info_GetTrustLevel( IAsyncInfo *iface, TrustLevel *level )
+{
+    return silent_async_GetTrustLevel( &impl_from_silent_info( iface )->IAsyncOperation_IInspectable_iface, level );
+}
+
+static HRESULT WINAPI silent_info_get_Id( IAsyncInfo *iface, UINT32 *id )
+{
+    struct silent_token_operation *impl = impl_from_silent_info( iface );
+    HRESULT hr = S_OK;
+
+    if (!id) return E_POINTER;
+    *id = 0;
+    EnterCriticalSection( &impl->cs );
+    if (impl->state == SILENT_OPERATION_CLOSED) hr = E_ILLEGAL_METHOD_CALL;
+    else *id = 1;
+    LeaveCriticalSection( &impl->cs );
+    return hr;
+}
+
+static HRESULT WINAPI silent_info_get_Status( IAsyncInfo *iface, AsyncStatus *status )
+{
+    struct silent_token_operation *impl = impl_from_silent_info( iface );
+
+    if (!status) return E_POINTER;
+    *status = Started;
+    EnterCriticalSection( &impl->cs );
+    if (impl->state == SILENT_OPERATION_CLOSED)
+    {
+        LeaveCriticalSection( &impl->cs );
+        return E_ILLEGAL_METHOD_CALL;
+    }
+    if (impl->state == SILENT_OPERATION_COMPLETED) *status = impl->error == S_OK ? Completed : Error;
+    else if (impl->state == SILENT_OPERATION_CANCELED) *status = Canceled;
+    else if (impl->state != SILENT_OPERATION_STARTING && impl->state != SILENT_OPERATION_RUNNING)
+        *status = Error;
+    LeaveCriticalSection( &impl->cs );
+    return S_OK;
+}
+
+static HRESULT WINAPI silent_info_get_ErrorCode( IAsyncInfo *iface, HRESULT *error )
+{
+    struct silent_token_operation *impl = impl_from_silent_info( iface );
+
+    if (!error) return E_POINTER;
+    *error = S_OK;
+    EnterCriticalSection( &impl->cs );
+    if (impl->state == SILENT_OPERATION_CLOSED)
+    {
+        LeaveCriticalSection( &impl->cs );
+        return E_ILLEGAL_METHOD_CALL;
+    }
+    *error = impl->error;
+    LeaveCriticalSection( &impl->cs );
+    return S_OK;
+}
+
+static void silent_operation_complete( struct silent_token_operation *impl, IInspectable *result,
+                                       AsyncStatus status, HRESULT error )
+{
+    IAsyncOperationCompletedHandler_IInspectable *handler = NULL;
+    enum silent_operation_state state;
+    BOOL transitioned = FALSE;
+
+    EnterCriticalSection( &impl->cs );
+    if (impl->state == SILENT_OPERATION_RUNNING)
+    {
+        transitioned = TRUE;
+        impl->error = error;
+        if (status == Completed)
+        {
+            impl->state = SILENT_OPERATION_COMPLETED;
+            if ((impl->result = result)) IInspectable_AddRef( result );
+        }
+        else if (status == Canceled) impl->state = SILENT_OPERATION_CANCELED;
+        else impl->state = SILENT_OPERATION_COMPLETED;
+        handler = silent_operation_claim_handler_locked( impl );
+    }
+    state = impl->state;
+    LeaveCriticalSection( &impl->cs );
+    TRACE( "silent operation %p completed state %u, status %u, error %#lx.\n", impl, state, status, error );
+    if (transitioned) silent_signal_test_completion();
+    if (handler) silent_operation_invoke( impl, handler, status );
+}
+
+static HRESULT WINAPI silent_info_Cancel( IAsyncInfo *iface )
+{
+    struct silent_token_operation *impl = impl_from_silent_info( iface );
+    IAsyncOperationCompletedHandler_IInspectable *handler = NULL;
+    BOOL transitioned = FALSE;
+
+    EnterCriticalSection( &impl->cs );
+    if (impl->state == SILENT_OPERATION_CLOSED)
+    {
+        LeaveCriticalSection( &impl->cs );
+        return E_ILLEGAL_METHOD_CALL;
+    }
+    if (impl->state == SILENT_OPERATION_STARTING || impl->state == SILENT_OPERATION_RUNNING)
+    {
+        transitioned = TRUE;
+        impl->state = SILENT_OPERATION_CANCELED;
+        impl->error = E_ABORT;
+        SetEvent( impl->cancel_event );
+        handler = silent_operation_claim_handler_locked( impl );
+    }
+    LeaveCriticalSection( &impl->cs );
+    TRACE( "silent operation %p canceled.\n", impl );
+    if (transitioned) silent_signal_test_completion();
+    if (handler) silent_operation_invoke( impl, handler, Canceled );
+    return S_OK;
+}
+
+static HRESULT WINAPI silent_info_Close( IAsyncInfo *iface )
+{
+    struct silent_token_operation *impl = impl_from_silent_info( iface );
+    IAsyncOperationCompletedHandler_IInspectable *handler;
+    IInspectable *result;
+
+    EnterCriticalSection( &impl->cs );
+    if (impl->state == SILENT_OPERATION_CLOSED)
+    {
+        LeaveCriticalSection( &impl->cs );
+        return S_OK;
+    }
+    impl->state = SILENT_OPERATION_CLOSED;
+    SetEvent( impl->cancel_event );
+    handler = impl->handler;
+    result = impl->result;
+    impl->handler = NULL;
+    impl->result = NULL;
+    LeaveCriticalSection( &impl->cs );
+    TRACE( "silent operation %p closed.\n", impl );
+    if (handler) IAsyncOperationCompletedHandler_IInspectable_Release( handler );
+    if (result) IInspectable_Release( result );
+    return S_OK;
+}
+
+static const IAsyncInfoVtbl silent_info_vtbl =
+{
+    silent_info_QueryInterface, silent_info_AddRef, silent_info_Release,
+    silent_info_GetIids, silent_info_GetRuntimeClassName, silent_info_GetTrustLevel,
+    silent_info_get_Id, silent_info_get_Status, silent_info_get_ErrorCode,
+    silent_info_Cancel, silent_info_Close,
+};
+
+static DWORD WINAPI silent_token_worker( void *parameter )
+{
+    struct silent_token_operation *impl = parameter;
+    HANDLE refresh_mutex = NULL, handles[2];
+    IInspectable *result = NULL;
+    DWORD wait;
+    BOOL owns_mutex = FALSE, canceled = FALSE, gate_canceled = FALSE;
+    BOOL have_token = FALSE, supported = FALSE;
+    INT32 response_status;
+    HRESULT hr;
+
+    EnterCriticalSection( &impl->cs );
+    if (impl->state == SILENT_OPERATION_STARTING) impl->state = SILENT_OPERATION_RUNNING;
+    else canceled = TRUE;
+    LeaveCriticalSection( &impl->cs );
+    TRACE( "silent operation %p worker entered, canceled %d.\n", impl, canceled );
+    if (canceled) goto done;
+
+    /* The gate is developer-only and is placed before mutex or token work so
+     * the regression can prove that the public caller returned first. */
+    if (!silent_wait_test_worker_gate( impl->cancel_event, &gate_canceled ))
+    {
+        canceled = gate_canceled;
+        goto finish_refresh;
+    }
+
+    supported = is_supported_wam_client( WindowsGetStringRawBuffer( impl->client_id, NULL )) &&
+                is_supported_resource_client( WindowsGetStringRawBuffer( impl->resource_client_id, NULL ));
+    if (supported)
+    {
+        refresh_mutex = CreateMutexW( NULL, FALSE, L"Wine365WamTokenRefresh" );
+        if (refresh_mutex)
+        {
+            handles[0] = refresh_mutex;
+            handles[1] = impl->cancel_event;
+            wait = WaitForMultipleObjects( 2, handles, FALSE, INFINITE );
+            if (wait == WAIT_OBJECT_0 + 1) canceled = TRUE;
+            else if (wait == WAIT_OBJECT_0 || wait == WAIT_ABANDONED_0) owns_mutex = TRUE;
+            else TRACE( "silent operation %p refresh mutex wait failed, result %#lx.\n", impl, wait );
+        }
+        /* Never refresh without proving that this worker owns the mutex. */
+        if (!canceled && owns_mutex)
+        {
+            have_token = prepare_silent_wam_token( WindowsGetStringRawBuffer( impl->scopes, NULL ),
+                                                    WindowsGetStringRawBuffer( impl->resource_client_id, NULL ),
+                                                    impl->cancel_event, &canceled );
+        }
+    }
+finish_refresh:
+    if (owns_mutex)
+    {
+        ReleaseMutex( refresh_mutex );
+        owns_mutex = FALSE;
+    }
+    if (refresh_mutex) CloseHandle( refresh_mutex );
+    refresh_mutex = NULL;
+    if (canceled || silent_cancel_requested( impl->cancel_event ))
+    {
+        silent_operation_complete( impl, NULL, Canceled, E_ABORT );
+        goto done;
+    }
+
+    response_status = supported && have_token ? 0 : 3;
+    hr = web_token_request_result_create( response_status,
+            WindowsGetStringRawBuffer( impl->scopes, NULL ), impl->account, &result );
+    if (SUCCEEDED(hr)) silent_operation_complete( impl, result, Completed, S_OK );
+    else silent_operation_complete( impl, NULL, Error, hr );
+    if (result) IInspectable_Release( result );
+done:
+    if (owns_mutex) ReleaseMutex( refresh_mutex );
+    if (refresh_mutex) CloseHandle( refresh_mutex );
+    silent_signal_test_worker_finished();
+    silent_async_Release( &impl->IAsyncOperation_IInspectable_iface );
+    return 0;
+}
+
+static HRESULT silent_get_resource_client_id( HSTRING scopes, HSTRING client_id, IInspectable *properties,
+                                              HSTRING *resource_client_id )
+{
+    IMap_HSTRING_HSTRING *map = NULL;
+    HSTRING key = NULL;
+    const WCHAR *scope_value;
+    HRESULT hr = E_FAIL;
+
+    if (!resource_client_id) return E_POINTER;
+    *resource_client_id = NULL;
+    if (properties && SUCCEEDED(IInspectable_QueryInterface( properties, &IID_IMap_HSTRING_HSTRING,
+                                                              (void **)&map )))
+    {
+        if (FAILED(hr = WindowsCreateString( L"nestedClientId", 14, &key ))) goto done;
+        hr = IMap_HSTRING_HSTRING_Lookup( map, key, resource_client_id );
+        if (SUCCEEDED(hr)) goto done;
+        WindowsDeleteString( *resource_client_id );
+        *resource_client_id = NULL;
+    }
+
+    scope_value = WindowsGetStringRawBuffer( scopes, NULL );
+    if (scope_value && wcsstr( scope_value, L"engage.cloud.microsoft/teams-branded-exp" ))
+        hr = WindowsCreateString( L"f4060917-6abe-40d7-baa6-f634c0eda4ac", 36, resource_client_id );
+    else hr = WindowsDuplicateString( client_id, resource_client_id );
+
+done:
+    WindowsDeleteString( key );
+    if (map) IMap_HSTRING_HSTRING_Release( map );
+    return hr;
+}
+
+static HRESULT silent_token_operation_create( IInspectable *request_object, IInspectable *account,
+                                              IInspectable **out )
+{
+    struct silent_token_operation *impl;
+    struct web_token_request *request = NULL;
+    IInspectable *properties = NULL;
+    HSTRING scopes = NULL, client_id = NULL, resource_client_id = NULL;
+    BOOL worker_reference = FALSE;
+    DWORD last_error;
+    HRESULT hr;
+
+    if (!out) return E_POINTER;
+    *out = NULL;
+    if (!request_object) return E_INVALIDARG;
+    if (FAILED(hr = IInspectable_QueryInterface( request_object, &IID_IWebTokenRequest,
+                                                  (void **)&request ))) return hr;
+    if (FAILED(hr = request->lpVtbl->get_Scope( request, &scopes )) ||
+        FAILED(hr = request->lpVtbl->get_ClientId( request, &client_id )) ||
+        FAILED(hr = request->lpVtbl->get_Properties( request, &properties )) ||
+        FAILED(hr = silent_get_resource_client_id( scopes, client_id, properties, &resource_client_id )))
+        goto failed_request;
+    IInspectable_Release( (IInspectable *)request );
+    request = NULL;
+    if (properties) IInspectable_Release( properties );
+    properties = NULL;
+    if (!(impl = calloc( 1, sizeof(*impl) )))
+    {
+        hr = E_OUTOFMEMORY;
+        goto failed_request;
+    }
+    impl->IAsyncOperation_IInspectable_iface.lpVtbl = &silent_async_vtbl;
+    impl->IAsyncInfo_iface.lpVtbl = &silent_info_vtbl;
+    impl->ref = 1;
+    impl->type = &async_web_token_request_result;
+    impl->state = SILENT_OPERATION_STARTING;
+    impl->error = S_OK;
+    InitializeCriticalSection( &impl->cs );
+    impl->scopes = scopes;
+    impl->client_id = client_id;
+    impl->resource_client_id = resource_client_id;
+    scopes = NULL;
+    client_id = NULL;
+    resource_client_id = NULL;
+    if (account) IInspectable_AddRef( impl->account = account );
+    if (!(impl->cancel_event = CreateEventW( NULL, TRUE, FALSE, NULL )))
+    {
+        last_error = GetLastError();
+        hr = HRESULT_FROM_WIN32( last_error ? last_error : ERROR_FUNCTION_FAILED );
+        goto failed;
+    }
+    /* Keep the operation alive independently of the caller until the worker
+     * has released every field and callback reference.  Keep the ownership
+     * bit explicit so CreateThread failure cannot release either reference
+     * twice or leave the allocation alive without a worker. */
+    silent_async_AddRef( &impl->IAsyncOperation_IInspectable_iface );
+    worker_reference = TRUE;
+    impl->worker = CreateThread( NULL, 0, silent_token_worker, impl, 0, NULL );
+    if (!impl->worker)
+    {
+        last_error = GetLastError();
+        hr = HRESULT_FROM_WIN32( last_error ? last_error : ERROR_FUNCTION_FAILED );
+        if (worker_reference)
+        {
+            worker_reference = FALSE;
+            silent_async_Release( &impl->IAsyncOperation_IInspectable_iface );
+        }
+        goto failed;
+    }
+    *out = (IInspectable *)&impl->IAsyncOperation_IInspectable_iface;
+    TRACE( "silent operation %p returned pending.\n", impl );
+    return S_OK;
+
+failed:
+    if (worker_reference) silent_async_Release( &impl->IAsyncOperation_IInspectable_iface );
+    silent_async_Release( &impl->IAsyncOperation_IInspectable_iface );
+failed_request:
+    if (request) IInspectable_Release( (IInspectable *)request );
+    if (properties) IInspectable_Release( properties );
+    WindowsDeleteString( scopes );
+    WindowsDeleteString( client_id );
+    WindowsDeleteString( resource_client_id );
+    return hr;
 }
 
 static HRESULT WINAPI web_manager_GetTokenSilentlyAsync(
         struct web_authentication_core_manager_statics *iface, IInspectable *request, IInspectable **operation )
 {
-    IInspectable *result;
-    HANDLE refresh_mutex;
-    HRESULT hr;
-
     TRACE( "iface %p, request %p, operation %p.\n", iface, request, operation );
     if (!operation) return E_POINTER;
     *operation = NULL;
-    {
-        struct web_token_request *token_request = (struct web_token_request *)request;
-        const WCHAR *client_id = WindowsGetStringRawBuffer( token_request->client_id, NULL );
-        const WCHAR *scopes = WindowsGetStringRawBuffer( token_request->scope, NULL );
-        const WCHAR *resource_client_id;
-        HSTRING nested_client_id;
-        INT32 status;
-        resource_client_id = get_resource_client_id( token_request, &nested_client_id );
-        refresh_mutex = CreateMutexW( NULL, FALSE, L"Wine365WamTokenRefresh" );
-        if (refresh_mutex) WaitForSingleObject( refresh_mutex, INFINITE );
-        status = is_supported_wam_client( client_id ) &&
-                 is_supported_resource_client( resource_client_id ) &&
-                 prepare_silent_wam_token( scopes, resource_client_id ) ? 0 : 3;
-        hr = web_token_request_result_create( status, scopes, NULL, &result );
-        if (refresh_mutex)
-        {
-            ReleaseMutex( refresh_mutex );
-            CloseHandle( refresh_mutex );
-        }
-        WindowsDeleteString( nested_client_id );
-        if (FAILED(hr)) return hr;
-    }
-    hr = completed_provider_operation_create( &async_web_token_request_result, result, operation );
-    IInspectable_Release( result );
-    return hr;
+    return silent_token_operation_create( request, NULL, operation );
 }
+
 static HRESULT WINAPI web_manager_GetTokenSilentlyWithWebAccountAsync(
         struct web_authentication_core_manager_statics *iface, IInspectable *request, IInspectable *account,
         IInspectable **operation )
 {
-    struct web_token_request *token_request = (struct web_token_request *)request;
-    const WCHAR *client_id = WindowsGetStringRawBuffer( token_request->client_id, NULL );
-    const WCHAR *resource_client_id;
-    HSTRING nested_client_id;
-    IInspectable *result;
-    HANDLE refresh_mutex;
-    HRESULT hr;
-
     TRACE( "iface %p, request %p, account %p, operation %p.\n", iface, request, account, operation );
     if (!operation) return E_POINTER;
     *operation = NULL;
-    resource_client_id = get_resource_client_id( token_request, &nested_client_id );
-    refresh_mutex = CreateMutexW( NULL, FALSE, L"Wine365WamTokenRefresh" );
-    if (refresh_mutex) WaitForSingleObject( refresh_mutex, INFINITE );
-    hr = web_token_request_result_create( is_supported_wam_client( client_id ) &&
-            is_supported_resource_client( resource_client_id ) &&
-            prepare_silent_wam_token(
-            WindowsGetStringRawBuffer( token_request->scope, NULL ),
-            resource_client_id ) ? 0 : 3,
-            WindowsGetStringRawBuffer( token_request->scope, NULL ), account, &result );
-    if (refresh_mutex)
-    {
-        ReleaseMutex( refresh_mutex );
-        CloseHandle( refresh_mutex );
-    }
-    WindowsDeleteString( nested_client_id );
-    if (FAILED(hr)) return hr;
-    hr = completed_provider_operation_create( &async_web_token_request_result, result, operation );
-    IInspectable_Release( result );
-    return hr;
+    return silent_token_operation_create( request, account, operation );
 }
 static HRESULT WINAPI web_manager_RequestTokenAsync(
         struct web_authentication_core_manager_statics *iface, IInspectable *request, IInspectable **operation )

--- a/dlls/windows.security.authentication.onlineid/authenticator.c
+++ b/dlls/windows.security.authentication.onlineid/authenticator.c
@@ -3674,6 +3674,7 @@ static BOOL prepare_silent_wam_token( const WCHAR *scopes, const WCHAR *client_i
          * produced its access token.  A fresh token therefore cannot prove
          * that it is usable for this request; preserve the resource refresh
          * until that identity is published transactionally with the token. */
+        have_token = FALSE;
         helper = run_wine365_resource_refresh( scopes, client_id, cancel_event, timeout, &exit_code );
         if (helper == HELPER_CANCELED)
         {
@@ -4157,15 +4158,15 @@ static DWORD WINAPI silent_token_worker( void *parameter )
         }
     }
 finish_refresh:
-    if (owns_mutex)
-    {
-        ReleaseMutex( refresh_mutex );
-        owns_mutex = FALSE;
-    }
-    if (refresh_mutex) CloseHandle( refresh_mutex );
-    refresh_mutex = NULL;
     if (canceled || silent_cancel_requested( impl->cancel_event ))
     {
+        if (owns_mutex)
+        {
+            ReleaseMutex( refresh_mutex );
+            owns_mutex = FALSE;
+        }
+        if (refresh_mutex) CloseHandle( refresh_mutex );
+        refresh_mutex = NULL;
         silent_operation_complete( impl, NULL, Canceled, E_ABORT );
         goto done;
     }
@@ -4173,6 +4174,15 @@ finish_refresh:
     response_status = supported && have_token ? 0 : 3;
     hr = web_token_request_result_create( response_status,
             WindowsGetStringRawBuffer( impl->scopes, NULL ), impl->account, &result );
+    /* Keep projection reads in the same serialized generation as refresh.
+     * A second helper may publish as soon as this mutex is released. */
+    if (owns_mutex)
+    {
+        ReleaseMutex( refresh_mutex );
+        owns_mutex = FALSE;
+    }
+    if (refresh_mutex) CloseHandle( refresh_mutex );
+    refresh_mutex = NULL;
     if (SUCCEEDED(hr)) silent_operation_complete( impl, result, Completed, S_OK );
     else silent_operation_complete( impl, NULL, Error, hr );
     if (result) IInspectable_Release( result );

--- a/dlls/windows.security.authentication.onlineid/tests/onlineid.c
+++ b/dlls/windows.security.authentication.onlineid/tests/onlineid.c
@@ -1448,6 +1448,44 @@ static void test_silent_helper_outcomes( struct test_manager_statics *manager, I
     }
 }
 
+static void test_silent_resource_refresh_failure( struct test_manager_statics *manager,
+                                                  IInspectable *resource_request,
+                                                  struct test_silent_events *events )
+{
+    IInspectable *operation = NULL;
+    IAsyncOperation_IInspectable *typed = NULL;
+    IAsyncInfo *info = NULL;
+    AsyncStatus status = Started;
+    HRESULT hr;
+
+    test_silent_events_reset( events );
+    test_silent_environment( L"fail" );
+    ok( test_write_success_fixture(), "failed to write cached resource-failure fixture.\n" );
+    hr = test_silent_start( manager, resource_request, NULL, &operation );
+    ok( hr == S_OK && operation, "resource-failure start got %#lx, %p.\n", hr, operation );
+    if (!operation) goto done;
+    ok( test_wait_event( events->helper_completed, "resource failure helper" ),
+        "resource failure helper did not finish.\n" );
+    ok( test_wait_event( events->operation_completed, "resource failure operation" ),
+        "resource failure operation did not finish.\n" );
+    ok( test_wait_event( events->worker_finished, "resource failure worker" ),
+        "resource failure worker did not finish.\n" );
+    ok( test_silent_get_abi( operation, &typed, &info ), "resource failure ABI setup failed.\n" );
+    if (info)
+    {
+        hr = IAsyncInfo_get_Status( info, &status );
+        ok( hr == S_OK && status == Completed, "resource failure status got %#lx, %u.\n",
+            hr, status );
+    }
+    if (typed) test_silent_check_response_status( typed, 3 );
+    if (typed && info) test_silent_postclose( typed, info );
+
+done:
+    if (typed) IAsyncOperation_IInspectable_Release( typed );
+    if (info) IAsyncInfo_Release( info );
+    if (operation) IInspectable_Release( operation );
+}
+
 static void test_silent_token_operations(void)
 {
     static const WCHAR class_name[] =
@@ -1537,6 +1575,7 @@ static void test_silent_token_operations(void)
     provider = NULL;
     if (resource_request) test_silent_completion_before_handler( manager, resource_request, &events );
     test_silent_helper_outcomes( manager, request, &events );
+    if (resource_request) test_silent_resource_refresh_failure( manager, resource_request, &events );
     test_silent_blocked_case( manager, request, NULL, &events, TRUE, FALSE, FALSE );
     test_silent_blocked_case( manager, request, NULL, &events, FALSE, FALSE, TRUE );
     test_silent_blocked_case( manager, request, NULL, &events, FALSE, TRUE, FALSE );

--- a/dlls/windows.security.authentication.onlineid/tests/onlineid.c
+++ b/dlls/windows.security.authentication.onlineid/tests/onlineid.c
@@ -18,6 +18,7 @@
 #define COBJMACROS
 #include "initguid.h"
 #include <stdarg.h>
+#include <stdlib.h>
 
 #include "windef.h"
 #include "winbase.h"
@@ -655,11 +656,11 @@ static void test_parameterized_iids(void)
                 if (find_iface)
                 {
                     void *out = (void *)0xdeadbeef;
+                    IID *result_iids = NULL;
+                    ULONG result_count = 0;
                     hr = find_iface->lpVtbl->QueryInterface(find_iface,
                                                             &test_iid_IAsyncOperation_WebAccount, &out);
                     ok(hr == E_NOINTERFACE && !out, "FindAllAccountsResult unrelated QI got %#lx, %p.\n", hr, out);
-                    IID *result_iids = NULL;
-                    ULONG result_count = 0;
                     hr = find_iface->lpVtbl->GetIids(find_iface, &result_count, &result_iids);
                     ok(hr == S_OK && result_count == 1 && result_iids &&
                        IsEqualGUID(&result_iids[0], &test_iid_IFindAllAccountsResult),
@@ -732,6 +733,834 @@ done:
     WindowsDeleteString(scope);
 }
 
+struct test_async_handler
+{
+    IAsyncOperationCompletedHandler_IInspectable iface;
+    LONG ref;
+    HANDLE entered;
+    HANDLE release;
+    HANDLE finished;
+    AsyncStatus status;
+    HRESULT status_hr;
+    HRESULT result_hr;
+};
+
+static inline struct test_async_handler *impl_from_test_handler(
+        IAsyncOperationCompletedHandler_IInspectable *iface )
+{
+    return CONTAINING_RECORD( iface, struct test_async_handler, iface );
+}
+
+static HRESULT WINAPI test_handler_QueryInterface( IAsyncOperationCompletedHandler_IInspectable *iface,
+                                                    REFIID iid, void **out )
+{
+    if (!out) return E_POINTER;
+    *out = NULL;
+    if (IsEqualGUID( iid, &IID_IUnknown ) || IsEqualGUID( iid, &IID_IInspectable ) ||
+        IsEqualGUID( iid, &IID_IAgileObject ) ||
+        IsEqualGUID( iid, &IID_IAsyncOperationCompletedHandler_IInspectable ))
+        *out = iface;
+    else return E_NOINTERFACE;
+    IAsyncOperationCompletedHandler_IInspectable_AddRef( iface );
+    return S_OK;
+}
+
+static ULONG WINAPI test_handler_AddRef( IAsyncOperationCompletedHandler_IInspectable *iface )
+{
+    return InterlockedIncrement( &impl_from_test_handler( iface )->ref );
+}
+
+static ULONG WINAPI test_handler_Release( IAsyncOperationCompletedHandler_IInspectable *iface )
+{
+    struct test_async_handler *impl = impl_from_test_handler( iface );
+    ULONG ref = InterlockedDecrement( &impl->ref );
+    if (!ref) free( impl );
+    return ref;
+}
+
+static HRESULT WINAPI test_handler_Invoke( IAsyncOperationCompletedHandler_IInspectable *iface,
+                                            IAsyncOperation_IInspectable *operation, AsyncStatus status )
+{
+    struct test_async_handler *impl = impl_from_test_handler( iface );
+    IAsyncInfo *info = NULL;
+    IInspectable *result = NULL;
+
+    impl->status = status;
+    impl->status_hr = IAsyncOperation_IInspectable_QueryInterface( operation, &IID_IAsyncInfo,
+                                                                    (void **)&info );
+    if (SUCCEEDED( impl->status_hr ))
+    {
+        impl->status_hr = IAsyncInfo_get_Status( info, &impl->status );
+        IAsyncInfo_Release( info );
+    }
+    impl->result_hr = IAsyncOperation_IInspectable_GetResults( operation, &result );
+    if (result) IInspectable_Release( result );
+    if (impl->entered) SetEvent( impl->entered );
+    if (impl->release) WaitForSingleObject( impl->release, 5000 );
+    if (impl->finished) SetEvent( impl->finished );
+    return S_OK;
+}
+
+static const IAsyncOperationCompletedHandler_IInspectableVtbl test_handler_vtbl =
+{
+    test_handler_QueryInterface, test_handler_AddRef, test_handler_Release, test_handler_Invoke,
+};
+
+static struct test_async_handler *test_handler_create( HANDLE entered, HANDLE release, HANDLE finished )
+{
+    struct test_async_handler *handler = calloc( 1, sizeof(*handler) );
+    if (!handler) return NULL;
+    handler->iface.lpVtbl = &test_handler_vtbl;
+    handler->ref = 1;
+    handler->entered = entered;
+    handler->release = release;
+    handler->finished = finished;
+    return handler;
+}
+
+struct test_silent_events
+{
+    HANDLE started;
+    HANDLE helper_release;
+    HANDLE helper_completed;
+    HANDLE operation_completed;
+    HANDLE worker_gate;
+    HANDLE worker_finished;
+    HANDLE callback_entered;
+    HANDLE callback_release;
+    HANDLE callback_finished;
+};
+
+static BOOL test_wait_event( HANDLE event, const char *name )
+{
+    DWORD wait = WaitForSingleObject( event, 5000 );
+    ok( wait == WAIT_OBJECT_0, "%s wait returned %#lx.\n", name, wait );
+    return wait == WAIT_OBJECT_0;
+}
+
+static void test_silent_wait_worker_finished( struct test_silent_events *events, BOOL worker_exists,
+                                              BOOL *worker_finished, const char *name )
+{
+    if (worker_exists && !*worker_finished)
+        *worker_finished = test_wait_event( events->worker_finished, name );
+}
+
+static BOOL test_silent_events_create( struct test_silent_events *events )
+{
+    static const WCHAR started_name[] = L"Local\\WineOnlineIdTestHelperStarted";
+    static const WCHAR release_name[] = L"Local\\WineOnlineIdTestHelperRelease";
+    static const WCHAR helper_completed_name[] = L"Local\\WineOnlineIdTestHelperCompleted";
+    static const WCHAR operation_completed_name[] = L"Local\\WineOnlineIdTestOperationCompleted";
+    static const WCHAR worker_gate_name[] = L"Local\\WineOnlineIdTestWorkerGate";
+    static const WCHAR worker_finished_name[] = L"Local\\WineOnlineIdTestWorkerFinished";
+
+    memset( events, 0, sizeof(*events) );
+    events->started = CreateEventW( NULL, TRUE, FALSE, started_name );
+    events->helper_release = CreateEventW( NULL, TRUE, FALSE, release_name );
+    events->helper_completed = CreateEventW( NULL, TRUE, FALSE, helper_completed_name );
+    events->operation_completed = CreateEventW( NULL, TRUE, FALSE, operation_completed_name );
+    events->worker_gate = CreateEventW( NULL, TRUE, FALSE, worker_gate_name );
+    events->worker_finished = CreateEventW( NULL, TRUE, FALSE, worker_finished_name );
+    events->callback_entered = CreateEventW( NULL, TRUE, FALSE, NULL );
+    events->callback_release = CreateEventW( NULL, TRUE, FALSE, NULL );
+    events->callback_finished = CreateEventW( NULL, TRUE, FALSE, NULL );
+    return events->started && events->helper_release && events->helper_completed &&
+           events->operation_completed && events->worker_gate && events->worker_finished &&
+           events->callback_entered && events->callback_release && events->callback_finished;
+}
+
+static void test_silent_events_reset( struct test_silent_events *events )
+{
+    ResetEvent( events->started );
+    ResetEvent( events->helper_release );
+    ResetEvent( events->helper_completed );
+    ResetEvent( events->operation_completed );
+    ResetEvent( events->worker_gate );
+    ResetEvent( events->worker_finished );
+    ResetEvent( events->callback_entered );
+    ResetEvent( events->callback_release );
+    ResetEvent( events->callback_finished );
+}
+
+static void test_silent_events_close( struct test_silent_events *events )
+{
+    if (events->started) CloseHandle( events->started );
+    if (events->helper_release) CloseHandle( events->helper_release );
+    if (events->helper_completed) CloseHandle( events->helper_completed );
+    if (events->operation_completed) CloseHandle( events->operation_completed );
+    if (events->worker_gate) CloseHandle( events->worker_gate );
+    if (events->worker_finished) CloseHandle( events->worker_finished );
+    if (events->callback_entered) CloseHandle( events->callback_entered );
+    if (events->callback_release) CloseHandle( events->callback_release );
+    if (events->callback_finished) CloseHandle( events->callback_finished );
+}
+
+static BOOL test_write_file( const WCHAR *path, const char *value )
+{
+    HANDLE file;
+    DWORD written;
+    DWORD size = strlen( value );
+
+    file = CreateFileW( path, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS,
+                        FILE_ATTRIBUTE_NORMAL, NULL );
+    if (file == INVALID_HANDLE_VALUE) return FALSE;
+    if (!WriteFile( file, value, size, &written, NULL ) || written != size)
+    {
+        CloseHandle( file );
+        return FALSE;
+    }
+    CloseHandle( file );
+    return TRUE;
+}
+
+static void test_delete_token_files(void)
+{
+    DeleteFileW( L"C:\\wam-refresh-token.txt" );
+    DeleteFileW( L"C:\\wam-access-token.txt" );
+    DeleteFileW( L"C:\\wam-licensing-token.txt" );
+    DeleteFileW( L"C:\\wam-token-expires-on.txt" );
+    DeleteFileW( L"C:\\wam-account-username.txt" );
+    DeleteFileW( L"C:\\wam-account-id.txt" );
+    DeleteFileW( L"C:\\wam-account-oid.txt" );
+    DeleteFileW( L"C:\\wam-account-tenant-id.txt" );
+    DeleteFileW( L"C:\\wam-account-authority.txt" );
+    DeleteFileW( L"C:\\wam-account-first-name.txt" );
+    DeleteFileW( L"C:\\wam-account-last-name.txt" );
+    DeleteFileW( L"C:\\wam-account-display-name.txt" );
+    DeleteFileW( L"C:\\wam-client-info.txt" );
+    DeleteFileW( L"C:\\wam-id-token.txt" );
+}
+
+static BOOL test_write_refresh_token(void)
+{
+    test_delete_token_files();
+    return test_write_file( L"C:\\wam-refresh-token.txt", "plan01-refresh-token" );
+}
+
+static BOOL test_write_account_fixture(void);
+
+static BOOL test_write_success_fixture(void)
+{
+    test_delete_token_files();
+    return test_write_file( L"C:\\wam-access-token.txt", "plan01-access-token" ) &&
+           test_write_file( L"C:\\wam-licensing-token.txt", "plan01-licensing-token" ) &&
+           test_write_file( L"C:\\wam-token-expires-on.txt", "4102444800" ) &&
+           test_write_file( L"C:\\wam-account-authority.txt", "https://login.microsoftonline.com/organizations/" ) &&
+           test_write_file( L"C:\\wam-client-info.txt", "plan01-client-info" ) &&
+           test_write_file( L"C:\\wam-id-token.txt", "plan01-id-token" ) &&
+           test_write_account_fixture();
+}
+
+static BOOL test_write_account_fixture(void)
+{
+    return test_write_file( L"C:\\wam-account-username.txt", "plan01@example.invalid" ) &&
+           test_write_file( L"C:\\wam-account-id.txt", "plan01-account-id" ) &&
+           test_write_file( L"C:\\wam-account-oid.txt", "11111111-1111-1111-1111-111111111111" ) &&
+           test_write_file( L"C:\\wam-account-tenant-id.txt", "22222222-2222-2222-2222-222222222222" ) &&
+           test_write_file( L"C:\\wam-account-authority.txt", "https://login.microsoftonline.com/organizations/" );
+}
+
+static void test_silent_environment( const WCHAR *mode )
+{
+    SetEnvironmentVariableW( L"LOCALAPPDATA", L"C:\\users\\plan01\\AppData\\Local" );
+    SetEnvironmentVariableW( L"WINE_ONLINEID_TEST_HELPER_MODE", mode );
+    SetEnvironmentVariableW( L"WINE_ONLINEID_HELPER_TIMEOUT_MS", L"5000" );
+}
+
+static void test_silent_environment_clear(void)
+{
+    SetEnvironmentVariableW( L"WINE_ONLINEID_TEST_HELPER_MODE", NULL );
+    SetEnvironmentVariableW( L"WINE_ONLINEID_HELPER_TIMEOUT_MS", NULL );
+    SetEnvironmentVariableW( L"LOCALAPPDATA", NULL );
+    test_delete_token_files();
+}
+
+static BOOL test_silent_get_abi( IInspectable *operation, IAsyncOperation_IInspectable **typed_out,
+                                 IAsyncInfo **info_out )
+{
+    IAsyncOperation_IInspectable *typed = NULL;
+    IAsyncOperation_IInspectable *from_info = NULL;
+    IAsyncInfo *info = NULL;
+    IUnknown *identity1 = NULL, *identity2 = NULL;
+    HSTRING class_name = NULL;
+    IID *iids = NULL, *info_iids = NULL;
+    ULONG count = 0, info_count = 0;
+    void *out = (void *)0xdeadbeef;
+    HRESULT hr;
+
+    *typed_out = NULL;
+    *info_out = NULL;
+    hr = IInspectable_QueryInterface( operation, &test_iid_IAsyncOperation_WebTokenRequestResult,
+                                      (void **)&typed );
+    ok( hr == S_OK && typed, "silent typed IID got %#lx, iface %p.\n", hr, typed );
+    hr = IInspectable_QueryInterface( operation, &test_iid_IAsyncOperation_WebAccount, &out );
+    ok( hr == E_NOINTERFACE && !out, "silent unrelated IID got %#lx, iface %p.\n", hr, out );
+    if (!typed) return FALSE;
+    hr = IAsyncOperation_IInspectable_GetIids( typed, &count, &iids );
+    ok( hr == S_OK && count == 2 && iids &&
+        test_iid_in_list( iids, count, &test_iid_IAsyncOperation_WebTokenRequestResult ) &&
+        test_iid_in_list( iids, count, &IID_IAsyncInfo ), "silent GetIids got %#lx, count %lu.\n", hr, count );
+    CoTaskMemFree( iids );
+    hr = IAsyncOperation_IInspectable_GetRuntimeClassName( typed, &class_name );
+    ok( hr == S_OK && class_name &&
+        !wcscmp( WindowsGetStringRawBuffer( class_name, NULL ),
+                 L"Windows.Foundation.IAsyncOperation`1<Windows.Security.Authentication.Web.Core.WebTokenRequestResult>" ),
+        "silent class name got %#lx, %s.\n", hr, wine_dbgstr_hstring( class_name ) );
+    WindowsDeleteString( class_name );
+    hr = IAsyncOperation_IInspectable_QueryInterface( typed, &IID_IAsyncInfo, (void **)&info );
+    ok( hr == S_OK && info, "silent IAsyncInfo QI got %#lx, iface %p.\n", hr, info );
+    if (info)
+    {
+        hr = IAsyncInfo_QueryInterface( info, &test_iid_IAsyncOperation_WebTokenRequestResult,
+                                        (void **)&from_info );
+        ok( hr == S_OK && from_info, "silent IAsyncInfo typed QI got %#lx, iface %p.\n", hr, from_info );
+        if (from_info) IAsyncOperation_IInspectable_Release( from_info );
+        hr = IAsyncInfo_GetIids( info, &info_count, &info_iids );
+        ok( hr == S_OK && info_count == 2 && info_iids &&
+            test_iid_in_list( info_iids, info_count, &test_iid_IAsyncOperation_WebTokenRequestResult ) &&
+            test_iid_in_list( info_iids, info_count, &IID_IAsyncInfo ),
+            "silent IAsyncInfo GetIids got %#lx, count %lu.\n", hr, info_count );
+        CoTaskMemFree( info_iids );
+    }
+    hr = IAsyncOperation_IInspectable_QueryInterface( typed, &IID_IUnknown, (void **)&identity1 );
+    ok( hr == S_OK && identity1, "silent identity QI got %#lx.\n", hr );
+    if (info)
+    {
+        hr = IAsyncInfo_QueryInterface( info, &IID_IUnknown, (void **)&identity2 );
+        ok( hr == S_OK && identity2 == identity1, "silent identity mismatch, hr %#lx.\n", hr );
+    }
+    if (identity2) IUnknown_Release( identity2 );
+    if (identity1) IUnknown_Release( identity1 );
+    if (!info)
+    {
+        IAsyncOperation_IInspectable_Release( typed );
+        return FALSE;
+    }
+    *typed_out = typed;
+    *info_out = info;
+    return TRUE;
+}
+
+static void test_silent_check_response_status( IAsyncOperation_IInspectable *typed, INT32 expected )
+{
+    struct test_token_result *token_result = NULL;
+    IInspectable *result = NULL;
+    INT32 status = -1;
+    HRESULT hr;
+
+    hr = IAsyncOperation_IInspectable_GetResults( typed, &result );
+    ok( hr == S_OK && result, "silent response result got %#lx, %p.\n", hr, result );
+    if (!result) return;
+    hr = IInspectable_QueryInterface( result, &test_iid_IWebTokenRequestResult, (void **)&token_result );
+    ok( hr == S_OK && token_result, "silent response result QI got %#lx, %p.\n", hr, token_result );
+    if (token_result)
+    {
+        hr = token_result->lpVtbl->get_ResponseStatus( token_result, &status );
+        ok( hr == S_OK && status == expected, "silent response status got %#lx, %d, expected %d.\n",
+            hr, status, expected );
+        token_result->lpVtbl->Release( token_result );
+    }
+    IInspectable_Release( result );
+}
+
+static void test_silent_postclose( IAsyncOperation_IInspectable *typed, IAsyncInfo *info )
+{
+    IAsyncOperationCompletedHandler_IInspectable *handler = (void *)0xdeadbeef;
+    IInspectable *result = (void *)0xdeadbeef;
+    AsyncStatus status = Completed;
+    HRESULT hr;
+
+    hr = IAsyncInfo_Close( info );
+    ok( hr == S_OK, "silent Close got %#lx.\n", hr );
+    hr = IAsyncInfo_Close( info );
+    ok( hr == S_OK, "silent second Close got %#lx.\n", hr );
+    hr = IAsyncInfo_get_Status( info, &status );
+    ok( hr == E_ILLEGAL_METHOD_CALL && status == Started, "silent closed status got %#lx, %u.\n", hr, status );
+    hr = IAsyncOperation_IInspectable_GetResults( typed, &result );
+    ok( hr == E_ILLEGAL_METHOD_CALL && !result, "silent closed results got %#lx, %p.\n", hr, result );
+    hr = IAsyncOperation_IInspectable_get_Completed( typed, &handler );
+    ok( hr == E_ILLEGAL_METHOD_CALL && !handler, "silent closed handler got %#lx, %p.\n", hr, handler );
+}
+
+static HRESULT test_silent_start( struct test_manager_statics *manager, IInspectable *request,
+                                  IInspectable *account, IInspectable **operation )
+{
+    if (account) return manager->lpVtbl->GetTokenSilentlyWithWebAccountAsync( manager, request, account, operation );
+    return manager->lpVtbl->GetTokenSilentlyAsync( manager, request, operation );
+}
+
+struct test_silent_call_context
+{
+    struct test_manager_statics *manager;
+    IInspectable *request;
+    IInspectable *account;
+    IInspectable *operation;
+    HANDLE returned;
+    HRESULT hr;
+};
+
+static DWORD WINAPI test_silent_call_thread( void *parameter )
+{
+    struct test_silent_call_context *context = parameter;
+
+    context->hr = test_silent_start( context->manager, context->request, context->account,
+                                      &context->operation );
+    if (context->account) IInspectable_Release( context->account );
+    SetEvent( context->returned );
+    return 0;
+}
+
+static BOOL test_silent_start_thread( struct test_manager_statics *manager, IInspectable *request,
+                                      IInspectable *account, struct test_silent_events *events,
+                                      BOOL release_worker_gate, IInspectable **operation )
+{
+    struct test_silent_call_context context = {manager, request, account, NULL, NULL, E_FAIL};
+    HANDLE thread;
+    BOOL returned;
+
+    *operation = NULL;
+    if (!(context.returned = CreateEventW( NULL, TRUE, FALSE, NULL ))) return FALSE;
+    if (account) IInspectable_AddRef( account );
+    if (!(thread = CreateThread( NULL, 0, test_silent_call_thread, &context, 0, NULL )))
+    {
+        if (account) IInspectable_Release( account );
+        CloseHandle( context.returned );
+        return FALSE;
+    }
+
+    returned = WaitForSingleObject( context.returned, 5000 ) == WAIT_OBJECT_0;
+    ok( returned, "silent caller did not return before the worker gate.\n" );
+    /* This is the ordering handoff: the worker cannot reach mutex, token, or
+     * helper work until the caller thread has signaled its return. */
+    if (release_worker_gate || !returned) SetEvent( events->worker_gate );
+    if (!returned) SetEvent( events->helper_release );
+    ok( WaitForSingleObject( thread, 5000 ) == WAIT_OBJECT_0, "silent caller thread did not finish.\n" );
+    CloseHandle( thread );
+    CloseHandle( context.returned );
+    *operation = context.operation;
+    return returned && context.hr == S_OK && !!context.operation;
+}
+
+static void test_silent_cancel_before_mutex( struct test_manager_statics *manager, IInspectable *request,
+                                             struct test_silent_events *events )
+{
+    IInspectable *operation = NULL;
+    IAsyncOperation_IInspectable *typed = NULL;
+    IAsyncInfo *info = NULL;
+    struct test_async_handler *handler = NULL;
+    BOOL worker_exists = FALSE, worker_finished = FALSE;
+    HRESULT hr;
+
+    test_silent_events_reset( events );
+    test_silent_environment( L"gated-block" );
+    ok( test_write_refresh_token(), "failed to write cancel-before-mutex fixture.\n" );
+    ok( test_silent_start_thread( manager, request, NULL, events, FALSE, &operation ),
+        "cancel-before-mutex start failed.\n" );
+    if (!operation) goto done;
+    worker_exists = TRUE;
+    ok( test_silent_get_abi( operation, &typed, &info ), "cancel-before-mutex ABI setup failed.\n" );
+    if (!typed || !info) goto done;
+    handler = test_handler_create( events->callback_entered, NULL, events->callback_finished );
+    ok( !!handler, "cancel-before-mutex handler allocation failed.\n" );
+    if (!handler) goto done;
+    hr = IAsyncOperation_IInspectable_put_Completed( typed, &handler->iface );
+    ok( hr == S_OK, "cancel-before-mutex put Completed got %#lx.\n", hr );
+    hr = IAsyncInfo_Cancel( info );
+    ok( hr == S_OK, "cancel-before-mutex Cancel got %#lx.\n", hr );
+    ok( test_wait_event( events->callback_entered, "cancel-before-mutex callback" ),
+        "cancel-before-mutex callback missing.\n" );
+    worker_finished = test_wait_event( events->worker_finished, "cancel-before-mutex worker" );
+    ok( WaitForSingleObject( events->started, 0 ) == WAIT_TIMEOUT,
+        "cancel-before-mutex reached helper work.\n" );
+    test_silent_postclose( typed, info );
+
+done:
+    SetEvent( events->worker_gate );
+    SetEvent( events->helper_release );
+    test_silent_wait_worker_finished( events, worker_exists, &worker_finished, "cancel-before-mutex cleanup worker" );
+    if (handler) IAsyncOperationCompletedHandler_IInspectable_Release( &handler->iface );
+    if (typed) IAsyncOperation_IInspectable_Release( typed );
+    if (info) IAsyncInfo_Release( info );
+    if (operation) IInspectable_Release( operation );
+}
+
+static void test_silent_blocked_case( struct test_manager_statics *manager, IInspectable *request,
+                                      IInspectable *account, struct test_silent_events *events,
+                                      BOOL cancel, BOOL close_race, BOOL close_before_callback )
+{
+    IInspectable *operation = NULL, *result = NULL;
+    IAsyncOperation_IInspectable *typed = NULL;
+    IAsyncInfo *info = NULL;
+    struct test_async_handler *handler = NULL;
+    BOOL worker_exists = FALSE, worker_finished = FALSE;
+    AsyncStatus status = Completed;
+    HRESULT hr;
+
+    test_silent_events_reset( events );
+    test_silent_environment( L"gated-block" );
+    ok( test_write_refresh_token(), "failed to write silent refresh fixture.\n" );
+    ok( test_silent_start_thread( manager, request, account, events, TRUE, &operation ),
+        "silent start did not return a pending operation.\n" );
+    if (account) IInspectable_Release( account );
+    if (!operation) goto done;
+    worker_exists = TRUE;
+    ok( test_wait_event( events->started, "helper started" ), "helper did not start.\n" );
+    ok( test_silent_get_abi( operation, &typed, &info ), "silent ABI setup failed.\n" );
+    if (!typed || !info) goto done;
+    hr = IAsyncInfo_get_Status( info, &status );
+    ok( hr == S_OK && status == Started, "pending silent status got %#lx, %u.\n", hr, status );
+
+    handler = test_handler_create( events->callback_entered, close_race ? events->callback_release : NULL,
+                                   events->callback_finished );
+    ok( !!handler, "failed to create silent handler.\n" );
+    if (!handler) goto done;
+    hr = IAsyncOperation_IInspectable_put_Completed( typed, &handler->iface );
+    ok( hr == S_OK, "silent put Completed got %#lx.\n", hr );
+    hr = IAsyncOperation_IInspectable_put_Completed( typed, &handler->iface );
+    ok( hr == E_ILLEGAL_DELEGATE_ASSIGNMENT, "silent second put Completed got %#lx.\n", hr );
+    ok( WaitForSingleObject( events->callback_entered, 0 ) == WAIT_TIMEOUT,
+        "silent callback ran before helper release.\n" );
+
+    if (cancel)
+    {
+        hr = IAsyncInfo_Cancel( info );
+        ok( hr == S_OK, "silent Cancel got %#lx.\n", hr );
+        ok( test_wait_event( events->callback_entered, "canceled callback" ), "canceled callback missing.\n" );
+        ok( handler->status == Canceled && handler->status_hr == S_OK &&
+            handler->result_hr == E_ILLEGAL_METHOD_CALL,
+            "canceled callback status %u, status hr %#lx, results hr %#lx.\n",
+            handler->status, handler->status_hr, handler->result_hr );
+        SetEvent( events->helper_release );
+        test_wait_event( events->helper_completed, "canceled helper" );
+        worker_finished = test_wait_event( events->worker_finished, "canceled worker" );
+        hr = IAsyncInfo_get_Status( info, &status );
+        ok( hr == S_OK && status == Canceled, "canceled status got %#lx, %u.\n", hr, status );
+        {
+            HRESULT error = S_OK;
+            hr = IAsyncInfo_get_ErrorCode( info, &error );
+            ok( hr == S_OK && error == E_ABORT, "canceled error got %#lx, %#lx.\n", hr, error );
+        }
+        result = (void *)0xdeadbeef;
+        hr = IAsyncOperation_IInspectable_GetResults( typed, &result );
+        ok( hr == E_ILLEGAL_METHOD_CALL && !result, "canceled results got %#lx, %p.\n", hr, result );
+        test_silent_postclose( typed, info );
+    }
+    else if (close_before_callback)
+    {
+        hr = IAsyncInfo_Close( info );
+        ok( hr == S_OK, "close-before-callback Close got %#lx.\n", hr );
+        test_silent_postclose( typed, info );
+        SetEvent( events->helper_release );
+        ok( test_wait_event( events->helper_completed, "closed helper" ), "closed helper missing.\n" );
+        worker_finished = test_wait_event( events->worker_finished, "closed worker" );
+        ok( WaitForSingleObject( events->callback_entered, 0 ) == WAIT_TIMEOUT,
+            "callback ran after Close won the terminal race.\n" );
+    }
+    else if (close_race)
+    {
+        SetEvent( events->helper_release );
+        ok( test_wait_event( events->callback_entered, "in-flight callback" ), "in-flight callback missing.\n" );
+        hr = IAsyncInfo_Close( info );
+        ok( hr == S_OK, "in-flight Close got %#lx.\n", hr );
+        test_silent_postclose( typed, info );
+        IAsyncOperation_IInspectable_Release( typed );
+        typed = NULL;
+        IAsyncInfo_Release( info );
+        info = NULL;
+        IInspectable_Release( operation );
+        operation = NULL;
+        IAsyncOperationCompletedHandler_IInspectable_Release( &handler->iface );
+        handler = NULL;
+        SetEvent( events->callback_release );
+        test_wait_event( events->callback_finished, "finished in-flight callback" );
+        worker_finished = test_wait_event( events->worker_finished, "in-flight worker" );
+    }
+    else
+    {
+        SetEvent( events->helper_release );
+        ok( test_wait_event( events->helper_completed, "completed helper" ), "helper completion missing.\n" );
+        ok( test_wait_event( events->callback_entered, "completed callback" ), "completed callback missing.\n" );
+        worker_finished = test_wait_event( events->worker_finished, "completed worker" );
+        ok( handler->status == Completed && handler->status_hr == S_OK && handler->result_hr == S_OK,
+            "completed callback status %u, status hr %#lx, results hr %#lx.\n",
+            handler->status, handler->status_hr, handler->result_hr );
+        result = NULL;
+        hr = IAsyncOperation_IInspectable_GetResults( typed, &result );
+        ok( hr == S_OK && result, "completed results got %#lx, %p.\n", hr, result );
+        if (result) IInspectable_Release( result );
+        test_silent_check_response_status( typed, 3 );
+        test_silent_postclose( typed, info );
+    }
+
+done:
+    SetEvent( events->worker_gate );
+    SetEvent( events->helper_release );
+    SetEvent( events->callback_release );
+    test_silent_wait_worker_finished( events, worker_exists, &worker_finished, "silent cleanup worker" );
+    if (handler) IAsyncOperationCompletedHandler_IInspectable_Release( &handler->iface );
+    if (typed) IAsyncOperation_IInspectable_Release( typed );
+    if (info) IAsyncInfo_Release( info );
+    if (operation) IInspectable_Release( operation );
+}
+
+static void test_silent_completion_before_handler( struct test_manager_statics *manager, IInspectable *request,
+                                                   struct test_silent_events *events )
+{
+    IInspectable *operation = NULL, *result = NULL;
+    IAsyncOperation_IInspectable *typed = NULL;
+    IAsyncInfo *info = NULL;
+    struct test_async_handler *handler = NULL;
+    BOOL worker_exists = FALSE, worker_finished = FALSE;
+    AsyncStatus status = Started;
+    HRESULT hr;
+
+    test_silent_events_reset( events );
+    test_silent_environment( L"success" );
+    ok( test_write_success_fixture(), "failed to write silent completion fixture.\n" );
+    hr = test_silent_start( manager, request, NULL, &operation );
+    ok( hr == S_OK && operation, "completion-before-handler start got %#lx, %p.\n", hr, operation );
+    if (!operation) goto done;
+    worker_exists = TRUE;
+    ok( test_wait_event( events->started, "fresh resource helper start" ),
+        "fresh resource token was reused without proving its scope and client.\n" );
+    ok( test_wait_event( events->helper_completed, "fresh resource helper completion" ),
+        "fresh resource helper did not complete.\n" );
+    ok( test_wait_event( events->operation_completed, "operation completion" ),
+        "operation did not reach terminal state.\n" );
+    worker_finished = test_wait_event( events->worker_finished, "completion worker" );
+    ok( test_silent_get_abi( operation, &typed, &info ), "completion-before-handler ABI failed.\n" );
+    if (!typed || !info) goto done;
+    hr = IAsyncInfo_get_Status( info, &status );
+    ok( hr == S_OK && status == Completed, "completion-before-handler status got %#lx, %u.\n", hr, status );
+    handler = test_handler_create( events->callback_entered, NULL, events->callback_finished );
+    ok( !!handler, "failed to create completion-before-handler callback.\n" );
+    if (!handler) goto done;
+    hr = IAsyncOperation_IInspectable_put_Completed( typed, &handler->iface );
+    ok( hr == S_OK, "completion-before-handler put got %#lx.\n", hr );
+    ok( test_wait_event( events->callback_entered, "late callback" ), "late callback missing.\n" );
+    ok( handler->status == Completed && handler->status_hr == S_OK && handler->result_hr == S_OK,
+        "late callback status %u, status hr %#lx, results hr %#lx.\n",
+        handler->status, handler->status_hr, handler->result_hr );
+    test_silent_check_response_status( typed, 0 );
+    result = NULL;
+    hr = IAsyncOperation_IInspectable_GetResults( typed, &result );
+    ok( hr == S_OK && result, "late results got %#lx, %p.\n", hr, result );
+    if (result) IInspectable_Release( result );
+    test_silent_postclose( typed, info );
+
+done:
+    SetEvent( events->worker_gate );
+    SetEvent( events->helper_release );
+    test_silent_wait_worker_finished( events, worker_exists, &worker_finished, "completion cleanup worker" );
+    if (handler) IAsyncOperationCompletedHandler_IInspectable_Release( &handler->iface );
+    if (typed) IAsyncOperation_IInspectable_Release( typed );
+    if (info) IAsyncInfo_Release( info );
+    if (operation) IInspectable_Release( operation );
+}
+
+static void test_silent_account_completion( struct test_manager_statics *manager, IInspectable *request,
+                                            IInspectable *account, struct test_silent_events *events )
+{
+    IInspectable *operation = NULL;
+    IAsyncOperation_IInspectable *typed = NULL;
+    IAsyncInfo *info = NULL;
+    BOOL worker_exists = FALSE, worker_finished = FALSE;
+    AsyncStatus status = Started;
+    HRESULT hr;
+
+    test_silent_events_reset( events );
+    test_silent_environment( L"success" );
+    ok( test_write_success_fixture(), "failed to write account completion fixture.\n" );
+    ok( test_silent_start_thread( manager, request, account, events, TRUE, &operation ),
+        "account silent start did not return a pending operation.\n" );
+    IInspectable_Release( account );
+    if (!operation) goto done;
+    worker_exists = TRUE;
+    ok( test_wait_event( events->operation_completed, "account operation completion" ),
+        "account operation did not complete.\n" );
+    worker_finished = test_wait_event( events->worker_finished, "account completion worker" );
+    ok( test_silent_get_abi( operation, &typed, &info ), "account completion ABI setup failed.\n" );
+    if (!typed || !info) goto done;
+    hr = IAsyncInfo_get_Status( info, &status );
+    ok( hr == S_OK && status == Completed, "account completion status got %#lx, %u.\n", hr, status );
+    test_silent_check_response_status( typed, 0 );
+    test_silent_postclose( typed, info );
+
+done:
+    SetEvent( events->worker_gate );
+    SetEvent( events->helper_release );
+    test_silent_wait_worker_finished( events, worker_exists, &worker_finished, "account cleanup worker" );
+    if (typed) IAsyncOperation_IInspectable_Release( typed );
+    if (info) IAsyncInfo_Release( info );
+    if (operation) IInspectable_Release( operation );
+}
+
+static void test_silent_helper_outcomes( struct test_manager_statics *manager, IInspectable *request,
+                                         struct test_silent_events *events )
+{
+    static const WCHAR *const modes[] =
+    {
+        L"fail", L"timeout", L"crash", L"missing", L"shutdown",
+        L"real-fail", L"real-timeout", L"real-crash", L"real-missing", L"real-shutdown"
+    };
+    unsigned int i;
+
+    for (i = 0; i < ARRAY_SIZE( modes ); ++i)
+    {
+        IInspectable *operation = NULL;
+        IAsyncOperation_IInspectable *typed = NULL;
+        IAsyncInfo *info = NULL;
+        AsyncStatus status = Started;
+        HRESULT hr;
+
+        test_silent_events_reset( events );
+        test_silent_environment( modes[i] );
+        if (!wcscmp( modes[i], L"real-timeout" ))
+            SetEnvironmentVariableW( L"WINE_ONLINEID_HELPER_TIMEOUT_MS", L"100" );
+        ok( test_write_refresh_token(), "failed to write %s fixture.\n", wine_dbgstr_w( modes[i] ) );
+        hr = test_silent_start( manager, request, NULL, &operation );
+        ok( hr == S_OK && operation, "%s start got %#lx, %p.\n", wine_dbgstr_w( modes[i] ), hr, operation );
+        if (!operation) continue;
+        ok( test_wait_event( events->helper_completed, "helper outcome" ), "%s helper did not finish.\n",
+                             wine_dbgstr_w( modes[i] ) );
+        ok( test_wait_event( events->operation_completed, "operation outcome" ),
+            "%s operation did not finish.\n", wine_dbgstr_w( modes[i] ) );
+        ok( test_wait_event( events->worker_finished, "outcome worker" ),
+            "%s worker did not finish.\n", wine_dbgstr_w( modes[i] ) );
+        ok( test_silent_get_abi( operation, &typed, &info ), "%s ABI setup failed.\n", wine_dbgstr_w( modes[i] ) );
+        if (info)
+        {
+            hr = IAsyncInfo_get_Status( info, &status );
+            ok( hr == S_OK && status == Completed, "%s status got %#lx, %u.\n",
+                wine_dbgstr_w( modes[i] ), hr, status );
+            {
+                HRESULT error = E_FAIL;
+                hr = IAsyncInfo_get_ErrorCode( info, &error );
+                ok( hr == S_OK && error == S_OK, "%s error got %#lx, %#lx.\n",
+                    wine_dbgstr_w( modes[i] ), hr, error );
+            }
+        }
+        if (typed) test_silent_check_response_status( typed, 3 );
+        if (typed && info) test_silent_postclose( typed, info );
+        if (typed) IAsyncOperation_IInspectable_Release( typed );
+        if (info) IAsyncInfo_Release( info );
+        IInspectable_Release( operation );
+    }
+}
+
+static void test_silent_token_operations(void)
+{
+    static const WCHAR class_name[] =
+        L"Windows.Security.Authentication.OnlineId.OnlineIdSystemAuthenticator";
+    static const WCHAR resource_scope_name[] = L"https://graph.microsoft.com/.default";
+    struct test_manager_statics *manager = NULL;
+    struct test_token_request_factory *request_factory = NULL;
+    struct test_silent_events events;
+    IActivationFactory *factory = NULL;
+    IInspectable *provider = NULL, *request = NULL, *resource_request = NULL;
+    IInspectable *account = NULL, *operation = NULL;
+    HSTRING class = NULL, id = NULL, authority = NULL, client_id = NULL, scope = NULL;
+    HSTRING resource_scope = NULL, account_id = NULL;
+    HRESULT hr;
+
+    if (!test_silent_events_create( &events ))
+    {
+        win_skip( "silent async event setup failed.\n" );
+        test_silent_events_close( &events );
+        return;
+    }
+    WindowsCreateString( class_name, ARRAY_SIZE(class_name) - 1, &class );
+    hr = RoGetActivationFactory( class, &IID_IActivationFactory, (void **)&factory );
+    WindowsDeleteString( class );
+    class = NULL;
+    if (hr == REGDB_E_CLASSNOTREG)
+    {
+        win_skip( "OnlineId runtime classes are unavailable for silent async tests.\n" );
+        goto done;
+    }
+    ok( hr == S_OK, "silent RoGetActivationFactory got %#lx.\n", hr );
+    if (FAILED(hr)) goto done;
+    hr = IActivationFactory_QueryInterface( factory, &test_iid_IWebAuthenticationCoreManagerStatics,
+                                            (void **)&manager );
+    ok( hr == S_OK && manager, "silent manager QI got %#lx.\n", hr );
+    hr = IActivationFactory_QueryInterface( factory, &test_iid_IWebTokenRequestFactory,
+                                            (void **)&request_factory );
+    ok( hr == S_OK && request_factory, "silent request factory QI got %#lx.\n", hr );
+    if (!manager || !request_factory) goto done;
+
+    WindowsCreateString( L"https://login.microsoft.com", 26, &id );
+    WindowsCreateString( L"organizations", 13, &authority );
+    WindowsCreateString( L"d3590ed6-52b3-4102-aeff-aad2292ab01c", 36, &client_id );
+    WindowsCreateString( L"service::officeapps.live.com", 28, &scope );
+    hr = manager->lpVtbl->FindAccountProviderWithAuthorityAsync( manager, id, authority, &operation );
+    ok( hr == S_OK && operation, "silent provider start got %#lx, %p.\n", hr, operation );
+    if (operation)
+    {
+        test_async_operation( operation, &test_iid_IAsyncOperation_WebAccountProvider,
+                              &test_iid_IAsyncOperation_WebAccount, &provider );
+        operation = NULL;
+    }
+    if (!provider) goto done;
+    hr = request_factory->lpVtbl->Create( request_factory, provider, scope, client_id, &request );
+    ok( hr == S_OK && request, "silent request create got %#lx, %p.\n", hr, request );
+    if (!request) goto done;
+    WindowsCreateString( resource_scope_name, ARRAY_SIZE(resource_scope_name) - 1, &resource_scope );
+    hr = request_factory->lpVtbl->Create( request_factory, provider, resource_scope, client_id,
+                                          &resource_request );
+    ok( hr == S_OK && resource_request, "silent resource request create got %#lx, %p.\n",
+        hr, resource_request );
+
+    test_silent_environment( L"success" );
+    ok( test_write_account_fixture(), "failed to write account fixture.\n" );
+    WindowsCreateString( L"plan01-account-id", 17, &account_id );
+    hr = manager->lpVtbl->FindAccountAsync( manager, provider, account_id, &operation );
+    ok( hr == S_OK && operation, "silent account start got %#lx, %p.\n", hr, operation );
+    if (operation)
+    {
+        test_async_operation( operation, &test_iid_IAsyncOperation_WebAccount,
+                              &test_iid_IAsyncOperation_WebAccountProvider, &account );
+        operation = NULL;
+    }
+    ok( !!account, "silent account fixture did not produce a WebAccount.\n" );
+
+    /* Both public entry points use the same pending operation and helper
+     * handshake. The account overload is completed after its caller-owned
+     * account reference is released, proving the operation copied it. */
+    test_silent_blocked_case( manager, request, NULL, &events, FALSE, FALSE, FALSE );
+    if (account)
+    {
+        test_silent_account_completion( manager, request, account, &events );
+        account = NULL;
+    }
+    test_silent_cancel_before_mutex( manager, request, &events );
+    IInspectable_Release( provider );
+    provider = NULL;
+    if (resource_request) test_silent_completion_before_handler( manager, resource_request, &events );
+    test_silent_helper_outcomes( manager, request, &events );
+    test_silent_blocked_case( manager, request, NULL, &events, TRUE, FALSE, FALSE );
+    test_silent_blocked_case( manager, request, NULL, &events, FALSE, FALSE, TRUE );
+    test_silent_blocked_case( manager, request, NULL, &events, FALSE, TRUE, FALSE );
+
+done:
+    test_silent_environment_clear();
+    if (operation) IInspectable_Release( operation );
+    if (resource_request) IInspectable_Release( resource_request );
+    if (request) IInspectable_Release( request );
+    if (account) IInspectable_Release( account );
+    if (provider) IInspectable_Release( provider );
+    if (request_factory) request_factory->lpVtbl->Release( request_factory );
+    if (manager) manager->lpVtbl->Release( manager );
+    if (factory) IActivationFactory_Release( factory );
+    WindowsDeleteString( class );
+    WindowsDeleteString( id );
+    WindowsDeleteString( authority );
+    WindowsDeleteString( client_id );
+    WindowsDeleteString( scope );
+    WindowsDeleteString( resource_scope );
+    WindowsDeleteString( account_id );
+    test_silent_events_close( &events );
+}
+
 START_TEST(onlineid)
 {
     HRESULT hr;
@@ -745,6 +1574,7 @@ START_TEST(onlineid)
     test_TicketStatics();
     test_async_close();
     test_parameterized_iids();
+    test_silent_token_operations();
 
     RoUninitialize();
 }

--- a/dlls/windows.security.authentication.onlineid/tests/onlineid.c
+++ b/dlls/windows.security.authentication.onlineid/tests/onlineid.c
@@ -743,6 +743,7 @@ struct test_async_handler
     AsyncStatus status;
     HRESULT status_hr;
     HRESULT result_hr;
+    HRESULT invoke_hr;
 };
 
 static inline struct test_async_handler *impl_from_test_handler(
@@ -798,7 +799,7 @@ static HRESULT WINAPI test_handler_Invoke( IAsyncOperationCompletedHandler_IInsp
     if (impl->entered) SetEvent( impl->entered );
     if (impl->release) WaitForSingleObject( impl->release, 5000 );
     if (impl->finished) SetEvent( impl->finished );
-    return S_OK;
+    return impl->invoke_hr;
 }
 
 static const IAsyncOperationCompletedHandler_IInspectableVtbl test_handler_vtbl =
@@ -812,6 +813,7 @@ static struct test_async_handler *test_handler_create( HANDLE entered, HANDLE re
     if (!handler) return NULL;
     handler->iface.lpVtbl = &test_handler_vtbl;
     handler->ref = 1;
+    handler->invoke_hr = S_OK;
     handler->entered = entered;
     handler->release = release;
     handler->finished = finished;
@@ -829,6 +831,7 @@ struct test_silent_events
     HANDLE callback_entered;
     HANDLE callback_release;
     HANDLE callback_finished;
+    HANDLE projection_waiting;
 };
 
 static BOOL test_wait_event( HANDLE event, const char *name )
@@ -853,6 +856,7 @@ static BOOL test_silent_events_create( struct test_silent_events *events )
     static const WCHAR operation_completed_name[] = L"Local\\WineOnlineIdTestOperationCompleted";
     static const WCHAR worker_gate_name[] = L"Local\\WineOnlineIdTestWorkerGate";
     static const WCHAR worker_finished_name[] = L"Local\\WineOnlineIdTestWorkerFinished";
+    static const WCHAR projection_waiting_name[] = L"Local\\WineOnlineIdTestProjectionWaiting";
 
     memset( events, 0, sizeof(*events) );
     events->started = CreateEventW( NULL, TRUE, FALSE, started_name );
@@ -864,9 +868,11 @@ static BOOL test_silent_events_create( struct test_silent_events *events )
     events->callback_entered = CreateEventW( NULL, TRUE, FALSE, NULL );
     events->callback_release = CreateEventW( NULL, TRUE, FALSE, NULL );
     events->callback_finished = CreateEventW( NULL, TRUE, FALSE, NULL );
+    events->projection_waiting = CreateEventW( NULL, TRUE, FALSE, projection_waiting_name );
     return events->started && events->helper_release && events->helper_completed &&
            events->operation_completed && events->worker_gate && events->worker_finished &&
-           events->callback_entered && events->callback_release && events->callback_finished;
+           events->callback_entered && events->callback_release && events->callback_finished &&
+           events->projection_waiting;
 }
 
 static void test_silent_events_reset( struct test_silent_events *events )
@@ -880,6 +886,7 @@ static void test_silent_events_reset( struct test_silent_events *events )
     ResetEvent( events->callback_entered );
     ResetEvent( events->callback_release );
     ResetEvent( events->callback_finished );
+    ResetEvent( events->projection_waiting );
 }
 
 static void test_silent_events_close( struct test_silent_events *events )
@@ -893,6 +900,7 @@ static void test_silent_events_close( struct test_silent_events *events )
     if (events->callback_entered) CloseHandle( events->callback_entered );
     if (events->callback_release) CloseHandle( events->callback_release );
     if (events->callback_finished) CloseHandle( events->callback_finished );
+    if (events->projection_waiting) CloseHandle( events->projection_waiting );
 }
 
 static BOOL test_write_file( const WCHAR *path, const char *value )
@@ -1335,8 +1343,9 @@ static void test_silent_completion_before_handler( struct test_manager_statics *
     handler = test_handler_create( events->callback_entered, NULL, events->callback_finished );
     ok( !!handler, "failed to create completion-before-handler callback.\n" );
     if (!handler) goto done;
+    handler->invoke_hr = E_FAIL;
     hr = IAsyncOperation_IInspectable_put_Completed( typed, &handler->iface );
-    ok( hr == S_OK, "completion-before-handler put got %#lx.\n", hr );
+    ok( hr == S_OK, "completion-before-handler put propagated callback hr %#lx.\n", hr );
     ok( test_wait_event( events->callback_entered, "late callback" ), "late callback missing.\n" );
     ok( handler->status == Completed && handler->status_hr == S_OK && handler->result_hr == S_OK,
         "late callback status %u, status hr %#lx, results hr %#lx.\n",
@@ -1353,6 +1362,66 @@ done:
     SetEvent( events->helper_release );
     test_silent_wait_worker_finished( events, worker_exists, &worker_finished, "completion cleanup worker" );
     if (handler) IAsyncOperationCompletedHandler_IInspectable_Release( &handler->iface );
+    if (typed) IAsyncOperation_IInspectable_Release( typed );
+    if (info) IAsyncInfo_Release( info );
+    if (operation) IInspectable_Release( operation );
+}
+
+static void test_silent_projection_snapshot( struct test_manager_statics *manager, IInspectable *request,
+                                             struct test_silent_events *events )
+{
+    static const WCHAR cache_mutex_name[] = L"Local\\Wine4OfficeWamCache";
+    IInspectable *operation = NULL;
+    IAsyncOperation_IInspectable *typed = NULL;
+    IAsyncInfo *info = NULL;
+    HANDLE cache_mutex = NULL;
+    BOOL owns_mutex = FALSE;
+    AsyncStatus status = Completed;
+    DWORD wait;
+    HRESULT hr;
+
+    test_silent_events_reset( events );
+    test_silent_environment( L"success" );
+    ok( test_write_success_fixture(), "failed to write projection snapshot fixture.\n" );
+    cache_mutex = CreateMutexW( NULL, FALSE, cache_mutex_name );
+    ok( !!cache_mutex, "failed to create projection cache mutex, error %lu.\n", GetLastError() );
+    if (!cache_mutex) goto done;
+    wait = WaitForSingleObject( cache_mutex, 5000 );
+    owns_mutex = wait == WAIT_OBJECT_0 || wait == WAIT_ABANDONED;
+    ok( owns_mutex, "projection cache mutex wait returned %#lx.\n", wait );
+    if (!owns_mutex) goto done;
+
+    hr = test_silent_start( manager, request, NULL, &operation );
+    ok( hr == S_OK && operation, "projection snapshot start got %#lx, %p.\n", hr, operation );
+    if (!operation) goto done;
+    ok( test_wait_event( events->projection_waiting, "projection snapshot wait" ),
+        "silent reader did not participate in the cache mutex.\n" );
+    wait = WaitForSingleObject( events->operation_completed, 0 );
+    ok( wait == WAIT_TIMEOUT, "projection operation completed while the writer mutex was held, wait %#lx.\n", wait );
+    ok( test_silent_get_abi( operation, &typed, &info ), "projection snapshot ABI setup failed.\n" );
+    if (info)
+    {
+        hr = IAsyncInfo_get_Status( info, &status );
+        ok( hr == S_OK && status == Started, "projection snapshot status got %#lx, %u.\n", hr, status );
+    }
+
+    ReleaseMutex( cache_mutex );
+    owns_mutex = FALSE;
+    ok( test_wait_event( events->operation_completed, "projection snapshot completion" ),
+        "projection operation did not complete after cache mutex release.\n" );
+    ok( test_wait_event( events->worker_finished, "projection snapshot worker" ),
+        "projection worker did not finish after cache mutex release.\n" );
+    if (info)
+    {
+        hr = IAsyncInfo_get_Status( info, &status );
+        ok( hr == S_OK && status == Completed, "projection snapshot final status got %#lx, %u.\n", hr, status );
+    }
+    if (typed) test_silent_check_response_status( typed, 0 );
+    if (typed && info) test_silent_postclose( typed, info );
+
+done:
+    if (owns_mutex) ReleaseMutex( cache_mutex );
+    if (cache_mutex) CloseHandle( cache_mutex );
     if (typed) IAsyncOperation_IInspectable_Release( typed );
     if (info) IAsyncInfo_Release( info );
     if (operation) IInspectable_Release( operation );
@@ -1571,6 +1640,7 @@ static void test_silent_token_operations(void)
         account = NULL;
     }
     test_silent_cancel_before_mutex( manager, request, &events );
+    test_silent_projection_snapshot( manager, request, &events );
     IInspectable_Release( provider );
     provider = NULL;
     if (resource_request) test_silent_completion_before_handler( manager, resource_request, &events );

--- a/programs/wine4officeauth/wine4officeauth.cpp
+++ b/programs/wine4officeauth/wine4officeauth.cpp
@@ -361,6 +361,9 @@ public:
     bool valid() const { return locked; }
 };
 
+struct cache_record;
+static bool cache_record_load_locked(const std::string &login_hint, cache_record &record);
+
 class cache_transaction
 {
     cache_lock lock;
@@ -441,6 +444,11 @@ public:
         return success;
     }
 
+    bool load_previous(cache_record &record) const
+    {
+        return valid() && cache_record_load_locked({}, record);
+    }
+
     bool replace_bundle(const std::string &value);
 };
 
@@ -448,6 +456,7 @@ static bool protected_write(const WCHAR *name, const std::string &value)
 {
     DATA_BLOB input, output = {};
     std::wstring path = cache_file(name), temporary;
+    WCHAR fault[128], expected[128];
     HANDLE file;
     DWORD written;
     bool success = false;
@@ -461,11 +470,32 @@ static bool protected_write(const WCHAR *name, const std::string &value)
                        FILE_ATTRIBUTE_HIDDEN | FILE_ATTRIBUTE_NOT_CONTENT_INDEXED, NULL);
     if (file != INVALID_HANDLE_VALUE)
     {
+        DWORD length = GetEnvironmentVariableW(L"WINE4OFFICE_TEST_PUBLICATION_FAILURE",
+                                                fault, ARRAY_SIZE(fault));
         success = WriteFile(file, output.pbData, output.cbData, &written, NULL) &&
-                  written == output.cbData && FlushFileBuffers(file);
+                  written == output.cbData;
+        swprintf(expected, ARRAY_SIZE(expected), L"%s:write", name);
+        if (success && length && length < ARRAY_SIZE(fault) && !wcscmp(fault, expected))
+        {
+            SetEnvironmentVariableW(L"WINE4OFFICE_TEST_PUBLICATION_FAILURE", NULL);
+            success = false;
+        }
+        swprintf(expected, ARRAY_SIZE(expected), L"%s:flush", name);
+        if (success && length && length < ARRAY_SIZE(fault) && !wcscmp(fault, expected))
+        {
+            SetEnvironmentVariableW(L"WINE4OFFICE_TEST_PUBLICATION_FAILURE", NULL);
+            success = false;
+        }
+        else if (success) success = FlushFileBuffers(file);
         CloseHandle(file);
-        if (success) success = MoveFileExW(temporary.c_str(), path.c_str(),
-                                           MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH);
+        swprintf(expected, ARRAY_SIZE(expected), L"%s:rename", name);
+        if (success && length && length < ARRAY_SIZE(fault) && !wcscmp(fault, expected))
+        {
+            SetEnvironmentVariableW(L"WINE4OFFICE_TEST_PUBLICATION_FAILURE", NULL);
+            success = false;
+        }
+        else if (success) success = MoveFileExW(temporary.c_str(), path.c_str(),
+                                                MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH);
         if (!success) DeleteFileW(temporary.c_str());
     }
     LocalFree(output.pbData);
@@ -948,6 +978,22 @@ static bool cache_record_identity_valid(const cache_record &record, const std::s
     return success;
 }
 
+static bool cache_record_matches(const cache_record &left, const cache_record &right)
+{
+    return left.office.access_token == right.office.access_token &&
+           left.office.refresh_token == right.office.refresh_token &&
+           left.office.id_token == right.office.id_token &&
+           left.licensing.access_token == right.licensing.access_token &&
+           left.licensing.refresh_token == right.licensing.refresh_token &&
+           left.licensing.id_token == right.licensing.id_token &&
+           left.licensing.expires_in == right.licensing.expires_in &&
+           left.username == right.username && left.oid == right.oid && left.tid == right.tid &&
+           left.first_name == right.first_name && left.last_name == right.last_name &&
+           left.display_name == right.display_name && left.account_id == right.account_id &&
+           left.authority == right.authority && left.client_info == right.client_info &&
+           left.expires == right.expires;
+}
+
 static bool recover_cache_transaction_locked(void)
 {
     std::wstring marker = cache_file(L"wam-transaction.pending");
@@ -1096,27 +1142,62 @@ static bool cache_record_save(const cache_record &record)
 {
     std::wstring bundle_name = cache_bundle_name(record.username);
     std::wstring bundle = cache_file(bundle_name.c_str());
+    cache_record previous;
     cache_transaction transaction;
     std::string bundle_json;
-    bool success;
+    bool previous_valid, success;
 
     if (bundle_name.empty() || bundle.empty() ||
         !cache_record_identity_valid(record, {}) || !transaction.begin(bundle))
         return false;
+    /* Snapshot the old generation only after the transaction owns the cache
+     * mutex.  Otherwise a second writer could publish between the snapshot
+     * and begin(), leaving rollback projections from the wrong generation. */
+    previous_valid = transaction.load_previous(previous);
     bundle_json = cache_record_json(record);
     success = transaction.replace_bundle(bundle_json);
     secure_clear(bundle_json);
     if (!success)
     {
         transaction.rollback();
+        secure_clear(previous);
         return false;
     }
-    if (!publish_projection(record)) return false;
+    if (!publish_projection(record))
+    {
+        success = previous_valid ? publish_projection(previous) : clear_projection();
+        if (success) transaction.rollback();
+        secure_clear(previous);
+        return false;
+    }
+    {
+        WCHAR fault[64];
+        cache_record verified;
+        DWORD length = GetEnvironmentVariableW(L"WINE4OFFICE_TEST_PUBLICATION_FAILURE",
+                                                fault, ARRAY_SIZE(fault));
+        if (length && length < ARRAY_SIZE(fault) && !wcscmp(fault, L"final-read"))
+        {
+            SetEnvironmentVariableW(L"WINE4OFFICE_TEST_PUBLICATION_FAILURE", NULL);
+            success = false;
+        }
+        else success = cache_record_load_locked({}, verified) && cache_record_matches(record, verified);
+        secure_clear(verified);
+    }
+    if (!success)
+    {
+        success = previous_valid ? publish_projection(previous) : clear_projection();
+        if (success) transaction.rollback();
+        secure_clear(previous);
+        return false;
+    }
     if (!transaction.commit())
     {
-        transaction.rollback();
+        success = previous_valid ? publish_projection(previous) : clear_projection();
+        if (success) transaction.rollback();
+        secure_clear(previous);
         return false;
     }
+    secure_clear(previous);
     return true;
 }
 
@@ -1920,6 +2001,84 @@ static void self_test_record(cache_record &record, const char *username, const c
     record.expires = unix_time() + 3600;
 }
 
+static bool self_test_projection_value(const WCHAR *name, const std::string &expected)
+{
+    std::string value;
+    bool success = protected_read(name, value) && value == expected;
+    secure_clear(value);
+    return success;
+}
+
+static bool self_test_projection(const cache_record &record)
+{
+    std::string expires = std::to_string(record.expires);
+    bool success =
+        self_test_projection_value(L"wam-access-token.dat", record.office.access_token) &&
+        self_test_projection_value(L"wam-id-token.dat", record.office.id_token) &&
+        self_test_projection_value(L"wam-refresh-token.dat", record.office.refresh_token) &&
+        self_test_projection_value(L"wam-licensing-token.dat", record.licensing.access_token) &&
+        self_test_projection_value(L"wam-token-expires-on.dat", expires) &&
+        self_test_projection_value(L"wam-account-username.dat", record.username) &&
+        self_test_projection_value(L"wam-account-id.dat", record.account_id) &&
+        self_test_projection_value(L"wam-account-oid.dat", record.oid) &&
+        self_test_projection_value(L"wam-account-tenant-id.dat", record.tid) &&
+        self_test_projection_value(L"wam-account-authority.dat", record.authority) &&
+        self_test_projection_value(L"wam-client-info.dat", record.client_info) &&
+        self_test_projection_value(L"wam-active-account.dat", record.username);
+    secure_clear(expires);
+    return success;
+}
+
+static bool self_test_publication_failures(const cache_record &first, const cache_record &second,
+                                           const std::wstring &first_bundle)
+{
+    static const WCHAR *const fields[] =
+    {
+        L"wam-access-token.dat", L"wam-id-token.dat", L"wam-refresh-token.dat",
+        L"wam-licensing-token.dat", L"wam-token-expires-on.dat", L"wam-account-username.dat",
+        L"wam-account-id.dat", L"wam-account-oid.dat", L"wam-account-tenant-id.dat",
+        L"wam-account-authority.dat", L"wam-client-info.dat", L"wam-active-account.dat"
+    };
+    unsigned int i;
+    WCHAR fault[128];
+    cache_record loaded;
+    bool success = true;
+
+    for (i = 0; i < ARRAY_SIZE(fields) && success; ++i)
+    {
+        swprintf(fault, ARRAY_SIZE(fault), L"%s:write", fields[i]);
+        SetEnvironmentVariableW(L"WINE4OFFICE_TEST_PUBLICATION_FAILURE", fault);
+        success = !cache_record_save(first) && cache_record_load(second.username, loaded) &&
+                  cache_record_matches(second, loaded) && self_test_projection(second);
+        secure_clear(loaded);
+        if (!success) break;
+
+        swprintf(fault, ARRAY_SIZE(fault), L"%s:flush", fields[i]);
+        SetEnvironmentVariableW(L"WINE4OFFICE_TEST_PUBLICATION_FAILURE", fault);
+        success = !cache_record_save(first) && cache_record_load(second.username, loaded) &&
+                  cache_record_matches(second, loaded) && self_test_projection(second);
+        secure_clear(loaded);
+        if (!success) break;
+
+        swprintf(fault, ARRAY_SIZE(fault), L"%s:rename", fields[i]);
+        SetEnvironmentVariableW(L"WINE4OFFICE_TEST_PUBLICATION_FAILURE", fault);
+        success = !cache_record_save(first) && cache_record_load(second.username, loaded) &&
+                  cache_record_matches(second, loaded) && self_test_projection(second);
+        secure_clear(loaded);
+    }
+    if (success)
+    {
+        SetEnvironmentVariableW(L"WINE4OFFICE_TEST_PUBLICATION_FAILURE", L"final-read");
+        success = !cache_record_save(first) && cache_record_load(second.username, loaded) &&
+                  cache_record_matches(second, loaded) && self_test_projection(second);
+        secure_clear(loaded);
+    }
+    SetEnvironmentVariableW(L"WINE4OFFICE_TEST_PUBLICATION_FAILURE", NULL);
+    DeleteFileW(cache_file(first_bundle.c_str()).c_str());
+    secure_clear(loaded);
+    return success;
+}
+
 struct cache_lock_probe
 {
     HANDLE started;
@@ -1954,6 +2113,38 @@ int WINAPI wWinMain(HINSTANCE instance, HINSTANCE previous, WCHAR *command_line,
     bool success;
     (void)previous; (void)command_line; (void)show;
     if (!argv) return 3;
+    if (argc >= 3 && !wcscmp(argv[1], L"--self-test-helper"))
+    {
+        if (!wcscmp(argv[2], L"fail"))
+        {
+            LocalFree(argv);
+            return 7;
+        }
+        if (!wcscmp(argv[2], L"crash"))
+        {
+            TerminateProcess(GetCurrentProcess(), 0xc0000005);
+            LocalFree(argv);
+            return 3;
+        }
+        if (!wcscmp(argv[2], L"timeout"))
+        {
+            HANDLE event = CreateEventW(NULL, TRUE, FALSE, NULL);
+            if (event)
+            {
+                WaitForSingleObject(event, INFINITE);
+                CloseHandle(event);
+            }
+            LocalFree(argv);
+            return 3;
+        }
+        if (!wcscmp(argv[2], L"shutdown"))
+        {
+            LocalFree(argv);
+            return 3;
+        }
+        LocalFree(argv);
+        return 0;
+    }
     if (argc >= 2 && !wcscmp(argv[1], L"--self-test-cache"))
     {
         bool recovered = recover_cache_transaction();
@@ -1974,6 +2165,8 @@ int WINAPI wWinMain(HINSTANCE instance, HINSTANCE previous, WCHAR *command_line,
                                loaded.office.refresh_token == first.office.refresh_token;
         if (success) success = cache_record_load(second.username, loaded) &&
                                loaded.office.refresh_token == second.office.refresh_token;
+        if (success) success = self_test_projection(second);
+        if (success) success = self_test_publication_failures(first, second, first_bundle);
         mismatch = "third@example.invalid";
         if (success) success = !cache_record_load(mismatch, loaded);
         if (success)

--- a/programs/wine4officeauth/wine4officeauth.cpp
+++ b/programs/wine4officeauth/wine4officeauth.cpp
@@ -1138,7 +1138,9 @@ static bool recover_cache_transaction_locked(void)
         }
         else if (target_is_new)
             success = DeleteFileW(target.c_str()) || GetLastError() == ERROR_FILE_NOT_FOUND;
-        else if (target_existed && restore_previous_projection) success = false;
+        else if (target_existed && restore_previous_projection &&
+                 GetFileAttributesW(target.c_str()) == INVALID_FILE_ATTRIBUTES)
+            success = false;
         if (!DeleteFileW(temporary.c_str()) && GetLastError() != ERROR_FILE_NOT_FOUND) success = false;
 
         if (!legacy_marker && previous_name != "-")
@@ -1156,12 +1158,14 @@ static bool recover_cache_transaction_locked(void)
              * created a new target that recovery removed. */
             if (GetFileAttributesW(target.c_str()) == INVALID_FILE_ATTRIBUTES)
                 success = clear_projection();
-            else success = cache_record_load_bundle_locked(utf8_to_wide(name), previous) &&
-                           publish_projection(previous);
+            else if (!cache_record_load_bundle_locked(utf8_to_wide(name), previous))
+                success = clear_projection();
+            else success = publish_projection(previous);
         }
         else if (previous_name == "-") success = clear_projection();
-        else success = cache_record_load_bundle_locked(previous_bundle, previous) &&
-                       publish_projection(previous);
+        else if (!cache_record_load_bundle_locked(previous_bundle, previous))
+            success = clear_projection();
+        else success = publish_projection(previous);
         secure_clear(previous);
     }
     /* Prepared, replacing, and rolling-back states have not changed the
@@ -2408,6 +2412,38 @@ int WINAPI wWinMain(HINSTANCE instance, HINSTANCE previous, WCHAR *command_line,
             if (success) success = cache_record_load(first.username, loaded) &&
                                    cache_record_matches(first, loaded) && self_test_projection(first) &&
                                    cache_record_save(second);
+        }
+        if (success)
+        {
+            /* Recovery may consume an existing target's backup before a
+             * transient projection failure.  The retained marker must make
+             * the next recovery attempt idempotent. */
+            success = self_test_run_cache_state_child(L"replaced");
+            if (success)
+            {
+                SetEnvironmentVariableW(L"WINE4OFFICE_TEST_PUBLICATION_FAILURE",
+                                        L"wam-access-token.dat:write");
+                success = !cache_record_load(second.username, loaded) &&
+                          cache_transaction_pending() &&
+                          cache_record_load(second.username, loaded) &&
+                          cache_record_matches(second, loaded) && self_test_projection(second) &&
+                          !cache_transaction_pending();
+            }
+            SetEnvironmentVariableW(L"WINE4OFFICE_TEST_PUBLICATION_FAILURE", NULL);
+        }
+        if (success)
+        {
+            /* A permanently unreadable previous bundle cannot be republished.
+             * Clear the projection and retire the marker so a later sign-in
+             * can replace the damaged cache instead of wedging forever. */
+            DeleteFileW(cache_file(first_bundle.c_str()).c_str());
+            success = self_test_run_cache_state_child(L"replaced") &&
+                      protected_write(second_bundle.c_str(), "corrupt bundle") &&
+                      !cache_record_load(second.username, loaded) &&
+                      !cache_transaction_pending() &&
+                      GetFileAttributesW(cache_file(L"wam-active-account.dat").c_str()) ==
+                          INVALID_FILE_ATTRIBUTES &&
+                      cache_record_save(second);
         }
         if (success)
         {

--- a/programs/wine4officeauth/wine4officeauth.cpp
+++ b/programs/wine4officeauth/wine4officeauth.cpp
@@ -367,31 +367,34 @@ static bool cache_record_load_locked(const std::string &login_hint, cache_record
 class cache_transaction
 {
     cache_lock lock;
-    std::wstring marker, target, backup, temporary;
-    bool active = false, replaced = false;
-    bool write_marker(const char *state = "prepared")
+    std::wstring marker, target, backup, temporary, previous_projection;
+    std::string marker_state = "prepared";
+    bool active = false, replaced = false, target_existed = false;
+    bool write_marker(const char *new_state = NULL)
     {
         HANDLE file;
         DWORD written;
-        std::string name;
+        std::string name, previous, state = new_state ? new_state : marker_state;
         std::wstring marker_temporary;
 
         if (target.empty()) return false;
         const WCHAR *filename = wcsrchr(target.c_str(), L'\\');
         name = wide_to_utf8(filename ? filename + 1 : target.c_str());
+        previous = previous_projection.empty() ? "-" : wide_to_utf8(previous_projection.c_str());
         marker = cache_file(L"wam-transaction.pending");
         if (marker.empty()) return false;
         marker_temporary = marker + L".new";
         file = CreateFileW(marker_temporary.c_str(), GENERIC_WRITE, 0, NULL, CREATE_ALWAYS,
                            FILE_ATTRIBUTE_HIDDEN | FILE_ATTRIBUTE_NOT_CONTENT_INDEXED, NULL);
         if (file == INVALID_HANDLE_VALUE) return false;
-        std::string content = "Wine4OfficeWamBundle=1\n" + name + "\n" + state + "\n";
+        std::string content = "Wine4OfficeWamBundle=1\n" + name + "\n" + state + "\n" + previous + "\n";
         bool success = WriteFile(file, content.data(), content.size(), &written, NULL) &&
                        written == content.size() && FlushFileBuffers(file);
         CloseHandle(file);
         if (success) success = MoveFileExW(marker_temporary.c_str(), marker.c_str(),
                                            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH);
         if (!success) DeleteFileW(marker_temporary.c_str());
+        else marker_state = state;
         return success;
     }
 
@@ -412,7 +415,18 @@ public:
 
     bool commit()
     {
-        if (!valid() || !DeleteFileW(marker.c_str())) return false;
+        WCHAR fault[64];
+        DWORD length;
+
+        if (!valid() || marker_state != "verified") return false;
+        length = GetEnvironmentVariableW(L"WINE4OFFICE_TEST_COMMIT_FAILURE", fault, ARRAY_SIZE(fault));
+        if (length && length < ARRAY_SIZE(fault) && !wcscmp(fault, L"marker-delete"))
+        {
+            SetEnvironmentVariableW(L"WINE4OFFICE_TEST_COMMIT_FAILURE", NULL);
+            SetLastError(ERROR_ACCESS_DENIED);
+            return false;
+        }
+        if (!DeleteFileW(marker.c_str()) && GetLastError() != ERROR_FILE_NOT_FOUND) return false;
         DeleteFileW(backup.c_str());
         DeleteFileW(temporary.c_str());
         active = false;
@@ -427,12 +441,12 @@ public:
         DeleteFileW(temporary.c_str());
         if (replaced)
         {
-            bool had_backup = GetFileAttributesW(backup.c_str()) != INVALID_FILE_ATTRIBUTES;
-            if (!write_marker(had_backup ? "rolling-back-existing" : "rolling-back-new"))
+            if (!write_marker(target_existed ? "rolling-back-existing" : "rolling-back-new"))
                 return false;
-            if (had_backup)
+            if (target_existed)
             {
-                success = DeleteFileW(target.c_str()) &&
+                success = GetFileAttributesW(backup.c_str()) != INVALID_FILE_ATTRIBUTES &&
+                          DeleteFileW(target.c_str()) &&
                           MoveFileExW(backup.c_str(), target.c_str(), MOVEFILE_WRITE_THROUGH);
             }
             else success = DeleteFileW(target.c_str()) ||
@@ -462,6 +476,20 @@ public:
     bool load_previous(cache_record &record) const
     {
         return valid() && cache_record_load_locked({}, record);
+    }
+
+    bool set_previous_projection(const std::wstring &bundle_name)
+    {
+        std::wstring previous = previous_projection;
+        previous_projection = bundle_name;
+        if (write_marker()) return true;
+        previous_projection = previous;
+        return false;
+    }
+
+    bool mark_verified()
+    {
+        return valid() && replaced && write_marker("verified");
     }
 
     bool replace_bundle(const std::string &value);
@@ -568,7 +596,7 @@ bool cache_transaction::replace_bundle(const std::string &value)
     DATA_BLOB input, output = {};
     HANDLE file;
     DWORD written;
-    bool target_existed, success = false;
+    bool success = false;
 
     if (!valid()) return false;
     target_existed = GetFileAttributesW(target.c_str()) != INVALID_FILE_ATTRIBUTES;
@@ -594,7 +622,7 @@ bool cache_transaction::replace_bundle(const std::string &value)
         if (!success) DeleteFileW(temporary.c_str());
     }
     replaced = success;
-    if (success && !write_marker("replaced")) success = false;
+    if (success && !write_marker(target_existed ? "replaced-existing" : "replaced-new")) success = false;
     return success;
 }
 
@@ -883,6 +911,16 @@ static std::wstring cache_bundle_name(const std::string &username)
     return L"wam-bundle-" + std::wstring(suffix) + L".dat";
 }
 
+static bool cache_bundle_name_valid(const std::string &name)
+{
+    if (name.compare(0, 11, "wam-bundle-") || name.size() != 11 + 32 + 4 ||
+        name.compare(name.size() - 4, 4, ".dat"))
+        return false;
+    for (size_t i = 11; i < 11 + 32; ++i)
+        if (!std::isxdigit((unsigned char)name[i])) return false;
+    return true;
+}
+
 static std::string json_escape(const std::string &value)
 {
     std::string result;
@@ -995,6 +1033,29 @@ static bool cache_record_identity_valid(const cache_record &record, const std::s
     return success;
 }
 
+static bool cache_record_load_bundle_locked(const std::wstring &bundle_name, cache_record &record)
+{
+    std::string json;
+    std::wstring expected;
+
+    record = {};
+    if (bundle_name.empty() || !protected_read_path(cache_file(bundle_name.c_str()), json, false) ||
+        !cache_record_from_json(json, record) || !cache_record_identity_valid(record, {}))
+    {
+        secure_clear(json);
+        secure_clear(record);
+        return false;
+    }
+    expected = cache_bundle_name(record.username);
+    secure_clear(json);
+    if (expected != bundle_name)
+    {
+        secure_clear(record);
+        return false;
+    }
+    return true;
+}
+
 static bool cache_record_matches(const cache_record &left, const cache_record &right)
 {
     return left.office.access_token == right.office.access_token &&
@@ -1017,9 +1078,10 @@ static bool recover_cache_transaction_locked(void)
     LARGE_INTEGER size;
     HANDLE file;
     DWORD read;
-    std::string content, name, state;
-    std::wstring target, backup, temporary;
-    bool success = true, transaction_removes_target = false, transaction_rolling_back = false;
+    std::string content, name, state, previous_name;
+    std::wstring target, backup, temporary, previous_bundle;
+    bool legacy_marker = false, restore_previous_projection = false;
+    bool success = true, target_existed = false, target_is_new = false, verified = false;
 
     if (marker.empty() || GetFileAttributesW(marker.c_str()) == INVALID_FILE_ATTRIBUTES) return true;
     file = CreateFileW(marker.c_str(), GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING,
@@ -1038,51 +1100,74 @@ static bool recover_cache_transaction_locked(void)
         return true;
     }
     {
-        size_t prefix_len = strlen("Wine4OfficeWamBundle=1\n"), name_end, state_end;
+        size_t prefix_len = strlen("Wine4OfficeWamBundle=1\n"), name_end, state_end, previous_end;
         name_end = content.find('\n', prefix_len);
         if (name_end == std::string::npos) return false;
         name = content.substr(prefix_len, name_end - prefix_len);
         state_end = content.find('\n', name_end + 1);
         if (state_end == std::string::npos) return false;
         state = content.substr(name_end + 1, state_end - name_end - 1);
+        previous_end = content.find('\n', state_end + 1);
+        if (previous_end == std::string::npos) legacy_marker = true;
+        else previous_name = content.substr(state_end + 1, previous_end - state_end - 1);
         if (state != "prepared" && state != "replacing-existing" && state != "replacing-new" &&
-            state != "replaced" && state != "rolling-back-existing" && state != "rolling-back-new")
+            state != "replaced" && state != "replaced-existing" && state != "replaced-new" &&
+            state != "rolling-back-existing" && state != "rolling-back-new" && state != "verified")
             return false;
-        transaction_removes_target = state == "replacing-new" || state == "replaced" ||
-                                     state == "rolling-back-new";
-        transaction_rolling_back = state == "rolling-back-existing" || state == "rolling-back-new";
-        if (name.compare(0, 11, "wam-bundle-") || name.size() != 11 + 32 + 4 ||
-            name.compare(name.size() - 4, 4, ".dat"))
+        if (!cache_bundle_name_valid(name) ||
+            (!legacy_marker && previous_name != "-" && !cache_bundle_name_valid(previous_name)))
             return false;
-        for (size_t i = 11; i < 11 + 32; ++i)
-            if (!std::isxdigit((unsigned char)name[i])) return false;
+        target_existed = state == "replacing-existing" || state == "replaced-existing" ||
+                         state == "rolling-back-existing";
+        target_is_new = state == "replacing-new" || state == "replaced-new" ||
+                        state == "rolling-back-new" || state == "replaced";
+        restore_previous_projection = state == "replaced-existing" || state == "replaced-new" ||
+                                      state == "replaced";
+        verified = state == "verified";
         target = cache_file(utf8_to_wide(name).c_str());
         backup = target + L".bak";
         temporary = target + L".new";
-        if (GetFileAttributesW(backup.c_str()) != INVALID_FILE_ATTRIBUTES)
+        if (verified)
         {
-            DeleteFileW(target.c_str());
-            success = MoveFileExW(backup.c_str(), target.c_str(), MOVEFILE_WRITE_THROUGH);
+            if (!DeleteFileW(backup.c_str()) && GetLastError() != ERROR_FILE_NOT_FOUND) success = false;
         }
-        else if (transaction_removes_target) DeleteFileW(target.c_str());
-        DeleteFileW(temporary.c_str());
+        else if (GetFileAttributesW(backup.c_str()) != INVALID_FILE_ATTRIBUTES)
+        {
+            success = (DeleteFileW(target.c_str()) || GetLastError() == ERROR_FILE_NOT_FOUND) &&
+                      MoveFileExW(backup.c_str(), target.c_str(), MOVEFILE_WRITE_THROUGH);
+        }
+        else if (target_is_new)
+            success = DeleteFileW(target.c_str()) || GetLastError() == ERROR_FILE_NOT_FOUND;
+        else if (target_existed && restore_previous_projection) success = false;
+        if (!DeleteFileW(temporary.c_str()) && GetLastError() != ERROR_FILE_NOT_FOUND) success = false;
+
+        if (!legacy_marker && previous_name != "-")
+            previous_bundle = utf8_to_wide(previous_name);
     }
-    DeleteFileW(temporary.c_str());
-    /* A rolling-back marker is written only after the prior projection was
-     * restored successfully.  Recover the target bundle, but do not replace
-     * that prior active projection with the target account. */
-    if (success && !transaction_rolling_back)
+    if (success && restore_previous_projection)
     {
-        std::string json;
-        cache_record record;
-        if (protected_read_path(target, json, false) &&
-            cache_record_from_json(json, record) &&
-            cache_record_identity_valid(record, {}))
-            success = publish_projection(record);
-        else success = clear_projection();
-        secure_clear(json);
-        secure_clear(record);
+        cache_record previous;
+
+        if (legacy_marker)
+        {
+            /* Old markers did not identify the previously projected account.
+             * Preserve their original recovery behavior: publish a restored
+             * target, or clear the projection when the interrupted write had
+             * created a new target that recovery removed. */
+            if (GetFileAttributesW(target.c_str()) == INVALID_FILE_ATTRIBUTES)
+                success = clear_projection();
+            else success = cache_record_load_bundle_locked(utf8_to_wide(name), previous) &&
+                           publish_projection(previous);
+        }
+        else if (previous_name == "-") success = clear_projection();
+        else success = cache_record_load_bundle_locked(previous_bundle, previous) &&
+                       publish_projection(previous);
+        secure_clear(previous);
     }
+    /* Prepared, replacing, and rolling-back states have not changed the
+     * active projection, or have already restored it.  A verified state has
+     * a complete new projection.  Preserve both instead of republishing the
+     * target account. */
     if (success) success = DeleteFileW(marker.c_str()) || GetLastError() == ERROR_FILE_NOT_FOUND;
     return success;
 }
@@ -1095,7 +1180,7 @@ static bool recover_cache_transaction(void)
 
 static bool cache_record_load_locked(const std::string &login_hint, cache_record &record)
 {
-    std::string username = login_hint, active_username, json;
+    std::string username = login_hint, active_username;
     std::wstring bundle;
     record = {};
     if (username.empty())
@@ -1104,16 +1189,13 @@ static bool cache_record_load_locked(const std::string &login_hint, cache_record
             return false;
         username = active_username;
     }
-    bundle = cache_file(cache_bundle_name(username).c_str());
-    if (bundle.empty() || !protected_read_path(bundle, json, false) ||
-        !cache_record_from_json(json, record) ||
-        !cache_record_identity_valid(record, login_hint))
+    bundle = cache_bundle_name(username);
+    if (!cache_record_load_bundle_locked(bundle, record) ||
+        (!login_hint.empty() && !same_account_string(record.username, login_hint)))
     {
-        secure_clear(json);
         secure_clear(record);
         return false;
     }
-    secure_clear(json);
     secure_clear(username);
     return true;
 }
@@ -1182,6 +1264,12 @@ static bool cache_record_save(const cache_record &record)
      * mutex.  Otherwise a second writer could publish between the snapshot
      * and begin(), leaving rollback projections from the wrong generation. */
     previous_valid = transaction.load_previous(previous);
+    if (!transaction.set_previous_projection(previous_valid ? cache_bundle_name(previous.username) : L""))
+    {
+        transaction.rollback();
+        secure_clear(previous);
+        return false;
+    }
     bundle_json = cache_record_json(record);
     success = transaction.replace_bundle(bundle_json);
     secure_clear(bundle_json);
@@ -1218,10 +1306,17 @@ static bool cache_record_save(const cache_record &record)
         secure_clear(previous);
         return false;
     }
-    if (!transaction.commit())
+    if (!transaction.mark_verified())
     {
         success = previous_valid ? publish_projection(previous) : clear_projection();
         if (success) transaction.rollback();
+        secure_clear(previous);
+        return false;
+    }
+    if (!transaction.commit())
+    {
+        /* The verified marker makes the complete new generation recoverable.
+         * Do not roll it back merely because marker cleanup failed. */
         secure_clear(previous);
         return false;
     }
@@ -2026,7 +2121,8 @@ static void self_test_record(cache_record &record, const char *username, const c
     record.licensing.access_token = std::string("license-") + suffix;
     record.licensing.refresh_token = record.office.refresh_token;
     record.licensing.id_token = record.office.id_token;
-    record.expires = unix_time() + 3600;
+    /* Keep parent and crash-test child records byte-for-byte identical. */
+    record.expires = 4102444800ULL;
 }
 
 static bool self_test_projection_value(const WCHAR *name, const std::string &expected)
@@ -2109,10 +2205,76 @@ static bool self_test_publication_failures(const cache_record &first, const cach
                   cache_record_matches(second, loaded) && self_test_projection(second);
         secure_clear(loaded);
     }
+    if (success)
+    {
+        SetEnvironmentVariableW(L"WINE4OFFICE_TEST_COMMIT_FAILURE", L"marker-delete");
+        success = !cache_record_save(first) && cache_record_load(first.username, loaded) &&
+                  cache_record_matches(first, loaded) && self_test_projection(first) &&
+                  cache_record_save(second);
+        secure_clear(loaded);
+    }
     SetEnvironmentVariableW(L"WINE4OFFICE_TEST_PUBLICATION_FAILURE", NULL);
     SetEnvironmentVariableW(L"WINE4OFFICE_TEST_ROLLBACK_FAILURE", NULL);
+    SetEnvironmentVariableW(L"WINE4OFFICE_TEST_COMMIT_FAILURE", NULL);
     DeleteFileW(cache_file(first_bundle.c_str()).c_str());
     secure_clear(loaded);
+    return success;
+}
+
+static int self_test_cache_state_child(const WCHAR *state)
+{
+    cache_record first, second;
+    std::wstring first_bundle, second_bundle;
+    std::string first_json;
+    bool success = false;
+
+    self_test_record(first, "first@example.invalid", "11111111-1111-1111-1111-111111111111",
+                     "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "first");
+    self_test_record(second, "second@example.invalid", "22222222-2222-2222-2222-222222222222",
+                     "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", "second");
+    first_bundle = cache_bundle_name(first.username);
+    second_bundle = cache_bundle_name(second.username);
+    cache_transaction interrupted;
+    success = interrupted.begin(cache_file(first_bundle.c_str())) &&
+              interrupted.set_previous_projection(second_bundle);
+    if (success && !wcscmp(state, L"replaced"))
+        success = interrupted.replace_bundle("partial bundle");
+    else if (success && !wcscmp(state, L"verified"))
+    {
+        first_json = cache_record_json(first);
+        success = interrupted.replace_bundle(first_json) && publish_projection(first) &&
+                  interrupted.mark_verified();
+    }
+    else if (wcscmp(state, L"prepared")) success = false;
+    secure_clear(first_json);
+    secure_clear(first);
+    secure_clear(second);
+    if (success) TerminateProcess(GetCurrentProcess(), 0x365);
+    return 3;
+}
+
+static bool self_test_run_cache_state_child(const WCHAR *state)
+{
+    WCHAR module[MAX_PATH], command[2 * MAX_PATH];
+    PROCESS_INFORMATION process = {};
+    STARTUPINFOW startup = {sizeof(startup)};
+    DWORD exit_code = 3, wait;
+    bool success = false;
+
+    if (!GetModuleFileNameW(NULL, module, ARRAY_SIZE(module)) ||
+        swprintf(command, ARRAY_SIZE(command), L"\"%s\" --self-test-cache-state %s", module, state) < 0 ||
+        !CreateProcessW(NULL, command, NULL, NULL, FALSE, 0, NULL, NULL, &startup, &process))
+        return false;
+    wait = WaitForSingleObject(process.hProcess, 30000);
+    if (wait == WAIT_TIMEOUT)
+    {
+        TerminateProcess(process.hProcess, WAIT_TIMEOUT);
+        WaitForSingleObject(process.hProcess, 5000);
+    }
+    else success = wait == WAIT_OBJECT_0 && GetExitCodeProcess(process.hProcess, &exit_code) &&
+                   exit_code == 0x365;
+    CloseHandle(process.hThread);
+    CloseHandle(process.hProcess);
     return success;
 }
 
@@ -2182,6 +2344,12 @@ int WINAPI wWinMain(HINSTANCE instance, HINSTANCE previous, WCHAR *command_line,
         LocalFree(argv);
         return 0;
     }
+    if (argc >= 3 && !wcscmp(argv[1], L"--self-test-cache-state"))
+    {
+        int result = self_test_cache_state_child(argv[2]);
+        LocalFree(argv);
+        return result;
+    }
     if (argc >= 2 && !wcscmp(argv[1], L"--self-test-cache"))
     {
         bool recovered = recover_cache_transaction();
@@ -2224,18 +2392,27 @@ int WINAPI wWinMain(HINSTANCE instance, HINSTANCE previous, WCHAR *command_line,
         }
         if (success)
         {
-            protected_write(first_bundle.c_str(), "corrupt bundle");
-            success = !cache_record_load(first.username, loaded) && cache_record_save(first);
+            success = self_test_run_cache_state_child(L"prepared");
+            if (success) success = cache_record_load(second.username, loaded) &&
+                                   cache_record_matches(second, loaded) && self_test_projection(second);
         }
         if (success)
         {
-            {
-                cache_transaction interrupted;
-                success = interrupted.begin(cache_file(first_bundle.c_str())) &&
-                          interrupted.replace_bundle("partial bundle");
-            }
+            success = self_test_run_cache_state_child(L"replaced");
+            if (success) success = cache_record_load(second.username, loaded) &&
+                                   cache_record_matches(second, loaded) && self_test_projection(second);
+        }
+        if (success)
+        {
+            success = self_test_run_cache_state_child(L"verified");
             if (success) success = cache_record_load(first.username, loaded) &&
-                                   loaded.office.refresh_token == first.office.refresh_token;
+                                   cache_record_matches(first, loaded) && self_test_projection(first) &&
+                                   cache_record_save(second);
+        }
+        if (success)
+        {
+            protected_write(first_bundle.c_str(), "corrupt bundle");
+            success = !cache_record_load(first.username, loaded) && cache_record_save(first);
         }
         DeleteFileW(cache_file(first_bundle.c_str()).c_str());
         DeleteFileW(cache_file(second_bundle.c_str()).c_str());

--- a/programs/wine4officeauth/wine4officeauth.cpp
+++ b/programs/wine4officeauth/wine4officeauth.cpp
@@ -421,12 +421,16 @@ public:
 
     bool rollback()
     {
+        WCHAR fault[64];
         bool success = true;
         if (!active) return false;
         DeleteFileW(temporary.c_str());
         if (replaced)
         {
-            if (GetFileAttributesW(backup.c_str()) != INVALID_FILE_ATTRIBUTES)
+            bool had_backup = GetFileAttributesW(backup.c_str()) != INVALID_FILE_ATTRIBUTES;
+            if (!write_marker(had_backup ? "rolling-back-existing" : "rolling-back-new"))
+                return false;
+            if (had_backup)
             {
                 success = DeleteFileW(target.c_str()) &&
                           MoveFileExW(backup.c_str(), target.c_str(), MOVEFILE_WRITE_THROUGH);
@@ -434,8 +438,19 @@ public:
             else success = DeleteFileW(target.c_str()) ||
                            GetLastError() == ERROR_FILE_NOT_FOUND;
         }
-        if (success && !DeleteFileW(marker.c_str()) && GetLastError() != ERROR_FILE_NOT_FOUND)
-            success = false;
+        if (success)
+        {
+            DWORD length = GetEnvironmentVariableW(L"WINE4OFFICE_TEST_ROLLBACK_FAILURE",
+                                                    fault, ARRAY_SIZE(fault));
+            if (length && length < ARRAY_SIZE(fault) && !wcscmp(fault, L"marker-delete"))
+            {
+                SetEnvironmentVariableW(L"WINE4OFFICE_TEST_ROLLBACK_FAILURE", NULL);
+                SetLastError(ERROR_ACCESS_DENIED);
+                success = false;
+            }
+            else if (!DeleteFileW(marker.c_str()) && GetLastError() != ERROR_FILE_NOT_FOUND)
+                success = false;
+        }
         if (success)
         {
             DeleteFileW(backup.c_str());
@@ -553,9 +568,11 @@ bool cache_transaction::replace_bundle(const std::string &value)
     DATA_BLOB input, output = {};
     HANDLE file;
     DWORD written;
-    bool success = false;
+    bool target_existed, success = false;
 
     if (!valid()) return false;
+    target_existed = GetFileAttributesW(target.c_str()) != INVALID_FILE_ATTRIBUTES;
+    if (!write_marker(target_existed ? "replacing-existing" : "replacing-new")) return false;
     input.cbData = value.size();
     input.pbData = (BYTE *)value.data();
     if (!CryptProtectData(&input, L"Wine4Office WAM bundle", NULL, NULL, NULL,
@@ -1000,9 +1017,9 @@ static bool recover_cache_transaction_locked(void)
     LARGE_INTEGER size;
     HANDLE file;
     DWORD read;
-    std::string content, name;
+    std::string content, name, state;
     std::wstring target, backup, temporary;
-    bool success = true, transaction_replaced = false;
+    bool success = true, transaction_removes_target = false, transaction_rolling_back = false;
 
     if (marker.empty() || GetFileAttributesW(marker.c_str()) == INVALID_FILE_ATTRIBUTES) return true;
     file = CreateFileW(marker.c_str(), GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING,
@@ -1021,11 +1038,19 @@ static bool recover_cache_transaction_locked(void)
         return true;
     }
     {
-        size_t prefix_len = strlen("Wine4OfficeWamBundle=1\n"), name_end;
+        size_t prefix_len = strlen("Wine4OfficeWamBundle=1\n"), name_end, state_end;
         name_end = content.find('\n', prefix_len);
         if (name_end == std::string::npos) return false;
         name = content.substr(prefix_len, name_end - prefix_len);
-        transaction_replaced = content.compare(name_end + 1, strlen("replaced"), "replaced") == 0;
+        state_end = content.find('\n', name_end + 1);
+        if (state_end == std::string::npos) return false;
+        state = content.substr(name_end + 1, state_end - name_end - 1);
+        if (state != "prepared" && state != "replacing-existing" && state != "replacing-new" &&
+            state != "replaced" && state != "rolling-back-existing" && state != "rolling-back-new")
+            return false;
+        transaction_removes_target = state == "replacing-new" || state == "replaced" ||
+                                     state == "rolling-back-new";
+        transaction_rolling_back = state == "rolling-back-existing" || state == "rolling-back-new";
         if (name.compare(0, 11, "wam-bundle-") || name.size() != 11 + 32 + 4 ||
             name.compare(name.size() - 4, 4, ".dat"))
             return false;
@@ -1039,11 +1064,14 @@ static bool recover_cache_transaction_locked(void)
             DeleteFileW(target.c_str());
             success = MoveFileExW(backup.c_str(), target.c_str(), MOVEFILE_WRITE_THROUGH);
         }
-        else if (transaction_replaced) DeleteFileW(target.c_str());
+        else if (transaction_removes_target) DeleteFileW(target.c_str());
         DeleteFileW(temporary.c_str());
     }
     DeleteFileW(temporary.c_str());
-    if (success)
+    /* A rolling-back marker is written only after the prior projection was
+     * restored successfully.  Recover the target bundle, but do not replace
+     * that prior active projection with the target account. */
+    if (success && !transaction_rolling_back)
     {
         std::string json;
         cache_record record;
@@ -2073,7 +2101,16 @@ static bool self_test_publication_failures(const cache_record &first, const cach
                   cache_record_matches(second, loaded) && self_test_projection(second);
         secure_clear(loaded);
     }
+    if (success)
+    {
+        SetEnvironmentVariableW(L"WINE4OFFICE_TEST_PUBLICATION_FAILURE", L"final-read");
+        SetEnvironmentVariableW(L"WINE4OFFICE_TEST_ROLLBACK_FAILURE", L"marker-delete");
+        success = !cache_record_save(first) && cache_record_load(second.username, loaded) &&
+                  cache_record_matches(second, loaded) && self_test_projection(second);
+        secure_clear(loaded);
+    }
     SetEnvironmentVariableW(L"WINE4OFFICE_TEST_PUBLICATION_FAILURE", NULL);
+    SetEnvironmentVariableW(L"WINE4OFFICE_TEST_ROLLBACK_FAILURE", NULL);
     DeleteFileW(cache_file(first_bundle.c_str()).c_str());
     secure_clear(loaded);
     return success;


### PR DESCRIPTION
## Summary

- return a typed pending WinRT operation before silent token cache, mutex, helper, network, or result work
- move refresh coordination to a cancellation-aware worker with explicit COM lifetime and callback linearization
- supervise helper failures and make token-cache publication rollback deterministic
- add event-driven OnlineId regressions for both public methods, cancellation, close/callback races, helper outcomes, and resource-token identity

## Validation

- focused x86_64 and i386 DLL, test, and helper targets build successfully with the task-owned combined WoW64 build
- remote x86_64 OnlineId suite: 666/666, 0 failures, 0 skipped
- remote i386 OnlineId suite: 666/666, 0 failures, 0 skipped
- remote x86_64 and i386 wine4officeauth --self-test-cache: exit 0
- git diff --check: clean

Remote environment: wine365-plan01-async-token-acquisition-20260825, runner source f251f31a1c2b4ea4a7c09efc05d5b3b8c69dd570, 2 GiB memory limit, OOMKilled=false.

## Self-review findings fixed

- do not reuse a fresh resource access token when the cache cannot prove that its scope and client match the request
- actually execute the existing cancel-during-helper regression, rather than covering only cancel-before-work

## Known limitations

- an expired real Microsoft 365 token is difficult to reproduce reliably; this PR does not claim a live expired-token pass
- Word startup/sign-in smoke attempts timed out and are not counted as passes
- deterministic two-process refresh/coherent-generation evidence is still missing
- no p50/p95/p99 caller-return and completion matrix is claimed
- native Windows status/error and callback compatibility has no available oracle

These limitations are intentionally exposed for external review; no acceptance or merge claim is made by the test results above.

## Summary by Sourcery

Keep silent Microsoft 365 token acquisition off the caller thread while preserving cancellation safety, callback correctness, and coherent token-cache state.

New Features:
- Return pending asynchronous operations for silent OnlineId token requests through both public APIs.
- Supervise authentication and resource-refresh helpers with cancellation, timeouts, failure handling, and deterministic test controls.

Bug Fixes:
- Prevent reuse of resource tokens when their scope and client identity cannot be verified.
- Make token-cache publication and interrupted transaction recovery restore a coherent account and token generation.

Enhancements:
- Add cancellation-aware worker coordination, explicit COM lifetimes, and race-safe completion callback handling.
- Expand OnlineId and authentication self-tests to cover asynchronous behavior, cancellation, close/callback races, helper outcomes, cache identity, and publication rollback.

Documentation:
- Document background token checking and consistency improvements in the unreleased changelog.

Tests:
- Add event-driven regressions for both silent-token entry points, pending completion, cancellation, helper failures, callback races, cache serialization, and resource-token identity.
- Extend cache self-tests with publication-failure injection and crash-recovery scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Microsoft 365 authentication now runs in the background, keeping Word responsive during token checks and refreshes.
  * Authentication operations support cancellation and configurable timeout handling.

* **Bug Fixes**
  * Improved handling of authentication failures, timeouts, crashes, and missing resources.
  * Cache updates now roll back safely when publication or verification fails, including interrupted operations.

* **Tests**
  * Expanded coverage for asynchronous authentication, cancellation, completion handling, and cache recovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->