### PR TITLE
build: add canonical Wine build environment

### DIFF
--- a/.github/workflows/wine4office-release.yml
+++ b/.github/workflows/wine4office-release.yml
@@ -44,45 +44,11 @@ jobs:
       - name: Check out Wine4Office
         uses: actions/checkout@v4
 
-      - name: Install build dependencies when permitted
+      - name: Verify release orchestration environment
         shell: bash
         run: |
           set -euo pipefail
-          if [[ $(id -u) -eq 0 ]]; then
-            elevate=()
-          elif command -v sudo >/dev/null && sudo -n true 2>/dev/null; then
-            elevate=(sudo)
-          else
-            echo "Runner has no root/package-manager access; using preinstalled build dependencies."
-            exit 0
-          fi
-          command -v apt-get >/dev/null || {
-            echo "This automatic dependency step supports apt-based runner containers only." >&2
-            exit 1
-          }
-          "${elevate[@]}" dpkg --add-architecture i386
-          "${elevate[@]}" apt-get update
-          "${elevate[@]}" apt-get install -y --no-install-recommends \
-            autoconf bison build-essential ca-certificates flex gh python3-pip python3-venv zstd \
-            gcc-mingw-w64-i686 gcc-mingw-w64-x86-64 \
-            g++-mingw-w64-i686 g++-mingw-w64-x86-64 \
-            libasound2-dev libavcodec-dev libavformat-dev libavutil-dev \
-            libcups2-dev libdbus-1-dev libfontconfig-dev \
-            libegl1 libfreetype-dev libgl1-mesa-dev libgnutls28-dev libgphoto2-dev \
-            libgstreamer-plugins-base1.0-dev libgstreamer1.0-dev libkrb5-dev libpython3-dev \
-            libpcap-dev libpcsclite-dev libpulse-dev libsane-dev libsdl2-dev \
-            libswresample-dev libswscale-dev libudev-dev libunwind-dev libva-dev \
-            libusb-1.0-0-dev libv4l-dev libvulkan-dev libwayland-dev \
-            libx11-dev libxcomposite-dev libxcursor-dev libxext-dev libxi-dev \
-            libxinerama-dev libxkbcommon-dev libxkbregistry-dev libxrandr-dev libxrender-dev \
-            libxxf86vm-dev ocl-icd-opencl-dev samba-dev unixodbc-dev \
-            wayland-protocols
-
-      - name: Verify self-hosted build environment
-        shell: bash
-        run: |
-          set -euo pipefail
-          required=(make gcc g++ bison flex i686-w64-mingw32-gcc x86_64-w64-mingw32-gcc python3 tar zstd gh)
+          required=(curl docker gh python3 tar zstd)
           missing=()
           for command in "${required[@]}"; do
             command -v "$command" >/dev/null || missing+=("$command")
@@ -92,7 +58,7 @@ jobs:
             exit 1
           fi
           echo "Runner: $(uname -a)"
-          echo "Available build cores: $(nproc)"
+          docker version
           df -h .
 
       - name: Select release version
@@ -141,39 +107,11 @@ jobs:
         run: tools/wine4office-manager/tests/test_release_artifacts.sh
       - name: Test OAuth helper source contracts
         run: python3 programs/wine4officeauth/tests/test_authorize_url.py
+      - name: Test canonical Wine build contract
+        run: tools/wine-build-env/tests/test_build_contract.sh
 
       - name: Configure and build Wine4Office
-        run: |
-          set -euo pipefail
-          mkdir -p build stage
-          cd build
-          CPPFLAGS="-I$GITHUB_WORKSPACE/tools/wine4office-manager/packaging/linux-uapi" \
-            ../configure \
-            --prefix=/opt/wine4office \
-            --enable-archs=i386,x86_64 \
-            --disable-tests
-          grep -q '^#define HAVE_LINUX_NTSYNC_H 1$' include/config.h || {
-            echo "Wine configure did not enable NTSYNC support." >&2
-            exit 1
-          }
-          for feature in SONAME_LIBFREETYPE SONAME_LIBFONTCONFIG SONAME_LIBGNUTLS SONAME_LIBDBUS_1 \
-              SONAME_LIBVA SONAME_LIBVA_DRM; do
-            grep -q "^#define $feature " include/config.h || {
-              echo "Wine configure did not enable $feature; Office web content requires fonts, TLS, and desktop integration." >&2
-              exit 1
-            }
-          done
-          echo "Building with $(nproc) parallel jobs"
-          make -j"$(nproc)"
-          make DESTDIR="$GITHUB_WORKSPACE/stage" install
-          grep -aq '/dev/ntsync' "$GITHUB_WORKSPACE/stage/opt/wine4office/bin/wineserver" || {
-            echo "Built wineserver does not contain NTSYNC support." >&2
-            exit 1
-          }
-          test -f "$GITHUB_WORKSPACE/stage/opt/wine4office/lib/wine/x86_64-unix/winewayland.so" || {
-            echo "Wine Wayland driver was not built; check libwayland, libxkbcommon, libxkbregistry, and protocol dependencies." >&2
-            exit 1
-          }
+        run: tools/wine-build-env/run-build-container.sh full "$GITHUB_WORKSPACE" "$GITHUB_WORKSPACE/build" "$GITHUB_WORKSPACE/stage"
 
       - name: Bundle Wine Gecko and Mono
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Build Wine4Office releases and agent runners from the same reproducible 18-job environment.
 - Display background-service RAM without reclaimable inactive file cache and hide it when the service is stopped.
 - Activate Microsoft 365 licenses after signing in to Office.
 - Keep Wine environment recreation responsive and show live progress and logs in the Manager.

--- a/tools/wine-build-env/README.md
+++ b/tools/wine-build-env/README.md
@@ -1,0 +1,34 @@
+# Wine4Office build environment
+
+This directory is the single build contract for release and agent Wine builds.
+The GitHub release workflow and the remote incremental lifecycle both build the
+same Dockerfile and invoke `run-build-container.sh`.
+The container defaults to 18 build jobs and an 18-CPU quota.
+
+The build fails during configure when required Kerberos/GSSAPI development
+support is unavailable. It also checks the configured Office capabilities and
+the installed runner directly in `build.sh`; there is no separate capability
+policy file.
+
+## Direct use
+
+```sh
+tools/wine-build-env/run-build-container.sh full "$PWD" "$PWD/build" "$PWD/stage"
+tools/wine-build-env/run-build-container.sh targets "$PWD" "$PWD/build" "$PWD/stage" \
+  dlls/kerberos/kerberos.so
+tools/wine-build-env/run-build-container.sh install "$PWD" "$PWD/build" "$PWD/stage"
+```
+
+`targets` requires explicit make targets and refuses a dry run with more than
+80 compile or link commands. For remote work, start with
+`create-agent-build.sh` (which calls `refresh-main-build.sh`), then use
+`sync-agent-source.sh`, `build-agent-targets.sh`, `install-agent-runner.sh`,
+and `remove-agent-build.sh` in lifecycle order.
+
+## Remote configuration
+
+Remote commands read `WINE365_REMOTE_HOST`, `WINE_BUILD_REMOTE_ROOT`, and
+`WINE_BUILD_REPO_URL` from the environment. When a value is absent, they load
+the matching GitHub repository variable with `gh`. Configure all three
+repository variables before creating an agent build; successful configuration
+leaves no server identity or user path in the source tree.

--- a/tools/wine-build-env/build-agent-targets.sh
+++ b/tools/wine-build-env/build-agent-targets.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "$0")" && pwd)
+source "$script_dir/config.sh"
+remote_host=$(wine_build_remote_host)
+remote_root=$(wine_build_remote_root)
+agent_id=${1:?usage: build-agent-targets.sh AGENT_ID TARGET...}
+shift
+(($# > 0)) || { echo "At least one explicit make target is required" >&2; exit 2; }
+[[ "$agent_id" =~ ^[a-z0-9][a-z0-9-]{2,47}$ ]] || { echo "Unsafe AGENT_ID" >&2; exit 2; }
+for target in "$@"; do
+    [[ -n "$target" && "$target" != -* && "$target" != *$'\n'* ]] || {
+        echo "Unsafe make target: $target" >&2
+        exit 2
+    }
+done
+remote_payload=$(printf '%s\0' "$agent_id" "$remote_root" "$@" | base64 -w0)
+
+ssh -o BatchMode=yes "$remote_host" bash -s -- "$remote_payload" <<'REMOTE'
+set -euo pipefail
+payload=$1
+[[ "$payload" =~ ^[A-Za-z0-9+/]*={0,2}$ ]] || { echo "Invalid remote argument payload" >&2; exit 2; }
+mapfile -d '' -t remote_args < <(printf '%s' "$payload" | base64 --decode)
+((${#remote_args[@]} >= 3)) || { echo "Invalid remote argument count" >&2; exit 2; }
+agent_id=${remote_args[0]}
+remote_root=${remote_args[1]}
+set -- "${remote_args[@]:2}"
+workspace=$remote_root/agents/$agent_id
+grep -qx 'wine4office-build-root-v1' "$remote_root/.wine4office-build-root"
+grep -qx "agent_id=$agent_id" "$workspace/OWNER.env"
+[[ -x "$workspace/contract/run-build-container.sh" ]]
+available_kb=$(awk '/MemAvailable:/ {print $2}' /proc/meminfo)
+((available_kb >= 4 * 1024 * 1024)) || { echo "Less than 4 GiB available" >&2; exit 1; }
+exec 9>"$remote_root/build.lock"
+flock 9
+WINE_BUILD_CPUS=18 WINE_BUILD_JOBS=18 WINE_BUILD_MEMORY=10g \
+    "$workspace/contract/run-build-container.sh" targets \
+    "$workspace/source" "$workspace/build" "$workspace/stage" "$@"
+REMOTE

--- a/tools/wine-build-env/build.sh
+++ b/tools/wine-build-env/build.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat >&2 <<'EOF'
+Usage: build.sh configure|full|targets|install|verify [MAKE_TARGET...]
+
+The caller must mount a Wine source tree, build tree, and stage tree and set
+WINE_SOURCE_DIR, WINE_BUILD_DIR, and WINE_STAGE_DIR when they differ from the
+canonical /work paths.
+EOF
+    exit 2
+}
+
+mode=${1:-}
+[[ -n "$mode" ]] || usage
+shift
+
+source_dir=${WINE_SOURCE_DIR:-/work/source}
+build_dir=${WINE_BUILD_DIR:-/work/build}
+stage_dir=${WINE_STAGE_DIR:-/work/stage}
+prefix=${WINE_BUILD_PREFIX:-/opt/wine4office}
+jobs=${WINE_BUILD_JOBS:-18}
+max_compile_commands=${WINE_BUILD_MAX_COMPILE_COMMANDS:-80}
+image_id=${WINE_BUILD_IMAGE_ID:-unknown}
+reconfigure=${WINE_BUILD_RECONFIGURE:-0}
+
+[[ "$jobs" =~ ^[1-9][0-9]*$ ]] || { echo "WINE_BUILD_JOBS must be a positive integer" >&2; exit 2; }
+[[ "$prefix" == /opt/wine4office ]] || { echo "WINE_BUILD_PREFIX must be /opt/wine4office" >&2; exit 2; }
+[[ "$reconfigure" == 0 || "$reconfigure" == 1 ]] || {
+    echo "WINE_BUILD_RECONFIGURE must be 0 or 1" >&2
+    exit 2
+}
+[[ "$max_compile_commands" =~ ^[0-9]+$ ]] || {
+    echo "WINE_BUILD_MAX_COMPILE_COMMANDS must be a non-negative integer" >&2
+    exit 2
+}
+[[ -x "$source_dir/configure" ]] || { echo "Invalid Wine source tree: $source_dir" >&2; exit 1; }
+mkdir -p "$build_dir" "$stage_dir"
+source_dir=$(cd "$source_dir" && pwd)
+build_dir=$(cd "$build_dir" && pwd)
+stage_dir=$(cd "$stage_dir" && pwd)
+[[ "$source_dir" != "$build_dir" && "$source_dir" != "$stage_dir" && "$build_dir" != "$stage_dir" ]] || {
+    echo "Source, build, and stage must be separate directories" >&2
+    exit 1
+}
+
+configure_build() {
+    if [[ "$reconfigure" == 1 || ! -f "$build_dir/Makefile" ]]; then
+        echo "Configuring the canonical Office build in $build_dir"
+        (
+            cd "$build_dir"
+            CPPFLAGS="-I$source_dir/tools/wine4office-manager/packaging/linux-uapi${CPPFLAGS:+ $CPPFLAGS}" \
+                "$source_dir/configure" \
+                --prefix="$prefix" \
+                --enable-archs=i386,x86_64 \
+                --with-gssapi \
+                --with-krb5
+        )
+    fi
+
+    [[ -f "$build_dir/config.status" ]] || { echo "Build tree has no config.status" >&2; exit 1; }
+    grep -F -- "--prefix=$prefix" "$build_dir/config.status" >/dev/null || {
+        echo "Build tree was configured with a different prefix" >&2
+        exit 1
+    }
+    for argument in --enable-archs=i386,x86_64 --with-gssapi --with-krb5; do
+        grep -F -- "$argument" "$build_dir/config.status" >/dev/null || {
+            echo "Build tree is missing required configure argument: $argument" >&2
+            exit 1
+        }
+    done
+    grep -Fx "srcdir = $source_dir" "$build_dir/Makefile" >/dev/null || {
+        echo "Build tree source provenance mismatch: expected $source_dir" >&2
+        exit 1
+    }
+}
+
+check_configured_capabilities() {
+    local config=$build_dir/include/config.h
+    [[ -f "$config" ]] || { echo "Wine configure did not produce $config" >&2; exit 1; }
+    local definitions=(
+        HAVE_GSSAPI_GSSAPI_EXT_H
+        HAVE_GSSAPI_GSSAPI_H
+        HAVE_LINUX_NTSYNC_H
+        SONAME_LIBDBUS_1
+        SONAME_LIBFONTCONFIG
+        SONAME_LIBFREETYPE
+        SONAME_LIBGNUTLS
+        SONAME_LIBGSSAPI_KRB5
+        SONAME_LIBKRB5
+        SONAME_LIBVA
+        SONAME_LIBVA_DRM
+    )
+    local definition
+    for definition in "${definitions[@]}"; do
+        grep -Eq "^#define $definition( |$)" "$config" || {
+            echo "Wine configure did not enable required Office capability: $definition" >&2
+            exit 1
+        }
+    done
+}
+
+record_provenance() {
+    local source_commit=unknown
+    local install_plan_sha256=
+    if git -C "$source_dir" rev-parse --verify HEAD >/dev/null 2>&1; then
+        source_commit=$(git -C "$source_dir" rev-parse HEAD)
+    fi
+    if [[ -f "$build_dir/WINE4OFFICE_BUILD.env" ]]; then
+        install_plan_sha256=$(sed -n 's/^install_plan_sha256=//p' "$build_dir/WINE4OFFICE_BUILD.env")
+    fi
+    cat > "$build_dir/WINE4OFFICE_BUILD.env" <<EOF
+source_commit=$source_commit
+builder_image_id=$image_id
+configure_prefix=$prefix
+configure_archs=i386,x86_64
+configure_gssapi=required
+configure_krb5=required
+jobs=$jobs
+EOF
+    if [[ -n "$install_plan_sha256" ]]; then
+        printf 'install_plan_sha256=%s\n' "$install_plan_sha256" >> "$build_dir/WINE4OFFICE_BUILD.env"
+    fi
+}
+
+install_plan_sha256() {
+    local dry_run=$1
+    sha256sum "$dry_run" | awk '{print $1}'
+}
+
+record_clean_install_plan() {
+    local dry_run plan_sha
+    dry_run=$(mktemp)
+    make -C "$build_dir" -n DESTDIR="$stage_dir" install > "$dry_run"
+    plan_sha=$(install_plan_sha256 "$dry_run")
+    rm -f -- "$dry_run"
+    sed -i '/^install_plan_sha256=/d' "$build_dir/WINE4OFFICE_BUILD.env"
+    printf 'install_plan_sha256=%s\n' "$plan_sha" >> "$build_dir/WINE4OFFICE_BUILD.env"
+}
+
+count_compile_commands() {
+    local dry_run=$1
+    grep -Ec '^[[:space:]]*([^[:space:]=]+=[^[:space:]]+[[:space:]]+)*([^[:space:]]*/)?(ccache[[:space:]]+)?((i686|x86_64)-w64-mingw32-)?(gcc|g[+][+]|cc|c[+][+]|clang|clang[+][+]|winegcc|widl|bison|flex)([[:space:]]|$)' \
+        "$dry_run" || true
+}
+
+guard_targets() {
+    (($# > 0)) || { echo "Focused builds require at least one explicit make target" >&2; exit 2; }
+    local target
+    for target in "$@"; do
+        [[ -n "$target" && "$target" != -* && "$target" != *$'\n'* ]] || {
+            echo "Unsafe make target: $target" >&2
+            exit 2
+        }
+    done
+    local dry_run
+    dry_run=$(mktemp)
+    if ! make -C "$build_dir" -n -- "$@" > "$dry_run"; then
+        rm -f -- "$dry_run"
+        echo "Focused build dry run failed" >&2
+        exit 1
+    fi
+    local compile_commands
+    compile_commands=$(count_compile_commands "$dry_run")
+    echo "Dry run proposes $compile_commands compile/link commands for $# explicit targets"
+    if ((compile_commands > max_compile_commands)); then
+        echo "Refusing unexpectedly broad focused build ($compile_commands > $max_compile_commands commands)" >&2
+        sed -n '1,120p' "$dry_run" >&2
+        rm -f -- "$dry_run"
+        exit 1
+    fi
+    rm -f -- "$dry_run"
+}
+
+verify_staged_runner() {
+    local runner=$stage_dir$prefix
+    [[ -x "$runner/bin/wine" && -x "$runner/bin/wineserver" ]] || {
+        echo "Staged runner is missing Wine executables: $runner" >&2
+        exit 1
+    }
+    grep -aq '/dev/ntsync' "$runner/bin/wineserver" || {
+        echo "Staged wineserver does not contain NTSYNC support" >&2
+        exit 1
+    }
+    [[ -f "$runner/lib/wine/x86_64-unix/winewayland.so" ]] || {
+        echo "Staged runner is missing the Wine Wayland driver" >&2
+        exit 1
+    }
+    mapfile -t kerberos_modules < <(find "$runner/lib/wine" -type f -name kerberos.so -print)
+    ((${#kerberos_modules[@]} > 0)) || {
+        echo "Staged runner has no Kerberos Unix module" >&2
+        exit 1
+    }
+    local module
+    for module in "${kerberos_modules[@]}"; do
+        grep -aq 'gss_init_sec_context' "$module" || {
+            echo "Staged Kerberos module lacks GSSAPI support: $module" >&2
+            exit 1
+        }
+    done
+}
+
+case "$mode" in
+    configure|full|install|verify)
+        (($# == 0)) || usage
+        ;;
+    targets)
+        (($# > 0)) || usage
+        ;;
+    *) usage ;;
+esac
+
+configure_build
+check_configured_capabilities
+record_provenance
+
+case "$mode" in
+    configure)
+        ;;
+    full)
+        echo "Building canonical Wine4Office tree with $jobs parallel jobs"
+        make -C "$build_dir" -j"$jobs"
+        rm -rf -- "$stage_dir$prefix"
+        make -C "$build_dir" -j"$jobs" DESTDIR="$stage_dir" install
+        verify_staged_runner
+        record_clean_install_plan
+        ;;
+    targets)
+        guard_targets "$@"
+        make -C "$build_dir" -j"$jobs" -- "$@"
+        ;;
+    install)
+        install_dry_run=$(mktemp)
+        trap 'rm -f -- "$install_dry_run"' EXIT
+        make -C "$build_dir" -n DESTDIR="$stage_dir" install > "$install_dry_run"
+        expected_install_plan=$(sed -n 's/^install_plan_sha256=//p' "$build_dir/WINE4OFFICE_BUILD.env")
+        current_install_plan=$(install_plan_sha256 "$install_dry_run")
+        if [[ -z "$expected_install_plan" || "$current_install_plan" != "$expected_install_plan" ]]; then
+            echo "Refusing runner installation: build state differs from the canonical clean install plan" >&2
+            sed -n '1,120p' "$install_dry_run" >&2
+            exit 1
+        fi
+        make -C "$build_dir" -j"$jobs" DESTDIR="$stage_dir" install
+        verify_staged_runner
+        ;;
+    verify)
+        verify_staged_runner
+        ;;
+esac

--- a/tools/wine-build-env/config.sh
+++ b/tools/wine-build-env/config.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+wine_build_repository_variable() {
+    local name=$1
+    local value=${!name:-}
+    if [[ -z "$value" ]]; then
+        command -v gh >/dev/null || {
+            echo "$name must be set in the environment or as a GitHub repository variable" >&2
+            return 1
+        }
+        local config_dir
+        config_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+        value=$(
+            cd "$config_dir"
+            gh variable list --json name,value \
+                --jq ".[] | select(.name == \"$name\") | .value"
+        )
+    fi
+    [[ -n "$value" && "$value" != *$'\n'* ]] || {
+        echo "Missing or invalid build configuration: $name" >&2
+        return 1
+    }
+    printf '%s' "$value"
+}
+
+wine_build_remote_host() {
+    local value
+    value=$(wine_build_repository_variable WINE365_REMOTE_HOST)
+    [[ "$value" =~ ^[A-Za-z0-9._-]+(@[A-Za-z0-9._-]+)?$ ]] || {
+        echo "WINE365_REMOTE_HOST has an unsafe format" >&2
+        return 1
+    }
+    printf '%s' "$value"
+}
+
+wine_build_remote_root() {
+    local value
+    value=$(wine_build_repository_variable WINE_BUILD_REMOTE_ROOT)
+    [[ "$value" =~ ^/[A-Za-z0-9._/-]+/_wine-build$ && "$value" != *'/../'* ]] || {
+        echo "WINE_BUILD_REMOTE_ROOT must be an absolute path ending in /_wine-build" >&2
+        return 1
+    }
+    printf '%s' "$value"
+}
+
+wine_build_repo_url() {
+    local value
+    value=$(wine_build_repository_variable WINE_BUILD_REPO_URL)
+    [[ "$value" != *[[:space:]]* ]] || {
+        echo "WINE_BUILD_REPO_URL cannot contain whitespace" >&2
+        return 1
+    }
+    printf '%s' "$value"
+}

--- a/tools/wine-build-env/create-agent-build.sh
+++ b/tools/wine-build-env/create-agent-build.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "$0")" && pwd)
+source "$script_dir/config.sh"
+remote_host=$(wine_build_remote_host)
+remote_root=$(wine_build_remote_root)
+agent_id=${1:?usage: create-agent-build.sh AGENT_ID}
+
+[[ "$agent_id" =~ ^[a-z0-9][a-z0-9-]{2,47}$ ]] || {
+    echo "AGENT_ID must be 3-48 lowercase letters, digits, or hyphens" >&2
+    exit 2
+}
+
+export WINE365_REMOTE_HOST="$remote_host" WINE_BUILD_REMOTE_ROOT="$remote_root"
+"$script_dir/refresh-main-build.sh"
+remote_payload=$(printf '%s\0' "$agent_id" "$remote_root" | base64 -w0)
+
+ssh -o BatchMode=yes "$remote_host" bash -s -- "$remote_payload" <<'REMOTE'
+set -euo pipefail
+payload=$1
+[[ "$payload" =~ ^[A-Za-z0-9+/]*={0,2}$ ]] || { echo "Invalid remote argument payload" >&2; exit 2; }
+mapfile -d '' -t remote_args < <(printf '%s' "$payload" | base64 --decode)
+((${#remote_args[@]} == 2)) || { echo "Invalid remote argument count" >&2; exit 2; }
+agent_id=${remote_args[0]}
+remote_root=${remote_args[1]}
+baseline_root=$remote_root/baselines
+workspace=$remote_root/agents/$agent_id
+
+grep -qx 'wine4office-build-root-v1' "$remote_root/.wine4office-build-root"
+[[ -L "$baseline_root/current" ]] || { echo "No canonical baseline is available" >&2; exit 1; }
+baseline=$(readlink -e "$baseline_root/current")
+[[ "$baseline" == "$baseline_root"/* && -f "$baseline/BUILD.env" ]]
+[[ ! -e "$workspace" ]] || { echo "Agent build already exists: $agent_id" >&2; exit 1; }
+
+cp -a --reflink=always "$baseline" "$workspace"
+source_commit=$(awk -F= '$1 == "source_commit" {print $2}' "$baseline/BUILD.env")
+contract_hash=$(awk -F= '$1 == "contract_hash" {print $2}' "$baseline/BUILD.env")
+cat > "$workspace/OWNER.env" <<EOF
+agent_id=$agent_id
+source_commit=$source_commit
+contract_hash=$contract_hash
+baseline=$baseline
+created=$(date --iso-8601=seconds)
+EOF
+printf 'agent_id=%s\nworkspace=%s\nsource_commit=%s\ncontract_hash=%s\n' \
+    "$agent_id" "$workspace" "$source_commit" "$contract_hash"
+REMOTE

--- a/tools/wine-build-env/image/Dockerfile
+++ b/tools/wine-build-env/image/Dockerfile
@@ -1,0 +1,82 @@
+FROM ubuntu:24.04@sha256:33ceb71981b602c1a7443a53469e4dba065f7503eab3078a2d7a57a2ab987517
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN dpkg --add-architecture i386 \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        autoconf \
+        bison \
+        build-essential \
+        ca-certificates \
+        ccache \
+        curl \
+        flex \
+        g++-mingw-w64-i686 \
+        g++-mingw-w64-x86-64 \
+        gcc-mingw-w64-i686 \
+        gcc-mingw-w64-x86-64 \
+        git \
+        libasound2-dev \
+        libavcodec-dev \
+        libavformat-dev \
+        libavutil-dev \
+        libcups2-dev \
+        libdbus-1-dev \
+        libegl1 \
+        libfontconfig-dev \
+        libfontconfig-dev:i386 \
+        libfreetype-dev \
+        libfreetype-dev:i386 \
+        libgl1-mesa-dev \
+        libgnutls28-dev \
+        libgphoto2-dev \
+        libgstreamer-plugins-base1.0-dev \
+        libgstreamer1.0-dev \
+        libkrb5-dev \
+        libpcap-dev \
+        libpcsclite-dev \
+        libpipewire-0.3-dev \
+        libpulse-dev \
+        libpython3-dev \
+        libsane-dev \
+        libsdl2-dev \
+        libswresample-dev \
+        libswscale-dev \
+        libudev-dev \
+        libunwind-dev \
+        libusb-1.0-0-dev \
+        libv4l-dev \
+        libva-dev \
+        libvulkan-dev \
+        libwayland-dev \
+        libx11-dev \
+        libxcomposite-dev \
+        libxcursor-dev \
+        libxext-dev \
+        libxfixes-dev \
+        libxi-dev \
+        libxinerama-dev \
+        libxkbcommon-dev \
+        libxkbregistry-dev \
+        libxrandr-dev \
+        libxrender-dev \
+        libxxf86vm-dev \
+        ocl-icd-opencl-dev \
+        pkg-config \
+        python3 \
+        python3-pip \
+        python3-venv \
+        samba-dev \
+        tar \
+        unixodbc-dev \
+        wayland-protocols \
+        xz-utils \
+        zstd \
+    && rm -rf /var/lib/apt/lists/*
+
+LABEL org.opencontainers.image.title="Wine4Office builder" \
+      org.opencontainers.image.description="Canonical combined-WoW64 Wine4Office build environment" \
+      wine4office.build-contract="1"
+
+WORKDIR /work/build

--- a/tools/wine-build-env/install-agent-runner.sh
+++ b/tools/wine-build-env/install-agent-runner.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "$0")" && pwd)
+source "$script_dir/config.sh"
+remote_host=$(wine_build_remote_host)
+remote_root=$(wine_build_remote_root)
+agent_id=${1:?usage: install-agent-runner.sh AGENT_ID}
+[[ "$agent_id" =~ ^[a-z0-9][a-z0-9-]{2,47}$ ]] || { echo "Unsafe AGENT_ID" >&2; exit 2; }
+remote_payload=$(printf '%s\0' "$agent_id" "$remote_root" | base64 -w0)
+
+ssh -o BatchMode=yes "$remote_host" bash -s -- "$remote_payload" <<'REMOTE'
+set -euo pipefail
+payload=$1
+[[ "$payload" =~ ^[A-Za-z0-9+/]*={0,2}$ ]] || { echo "Invalid remote argument payload" >&2; exit 2; }
+mapfile -d '' -t remote_args < <(printf '%s' "$payload" | base64 --decode)
+((${#remote_args[@]} == 2)) || { echo "Invalid remote argument count" >&2; exit 2; }
+agent_id=${remote_args[0]}
+remote_root=${remote_args[1]}
+workspace=$remote_root/agents/$agent_id
+grep -qx 'wine4office-build-root-v1' "$remote_root/.wine4office-build-root"
+grep -qx "agent_id=$agent_id" "$workspace/OWNER.env"
+exec 9>"$remote_root/build.lock"
+flock 9
+WINE_BUILD_CPUS=18 WINE_BUILD_JOBS=18 WINE_BUILD_MEMORY=10g \
+    "$workspace/contract/run-build-container.sh" install \
+    "$workspace/source" "$workspace/build" "$workspace/stage"
+printf 'runner=%s\n' "$workspace/stage/opt/wine4office"
+REMOTE

--- a/tools/wine-build-env/refresh-main-build.sh
+++ b/tools/wine-build-env/refresh-main-build.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "$0")" && pwd)
+source "$script_dir/config.sh"
+remote_host=$(wine_build_remote_host)
+repo_url=$(wine_build_repo_url)
+remote_root=$(wine_build_remote_root)
+remote_payload=$(printf '%s\0' "$repo_url" "$remote_root" | base64 -w0)
+
+ssh -o BatchMode=yes "$remote_host" bash -s -- "$remote_payload" <<'REMOTE'
+set -euo pipefail
+payload=$1
+[[ "$payload" =~ ^[A-Za-z0-9+/]*={0,2}$ ]] || { echo "Invalid remote argument payload" >&2; exit 2; }
+mapfile -d '' -t remote_args < <(printf '%s' "$payload" | base64 --decode)
+((${#remote_args[@]} == 2)) || { echo "Invalid remote argument count" >&2; exit 2; }
+repo_url=${remote_args[0]}
+remote_root=${remote_args[1]}
+baseline_root=$remote_root/baselines
+
+[[ "$remote_root" =~ ^/[A-Za-z0-9._/-]+/_wine-build$ && "$remote_root" != *'/../'* ]] || {
+    echo "Unexpected remote build root: $remote_root" >&2
+    exit 1
+}
+mkdir -p "$remote_root"
+root_marker=$remote_root/.wine4office-build-root
+if [[ ! -e "$root_marker" ]]; then
+    printf 'wine4office-build-root-v1\n' > "$root_marker"
+fi
+grep -qx 'wine4office-build-root-v1' "$root_marker" || {
+    echo "Invalid remote build-root marker" >&2
+    exit 1
+}
+[[ $(stat -f -c %T "$remote_root") == btrfs ]] || {
+    echo "Canonical incremental builds require Btrfs reflinks" >&2
+    exit 1
+}
+mkdir -p "$baseline_root" "$remote_root/agents"
+exec 9>"$remote_root/refresh.lock"
+flock 9
+
+origin_commit=$(git ls-remote "$repo_url" refs/heads/main | awk 'NR == 1 {print $1}')
+[[ "$origin_commit" =~ ^[0-9a-f]{40}$ ]] || { echo "Cannot resolve origin/main" >&2; exit 1; }
+
+candidate=$(mktemp -d "$baseline_root/.refresh.XXXXXX")
+cleanup() {
+    [[ -n ${candidate:-} && "$candidate" == "$baseline_root"/.refresh.* ]] && rm -rf -- "$candidate"
+}
+trap cleanup EXIT INT TERM
+
+if [[ -L "$baseline_root/current" ]]; then
+    current=$(readlink -e "$baseline_root/current")
+    [[ "$current" == "$baseline_root"/* && -f "$current/BUILD.env" ]] || {
+        echo "Invalid canonical baseline pointer" >&2
+        exit 1
+    }
+    cp -a --reflink=always "$current"/. "$candidate"/
+    git -C "$candidate/source" status --porcelain | grep -q . && {
+        echo "Canonical baseline source is dirty" >&2
+        exit 1
+    }
+    git -C "$candidate/source" fetch --quiet origin main
+    git -C "$candidate/source" checkout --quiet --detach "$origin_commit"
+else
+    git clone --quiet --no-tags "$repo_url" "$candidate/source"
+    git -C "$candidate/source" checkout --quiet --detach "$origin_commit"
+    mkdir -p "$candidate/build" "$candidate/stage"
+fi
+
+contract_dir=$candidate/source/tools/wine-build-env
+[[ -x "$contract_dir/run-build-container.sh" && -f "$contract_dir/image/Dockerfile" ]] || {
+    echo "origin/main does not contain the canonical Wine build contract" >&2
+    exit 1
+}
+contract_hash=$(sha256sum \
+    "$contract_dir/image/Dockerfile" \
+    "$contract_dir/build.sh" \
+    "$contract_dir/run-build-container.sh" | awk '{print $1}' | sha256sum | cut -c1-16)
+baseline_name=${origin_commit:0:12}-$contract_hash
+destination=$baseline_root/$baseline_name
+
+if [[ -d "$destination" ]]; then
+    grep -qx "source_commit=$origin_commit" "$destination/BUILD.env"
+    grep -qx "contract_hash=$contract_hash" "$destination/BUILD.env"
+else
+    exec 8>"$remote_root/build.lock"
+    flock 8
+    available_kb=$(awk '/MemAvailable:/ {print $2}' /proc/meminfo)
+    ((available_kb >= 4 * 1024 * 1024)) || {
+        echo "Less than 4 GiB is available; refusing canonical build refresh" >&2
+        exit 1
+    }
+    WINE_BUILD_CPUS=18 WINE_BUILD_JOBS=18 WINE_BUILD_MEMORY=10g WINE_BUILD_RECONFIGURE=1 \
+        "$contract_dir/run-build-container.sh" full \
+        "$candidate/source" "$candidate/build" "$candidate/stage"
+    rm -rf -- "$candidate/contract"
+    cp -a "$contract_dir" "$candidate/contract"
+    builder_image=$(awk -F= '$1 == "builder_image_id" {print $2}' \
+        "$candidate/build/WINE4OFFICE_BUILD.env")
+    cat > "$candidate/BUILD.env" <<EOF
+source_commit=$origin_commit
+contract_hash=$contract_hash
+builder_image_id=$builder_image
+configure_archs=i386,x86_64
+created=$(date --iso-8601=seconds)
+EOF
+    mv "$candidate" "$destination"
+    candidate=
+fi
+
+link_tmp=$baseline_root/.current.$$
+ln -s "$baseline_name" "$link_tmp"
+mv -Tf "$link_tmp" "$baseline_root/current"
+printf 'baseline=%s\nsource_commit=%s\ncontract_hash=%s\n' \
+    "$destination" "$origin_commit" "$contract_hash"
+REMOTE

--- a/tools/wine-build-env/remove-agent-build.sh
+++ b/tools/wine-build-env/remove-agent-build.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "$0")" && pwd)
+source "$script_dir/config.sh"
+remote_host=$(wine_build_remote_host)
+remote_root=$(wine_build_remote_root)
+agent_id=${1:?usage: remove-agent-build.sh AGENT_ID}
+[[ "$agent_id" =~ ^[a-z0-9][a-z0-9-]{2,47}$ ]] || { echo "Unsafe AGENT_ID" >&2; exit 2; }
+remote_payload=$(printf '%s\0' "$agent_id" "$remote_root" | base64 -w0)
+
+ssh -o BatchMode=yes "$remote_host" bash -s -- "$remote_payload" <<'REMOTE'
+set -euo pipefail
+payload=$1
+[[ "$payload" =~ ^[A-Za-z0-9+/]*={0,2}$ ]] || { echo "Invalid remote argument payload" >&2; exit 2; }
+mapfile -d '' -t remote_args < <(printf '%s' "$payload" | base64 --decode)
+((${#remote_args[@]} == 2)) || { echo "Invalid remote argument count" >&2; exit 2; }
+agent_id=${remote_args[0]}
+remote_root=${remote_args[1]}
+workspace=$remote_root/agents/$agent_id
+grep -qx 'wine4office-build-root-v1' "$remote_root/.wine4office-build-root" || {
+    echo "Refusing removal outside a marked Wine4Office build root" >&2
+    exit 2
+}
+[[ -f "$workspace/OWNER.env" ]] || { echo "Not an agent workspace: $workspace" >&2; exit 1; }
+grep -qx "agent_id=$agent_id" "$workspace/OWNER.env"
+rm -rf -- "$workspace"
+printf 'removed=%s\n' "$workspace"
+REMOTE

--- a/tools/wine-build-env/run-build-container.sh
+++ b/tools/wine-build-env/run-build-container.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 MODE SOURCE_DIR BUILD_DIR STAGE_DIR [MAKE_TARGET...]" >&2
+    exit 2
+}
+
+[[ $# -ge 4 ]] || usage
+mode=$1
+source_dir=$2
+build_dir=$3
+stage_dir=$4
+shift 4
+
+case "$mode" in configure|full|targets|install|verify) ;; *) usage ;; esac
+[[ -d "$source_dir" && -x "$source_dir/configure" ]] || { echo "Invalid source directory: $source_dir" >&2; exit 1; }
+mkdir -p "$build_dir" "$stage_dir"
+source_dir=$(cd "$source_dir" && pwd)
+build_dir=$(cd "$build_dir" && pwd)
+stage_dir=$(cd "$stage_dir" && pwd)
+script_dir=$(cd "$(dirname "$0")" && pwd)
+dockerfile=$script_dir/image/Dockerfile
+[[ -f "$dockerfile" && -x "$script_dir/build.sh" ]] || { echo "Incomplete build contract: $script_dir" >&2; exit 1; }
+
+contract_hash=$(sha256sum "$dockerfile" "$script_dir/build.sh" "$script_dir/run-build-container.sh" \
+    | awk '{print $1}' | sha256sum | cut -c1-16)
+image=${WINE_BUILD_IMAGE:-wine4office-builder:$contract_hash}
+if ! docker image inspect "$image" >/dev/null 2>&1; then
+    docker build --pull --tag "$image" "$script_dir/image"
+fi
+image_id=$(docker image inspect "$image" --format '{{.Id}}')
+
+cpus=${WINE_BUILD_CPUS:-18}
+memory=${WINE_BUILD_MEMORY:-10g}
+jobs=${WINE_BUILD_JOBS:-18}
+[[ "$cpus" =~ ^[1-9][0-9]*([.][0-9]+)?$ && "$memory" =~ ^[1-9][0-9]*[mg]$ && "$jobs" =~ ^[1-9][0-9]*$ ]] || {
+    echo "Invalid WINE_BUILD_CPUS, WINE_BUILD_MEMORY, or WINE_BUILD_JOBS" >&2
+    exit 2
+}
+
+volume_args=()
+container_source=/work/source
+container_build=/work/build
+container_stage=/work/stage
+container_contract=/work/contract
+if [[ -n ${HOSTNAME:-} ]] && docker container inspect "$HOSTNAME" >/dev/null 2>&1; then
+    volume_args=(--volumes-from "$HOSTNAME")
+    container_source=$source_dir
+    container_build=$build_dir
+    container_stage=$stage_dir
+    container_contract=$script_dir
+else
+    volume_args=(
+        --mount "type=bind,src=$source_dir,dst=$container_source,readonly"
+        --mount "type=bind,src=$build_dir,dst=$container_build"
+        --mount "type=bind,src=$stage_dir,dst=$container_stage"
+        --mount "type=bind,src=$script_dir,dst=$container_contract,readonly"
+    )
+fi
+
+exec docker run --rm --init \
+    --label wine4office.role=wine-builder \
+    --cpus "$cpus" --memory "$memory" --memory-swap "$memory" \
+    --network none --security-opt no-new-privileges \
+    --user "$(id -u):$(id -g)" \
+    "${volume_args[@]}" \
+    --workdir "$container_build" \
+    --env WINE_SOURCE_DIR="$container_source" \
+    --env WINE_BUILD_DIR="$container_build" \
+    --env WINE_STAGE_DIR="$container_stage" \
+    --env WINE_BUILD_JOBS="$jobs" \
+    --env WINE_BUILD_RECONFIGURE="${WINE_BUILD_RECONFIGURE:-0}" \
+    --env WINE_BUILD_MAX_COMPILE_COMMANDS="${WINE_BUILD_MAX_COMPILE_COMMANDS:-80}" \
+    --env WINE_BUILD_IMAGE_ID="$image_id" \
+    "$image" \
+    "$container_contract/build.sh" "$mode" "$@"

--- a/tools/wine-build-env/sync-agent-source.sh
+++ b/tools/wine-build-env/sync-agent-source.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "$0")" && pwd)
+source "$script_dir/config.sh"
+remote_host=$(wine_build_remote_host)
+remote_root=$(wine_build_remote_root)
+agent_id=${1:?usage: sync-agent-source.sh AGENT_ID LOCAL_WORKTREE}
+local_source=${2:?usage: sync-agent-source.sh AGENT_ID LOCAL_WORKTREE}
+
+[[ "$agent_id" =~ ^[a-z0-9][a-z0-9-]{2,47}$ ]] || { echo "Unsafe AGENT_ID" >&2; exit 2; }
+local_source=$(cd "$local_source" && pwd)
+git -C "$local_source" rev-parse --is-inside-work-tree >/dev/null
+remote_payload=$(printf '%s\0' "$agent_id" "$remote_root" | base64 -w0)
+
+metadata=$(ssh -o BatchMode=yes "$remote_host" bash -s -- "$remote_payload" <<'REMOTE'
+set -euo pipefail
+payload=$1
+[[ "$payload" =~ ^[A-Za-z0-9+/]*={0,2}$ ]] || { echo "Invalid remote argument payload" >&2; exit 2; }
+mapfile -d '' -t remote_args < <(printf '%s' "$payload" | base64 --decode)
+((${#remote_args[@]} == 2)) || { echo "Invalid remote argument count" >&2; exit 2; }
+agent_id=${remote_args[0]}
+remote_root=${remote_args[1]}
+workspace=$remote_root/agents/$agent_id
+grep -qx 'wine4office-build-root-v1' "$remote_root/.wine4office-build-root"
+grep -qx "agent_id=$agent_id" "$workspace/OWNER.env"
+awk -F= '$1 == "source_commit" {print $2}' "$workspace/OWNER.env"
+REMOTE
+)
+base_commit=$metadata
+[[ "$base_commit" =~ ^[0-9a-f]{40}$ ]]
+git -C "$local_source" merge-base --is-ancestor "$base_commit" HEAD || {
+    echo "Local worktree is not based on the agent baseline $base_commit" >&2
+    exit 1
+}
+
+rsync -rlp --checksum --delete --no-times --omit-dir-times --safe-links \
+    --exclude=/.git \
+    "$local_source"/ "$remote_host:$remote_root/agents/$agent_id/source/"
+
+ssh -o BatchMode=yes "$remote_host" bash -s -- "$remote_payload" <<'REMOTE'
+set -euo pipefail
+payload=$1
+[[ "$payload" =~ ^[A-Za-z0-9+/]*={0,2}$ ]] || { echo "Invalid remote argument payload" >&2; exit 2; }
+mapfile -d '' -t remote_args < <(printf '%s' "$payload" | base64 --decode)
+((${#remote_args[@]} == 2)) || { echo "Invalid remote argument count" >&2; exit 2; }
+agent_id=${remote_args[0]}
+remote_root=${remote_args[1]}
+grep -qx 'wine4office-build-root-v1' "$remote_root/.wine4office-build-root"
+git -C "$remote_root/agents/$agent_id/source" status --short --branch
+REMOTE

--- a/tools/wine-build-env/tests/test_build_contract.sh
+++ b/tools/wine-build-env/tests/test_build_contract.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root=$(cd "$(dirname "$0")/../../.." && pwd)
+contract=$root/tools/wine-build-env
+tmp=$(mktemp -d)
+trap 'rm -rf -- "$tmp"' EXIT
+
+assert_absent() {
+    local pattern=$1
+    local file=$2
+    local status
+    if grep -F -- "$pattern" "$file" >/dev/null; then
+        echo "Forbidden text found in $file: $pattern" >&2
+        exit 1
+    else
+        status=$?
+        ((status == 1)) || { echo "Cannot search $file" >&2; exit "$status"; }
+    fi
+}
+
+for script in "$contract"/*.sh "$contract"/tests/*.sh; do
+    bash -n "$script"
+done
+
+source_dir=$tmp/source
+build_dir=$tmp/build
+stage_dir=$tmp/stage
+fake_bin=$tmp/bin
+mkdir -p "$source_dir/tools/wine4office-manager/packaging/linux-uapi" \
+    "$build_dir/include" "$stage_dir" "$fake_bin"
+printf '#!/bin/sh\nexit 99\n' > "$source_dir/configure"
+chmod 0755 "$source_dir/configure"
+printf 'srcdir = %s\n' "$source_dir" > "$build_dir/Makefile"
+cat > "$build_dir/config.status" <<'EOF'
+ac_cs_config='--prefix=/opt/wine4office --enable-archs=i386,x86_64 --with-gssapi --with-krb5'
+EOF
+cat > "$build_dir/include/config.h" <<'EOF'
+#define HAVE_GSSAPI_GSSAPI_EXT_H 1
+#define HAVE_GSSAPI_GSSAPI_H 1
+#define HAVE_LINUX_NTSYNC_H 1
+#define SONAME_LIBDBUS_1 "libdbus-1.so.3"
+#define SONAME_LIBFONTCONFIG "libfontconfig.so.1"
+#define SONAME_LIBFREETYPE "libfreetype.so.6"
+#define SONAME_LIBGNUTLS "libgnutls.so.30"
+#define SONAME_LIBGSSAPI_KRB5 "libgssapi_krb5.so.2"
+#define SONAME_LIBKRB5 "libkrb5.so.3"
+#define SONAME_LIBVA "libva.so.2"
+#define SONAME_LIBVA_DRM "libva-drm.so.2"
+EOF
+
+build_env=(
+    WINE_SOURCE_DIR="$source_dir"
+    WINE_BUILD_DIR="$build_dir"
+    WINE_STAGE_DIR="$stage_dir"
+    WINE_BUILD_JOBS=12
+)
+env "${build_env[@]}" "$contract/build.sh" configure
+grep -qx 'configure_archs=i386,x86_64' "$build_dir/WINE4OFFICE_BUILD.env"
+grep -qx 'jobs=12' "$build_dir/WINE4OFFICE_BUILD.env"
+provenance_before=$(sha256sum "$build_dir/WINE4OFFICE_BUILD.env")
+if env "${build_env[@]}" "$contract/build.sh" invalid >"$tmp/invalid-mode.log" 2>&1; then
+    echo "Build contract accepted an invalid mode" >&2
+    exit 1
+fi
+[[ $(sha256sum "$build_dir/WINE4OFFICE_BUILD.env") == "$provenance_before" ]] || {
+    echo "Invalid mode changed build provenance" >&2
+    exit 1
+}
+
+cp "$build_dir/include/config.h" "$tmp/config.good"
+sed -i '/SONAME_LIBGSSAPI_KRB5/d' "$build_dir/include/config.h"
+if env "${build_env[@]}" "$contract/build.sh" configure >"$tmp/missing.log" 2>&1; then
+    echo "Build contract accepted missing GSSAPI support" >&2
+    exit 1
+fi
+grep -F 'SONAME_LIBGSSAPI_KRB5' "$tmp/missing.log" >/dev/null
+cp "$tmp/config.good" "$build_dir/include/config.h"
+
+cat > "$fake_bin/make" <<'EOF'
+#!/bin/sh
+case " $* " in
+    *' -n '*)
+        echo 'gcc -c one.c -o one.o'
+        echo 'gcc -c two.c -o two.o'
+        echo 'gcc one.o two.o -o module.so'
+        ;;
+    *) echo 'unguarded make executed' >&2; exit 90 ;;
+esac
+EOF
+chmod 0755 "$fake_bin/make"
+if env PATH="$fake_bin:$PATH" "${build_env[@]}" WINE_BUILD_MAX_COMPILE_COMMANDS=2 \
+    "$contract/build.sh" targets dlls/example/example.so >"$tmp/broad.log" 2>&1; then
+    echo "Build contract accepted an unexpectedly broad focused build" >&2
+    exit 1
+fi
+grep -F 'Refusing unexpectedly broad focused build' "$tmp/broad.log" >/dev/null
+
+runner=$stage_dir/opt/wine4office
+mkdir -p "$runner/bin" "$runner/lib/wine/x86_64-unix"
+printf '#!/bin/sh\nexit 0\n' > "$runner/bin/wine"
+printf '#!/bin/sh\n# /dev/ntsync\nexit 0\n' > "$runner/bin/wineserver"
+chmod 0755 "$runner/bin/wine" "$runner/bin/wineserver"
+printf 'wayland driver\n' > "$runner/lib/wine/x86_64-unix/winewayland.so"
+printf 'gss_init_sec_context\n' > "$runner/lib/wine/x86_64-unix/kerberos.so"
+env "${build_env[@]}" "$contract/build.sh" verify
+
+printf 'stub kerberos\n' > "$runner/lib/wine/x86_64-unix/kerberos.so"
+if env "${build_env[@]}" "$contract/build.sh" verify >"$tmp/stub.log" 2>&1; then
+    echo "Build contract accepted a Kerberos stub" >&2
+    exit 1
+fi
+grep -F 'lacks GSSAPI support' "$tmp/stub.log" >/dev/null
+
+printf 'gss_init_sec_context\n' > "$runner/lib/wine/x86_64-unix/kerberos.so"
+cat > "$fake_bin/make" <<'EOF'
+#!/bin/sh
+case " $* " in
+    *' -n '*' install '*) echo 'tools/install staged-runner' ;;
+    *' install '*)
+        runner=$WINE_STAGE_DIR/opt/wine4office
+        mkdir -p "$runner/bin" "$runner/lib/wine/x86_64-unix"
+        printf '#!/bin/sh\nexit 0\n' > "$runner/bin/wine"
+        printf '#!/bin/sh\n# /dev/ntsync\nexit 0\n' > "$runner/bin/wineserver"
+        chmod 0755 "$runner/bin/wine" "$runner/bin/wineserver"
+        printf 'wayland driver\n' > "$runner/lib/wine/x86_64-unix/winewayland.so"
+        printf 'gss_init_sec_context\n' > "$runner/lib/wine/x86_64-unix/kerberos.so"
+        ;;
+    *) exit 0 ;;
+esac
+EOF
+chmod 0755 "$fake_bin/make"
+touch "$stage_dir/unrelated-stage-file"
+env PATH="$fake_bin:$PATH" "${build_env[@]}" "$contract/build.sh" full
+[[ -f "$stage_dir/unrelated-stage-file" ]] || { echo "Full build removed unrelated stage data" >&2; exit 1; }
+grep -Eq '^install_plan_sha256=[0-9a-f]{64}$' "$build_dir/WINE4OFFICE_BUILD.env"
+env PATH="$fake_bin:$PATH" "${build_env[@]}" "$contract/build.sh" install
+
+sed -i "s/tools\/install staged-runner/gcc -c unbuilt.c -o unbuilt.o/" "$fake_bin/make"
+if env PATH="$fake_bin:$PATH" "${build_env[@]}" "$contract/build.sh" install \
+    >"$tmp/dirty-install.log" 2>&1; then
+    echo "Build contract installed a runner with unbuilt work" >&2
+    exit 1
+fi
+grep -F 'differs from the canonical clean install plan' "$tmp/dirty-install.log" >/dev/null
+
+grep -F 'libkrb5-dev' "$contract/image/Dockerfile" >/dev/null
+grep -F 'libfreetype-dev:i386' "$contract/image/Dockerfile" >/dev/null
+grep -F 'libfontconfig-dev:i386' "$contract/image/Dockerfile" >/dev/null
+grep -F 'tools/wine-build-env/run-build-container.sh full' \
+    "$root/.github/workflows/wine4office-release.yml" >/dev/null
+assert_absent 'apt-get install' "$root/.github/workflows/wine4office-release.yml"
+grep -F -- '--exclude=/.git' "$contract/sync-agent-source.sh" >/dev/null
+assert_absent '--exclude=/.git/' "$contract/sync-agent-source.sh"
+grep -F 'docker container inspect "$HOSTNAME"' "$contract/run-build-container.sh" >/dev/null
+grep -F 'jobs=${WINE_BUILD_JOBS:-18}' "$contract/build.sh" >/dev/null
+grep -F 'cpus=${WINE_BUILD_CPUS:-18}' "$contract/run-build-container.sh" >/dev/null
+grep -F 'WINE_BUILD_RECONFIGURE=1' "$contract/refresh-main-build.sh" >/dev/null
+
+ssh_bin=$tmp/ssh-bin
+mkdir -p "$ssh_bin"
+cat > "$ssh_bin/ssh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ "$*" != *';'* ]] || { echo "SSH received an unencoded shell metacharacter" >&2; exit 1; }
+payload=${!#}
+mapfile -d '' -t decoded < <(printf '%s' "$payload" | base64 --decode)
+[[ ${decoded[0]} == agent-safe ]]
+[[ ${decoded[1]} == /srv/wine4office/_wine-build ]]
+[[ ${decoded[2]} == 'dlls/example;printf injected' ]]
+EOF
+chmod 0755 "$ssh_bin/ssh"
+PATH="$ssh_bin:$PATH" WINE365_REMOTE_HOST=builder@build-host \
+    WINE_BUILD_REMOTE_ROOT=/srv/wine4office/_wine-build \
+    "$contract/build-agent-targets.sh" agent-safe 'dlls/example;printf injected'
+
+assert_absent 'remote_host=${WINE365_REMOTE_HOST:-' "$contract/build-agent-targets.sh"
+assert_absent 'remote_root=${WINE_BUILD_REMOTE_ROOT:-' "$contract/build-agent-targets.sh"
+grep -F 'wine_build_repository_variable WINE365_REMOTE_HOST' "$contract/config.sh" >/dev/null
+grep -F 'wine_build_repository_variable WINE_BUILD_REMOTE_ROOT' "$contract/config.sh" >/dev/null
+grep -F 'wine_build_repository_variable WINE_BUILD_REPO_URL' "$contract/config.sh" >/dev/null
+
+echo "canonical Wine build contract: PASS"


### PR DESCRIPTION
## Purpose

Use one pinned Wine build environment for GitHub releases and remote agent builds, with a reusable incremental baseline instead of ad-hoc host builds.

## Changes

- add a pinned Ubuntu 24.04 builder image with the release dependencies, including Kerberos/GSSAPI and 32-bit font dependencies
- add a shared combined-WoW64 build entry point with required Office capability checks and an 18-job default
- add Btrfs reflink lifecycle commands for refreshing the origin/main baseline and creating isolated agent workspaces
- load remote host, root, and repository configuration from environment overrides or GitHub repository variables
- guard focused builds with explicit targets and guard runner installation with the canonical clean install plan
- make the release workflow call the same builder instead of installing and building directly on the runner host

## Validation

- `tools/wine-build-env/tests/test_build_contract.sh`
- `tools/wine4office-manager/tests/test_release_artifacts.sh`
- `tools/wine4office-manager/tests/test_curl_install.sh`
- `python3 programs/wine4officeauth/tests/test_authorize_url.py`
- shell syntax, workflow YAML parsing, identifier audit, and `git diff --check`
- built the pinned image and a complete combined-WoW64 runner on the remote build environment
- reconfigured the reused build with 18 jobs and verified Kerberos/GSSAPI in the staged runner
- touched `dlls/kerberos/unixlib.c`; the focused rebuild took 2.6 seconds and rebuilt only `unixlib.o` and `kerberos.so`
- verified GitHub variable loading and metacharacter-safe argument transport over real SSH

## Operational notes

- the self-hosted GitHub runner must provide the Docker CLI and access to its Docker daemon
- configure `WINE365_REMOTE_HOST`, `WINE_BUILD_REMOTE_ROOT`, and `WINE_BUILD_REPO_URL` as GitHub repository variables before creating remote agent builds
- remote baseline refresh is lazy: `create-agent-build.sh` refreshes it from `origin/main` before cloning an agent workspace
- this PR does not add a push-to-main workflow that prewarms the remote baseline
