### PR TITLE
onlineid: Support consumer Microsoft account sign-in

### DIFF
--- a/dlls/jscript/function.c
+++ b/dlls/jscript/function.c
@@ -485,7 +485,9 @@ static HRESULT Function_apply(script_ctx_t *ctx, jsval_t vthis, WORD flags, unsi
         }
     }
 
-    if(argc >= 2) {
+    /* ECMA-262 15.3.4.3: a null or undefined argArray means an empty argument
+     * list, not an error. */
+    if(argc >= 2 && !is_undefined(argv[1]) && !is_null(argv[1])) {
         IDispatch *obj = NULL;
         jsdisp_t *arg_array;
 

--- a/dlls/mshtml/htmlevent.c
+++ b/dlls/mshtml/htmlevent.c
@@ -3590,6 +3590,17 @@ dispex_static_data_t Event_dispex = {
     .iface_tids = Event_iface_tids,
 };
 
+/* Scripts only need the ErrorEvent constructor to exist and to inherit from
+ * Event; the message/filename/lineno/colno properties are not implemented. */
+dispex_static_data_t ErrorEvent_dispex = {
+    .id              = OBJID_ErrorEvent,
+    .prototype_id    = OBJID_Event,
+    .vtbl            = &DOMEvent_dispex_vtbl,
+    .disp_tid        = DispDOMEvent_tid,
+    .iface_tids      = Event_iface_tids,
+    .min_compat_mode = COMPAT_MODE_IE10,
+};
+
 static const dispex_static_data_vtbl_t DOMUIEvent_dispex_vtbl = {
     .query_interface  = DOMUIEvent_query_interface,
     .destructor       = DOMEvent_destructor,

--- a/dlls/mshtml/mshtml_private.h
+++ b/dlls/mshtml/mshtml_private.h
@@ -456,6 +456,7 @@ typedef struct {
     X(DocumentFragment)                    \
     X(DocumentType)                        \
     X(Element)                             \
+    X(ErrorEvent)                          \
     X(Event)                               \
     X(HTMLAnchorElement)                   \
     X(HTMLAreaElement)                     \

--- a/dlls/mshtml/omnavigator.c
+++ b/dlls/mshtml/omnavigator.c
@@ -2427,10 +2427,62 @@ static HRESULT WINAPI console_dirxml(IWineMSHTMLConsole *iface, VARIANT *object)
     return S_OK;
 }
 
+
+/* Unhandled promise rejections surface only through console.error; the stub
+ * discarded them, which is why script failures showed up as a blank page with
+ * no diagnosable error. Log the argument, including Error.name/.message. */
+static void console_report_value(VARIANT *value)
+{
+    static const WCHAR *const props[] = { L"name", L"message", L"stack" };
+    VARIANT converted;
+    unsigned i;
+
+    if(!value) {
+        WARN("console.error: (no argument)\n");
+        return;
+    }
+    while(V_VT(value) == (VT_BYREF|VT_VARIANT) && V_VARIANTREF(value))
+        value = V_VARIANTREF(value);
+
+    if(V_VT(value) == VT_DISPATCH && V_DISPATCH(value)) {
+        IDispatch *disp = V_DISPATCH(value);
+
+        for(i = 0; i < ARRAY_SIZE(props); i++) {
+            DISPPARAMS dp = { NULL, NULL, 0, 0 };
+            VARIANT res;
+            DISPID id;
+            WCHAR *name = (WCHAR *)props[i];
+
+            if(FAILED(IDispatch_GetIDsOfNames(disp, &IID_NULL, &name, 1,
+                                              LOCALE_USER_DEFAULT, &id)))
+                continue;
+            VariantInit(&res);
+            if(FAILED(IDispatch_Invoke(disp, id, &IID_NULL, LOCALE_USER_DEFAULT,
+                                       DISPATCH_PROPERTYGET, &dp, &res, NULL, NULL)))
+                continue;
+            VariantInit(&converted);
+            if(SUCCEEDED(VariantChangeType(&converted, &res, 0, VT_BSTR)))
+                WARN("console.error: .%s = %s\n", debugstr_w(props[i]),
+                     debugstr_w(V_BSTR(&converted)));
+            VariantClear(&converted);
+            VariantClear(&res);
+        }
+        return;
+    }
+
+    VariantInit(&converted);
+    if(SUCCEEDED(VariantChangeType(&converted, value, 0, VT_BSTR)))
+        WARN("console.error: %s\n", debugstr_w(V_BSTR(&converted)));
+    else
+        WARN("console.error: unprintable value, vt %u\n", V_VT(value));
+    VariantClear(&converted);
+}
+
 static HRESULT WINAPI console_error(IWineMSHTMLConsole *iface, VARIANT *vararg_start)
 {
-    FIXME("iface %p, vararg_start %p stub.\n", iface, vararg_start);
+    TRACE("iface %p, vararg_start %p.\n", iface, vararg_start);
 
+    console_report_value(vararg_start);
     return S_OK;
 }
 

--- a/dlls/mshtml/script.c
+++ b/dlls/mshtml/script.c
@@ -184,6 +184,10 @@ static void install_intl_shim(ScriptHost *script_host)
        || !IsEqualGUID(&script_host->guid, &CLSID_JScript))
         return;
 
+    /* Attempt this once per host: retrying from parse_elem_text would re-enter
+     * the script engine for every element that follows. */
+    script_host->intl_installed = TRUE;
+
     V_VT(&res) = VT_EMPTY;
     hres = IActiveScriptParse_ParseScriptText(script_host->parse, intl_shim, L"window", NULL,
                                               NULL, 0, 0, 0, &res, &ei);
@@ -194,7 +198,6 @@ static void install_intl_shim(ScriptHost *script_host)
         SysFreeString(ei.bstrHelpFile);
         return;
     }
-    script_host->intl_installed = TRUE;
     VariantClear(&res);
 }
 

--- a/dlls/mshtml/script.c
+++ b/dlls/mshtml/script.c
@@ -81,6 +81,7 @@ struct ScriptHost {
 
     HTMLInnerWindow *window;
     IWineJSDispatch *script_jsdisp;
+    BOOL intl_installed;
 
     GUID guid;
     struct list entry;
@@ -108,6 +109,89 @@ static BOOL set_script_prop(IActiveScript *script, DWORD property, VARIANT *val)
     }
 
     return TRUE;
+}
+
+/* Minimal ECMA-402 surface. Modern Microsoft bundles abort without Intl; a full
+ * implementation in C is not warranted, so install a JS shim into each JScript
+ * engine. Locale-aware formatting and collation are approximated. */
+static void install_intl_shim(ScriptHost *script_host)
+{
+    static const WCHAR intl_shim[] =
+        L"(function(){ "
+        L"if(window.Intl) return; "
+        L"function opts(o){ return o || {}; } "
+        L"function locs(l){ return l ? (typeof l === 'string' ? [l] : l) : []; } "
+        L"function DateTimeFormat(locale, options){ "
+        L"if(!(this instanceof DateTimeFormat)) return new DateTimeFormat(locale, options); "
+        L"this._locale = locale || 'en-US'; this._options = opts(options); "
+        L"} "
+        L"DateTimeFormat.prototype.format = function(date){ "
+        L"var d = (date === undefined) ? new Date() : (date instanceof Date ? date : new Date(date)); "
+        L"return d.toLocaleString(); "
+        L"}; "
+        L"DateTimeFormat.prototype.resolvedOptions = function(){ "
+        L"return { locale: this._locale, calendar: 'gregory', numberingSystem: 'latn', "
+        L"timeZone: this._options.timeZone || 'UTC' }; "
+        L"}; "
+        L"DateTimeFormat.supportedLocalesOf = locs; "
+        L"function NumberFormat(locale, options){ "
+        L"if(!(this instanceof NumberFormat)) return new NumberFormat(locale, options); "
+        L"this._locale = locale || 'en-US'; this._options = opts(options); "
+        L"} "
+        L"NumberFormat.prototype.format = function(n){ "
+        L"var num = Number(n); "
+        L"var min = this._options.minimumFractionDigits; "
+        L"var max = this._options.maximumFractionDigits; "
+        L"if(typeof max === 'number') num = Number(num.toFixed(max)); "
+        L"return (typeof min === 'number') ? num.toFixed(min) : String(num); "
+        L"}; "
+        L"NumberFormat.prototype.resolvedOptions = function(){ "
+        L"return { locale: this._locale, numberingSystem: 'latn', style: this._options.style || 'decimal' }; "
+        L"}; "
+        L"NumberFormat.supportedLocalesOf = locs; "
+        L"function Collator(locale, options){ "
+        L"if(!(this instanceof Collator)) return new Collator(locale, options); "
+        L"this._locale = locale || 'en-US'; "
+        L"} "
+        L"Collator.prototype.compare = function(a, b){ "
+        L"var x = String(a), y = String(b); "
+        L"return x < y ? -1 : (x > y ? 1 : 0); "
+        L"}; "
+        L"Collator.prototype.resolvedOptions = function(){ "
+        L"return { locale: this._locale, usage: 'sort', sensitivity: 'variant' }; "
+        L"}; "
+        L"Collator.supportedLocalesOf = locs; "
+        L"function PluralRules(locale, options){ "
+        L"if(!(this instanceof PluralRules)) return new PluralRules(locale, options); "
+        L"this._locale = locale || 'en-US'; this._type = opts(options).type || 'cardinal'; "
+        L"} "
+        L"PluralRules.prototype.select = function(n){ "
+        L"if(this._type === 'ordinal') return 'other'; "
+        L"return Number(n) === 1 ? 'one' : 'other'; "
+        L"}; "
+        L"PluralRules.prototype.resolvedOptions = function(){ "
+        L"return { locale: this._locale, type: this._type }; "
+        L"}; "
+        L"PluralRules.supportedLocalesOf = locs; "
+        L"window.Intl = { DateTimeFormat: DateTimeFormat, NumberFormat: NumberFormat, "
+        L"Collator: Collator, PluralRules: PluralRules, getCanonicalLocales: locs }; "
+        L"})(); ";
+    EXCEPINFO ei = { 0 };
+    VARIANT res;
+    HRESULT hres;
+
+    if(script_host->intl_installed || !script_host->parse
+       || !IsEqualGUID(&script_host->guid, &CLSID_JScript))
+        return;
+    script_host->intl_installed = TRUE;
+
+    V_VT(&res) = VT_EMPTY;
+    hres = IActiveScriptParse_ParseScriptText(script_host->parse, intl_shim, L"window", NULL,
+                                              NULL, 0, 0, 0, &res, &ei);
+    if(FAILED(hres))
+        WARN("could not install the Intl shim: %08lx\n", hres);
+    else
+        VariantClear(&res);
 }
 
 static BOOL init_script_engine(ScriptHost *script_host, IActiveScript *script)
@@ -463,7 +547,29 @@ static HRESULT WINAPI ActiveScriptSite_OnStateChange(IActiveScriptSite *iface, S
 static HRESULT WINAPI ActiveScriptSite_OnScriptError(IActiveScriptSite *iface, IActiveScriptError *pscripterror)
 {
     ScriptHost *This = impl_from_IActiveScriptSite(iface);
-    FIXME("(%p)->(%p)\n", This, pscripterror);
+    EXCEPINFO ei = { 0 };
+    BSTR line_text = NULL;
+    DWORD source_ctx = 0;
+    ULONG line = 0;
+    LONG char_pos = 0;
+
+    TRACE("(%p)->(%p)\n", This, pscripterror);
+
+    if(SUCCEEDED(IActiveScriptError_GetExceptionInfo(pscripterror, &ei))) {
+        IActiveScriptError_GetSourcePosition(pscripterror, &source_ctx, &line, &char_pos);
+        IActiveScriptError_GetSourceLineText(pscripterror, &line_text);
+        WARN("script error %08lx at line %lu char %ld: source %s desc %s text %s\n",
+             ei.scode ? (unsigned long)ei.scode : (unsigned long)ei.wCode,
+             line, char_pos, debugstr_w(ei.bstrSource), debugstr_w(ei.bstrDescription),
+             debugstr_w(line_text));
+        SysFreeString(line_text);
+        SysFreeString(ei.bstrSource);
+        SysFreeString(ei.bstrDescription);
+        SysFreeString(ei.bstrHelpFile);
+    }else {
+        WARN("could not retrieve script error information\n");
+    }
+
     return E_NOTIMPL;
 }
 
@@ -940,6 +1046,8 @@ static void parse_elem_text(ScriptHost *script_host, HTMLScriptElement *script_e
     HRESULT hres;
 
     TRACE("%s\n", debugstr_w(text));
+
+    install_intl_shim(script_host);
 
     VariantInit(&var);
     memset(&excepinfo, 0, sizeof(excepinfo));

--- a/dlls/mshtml/script.c
+++ b/dlls/mshtml/script.c
@@ -183,15 +183,19 @@ static void install_intl_shim(ScriptHost *script_host)
     if(script_host->intl_installed || !script_host->parse
        || !IsEqualGUID(&script_host->guid, &CLSID_JScript))
         return;
-    script_host->intl_installed = TRUE;
 
     V_VT(&res) = VT_EMPTY;
     hres = IActiveScriptParse_ParseScriptText(script_host->parse, intl_shim, L"window", NULL,
                                               NULL, 0, 0, 0, &res, &ei);
-    if(FAILED(hres))
+    if(FAILED(hres)) {
         WARN("could not install the Intl shim: %08lx\n", hres);
-    else
-        VariantClear(&res);
+        SysFreeString(ei.bstrSource);
+        SysFreeString(ei.bstrDescription);
+        SysFreeString(ei.bstrHelpFile);
+        return;
+    }
+    script_host->intl_installed = TRUE;
+    VariantClear(&res);
 }
 
 static BOOL init_script_engine(ScriptHost *script_host, IActiveScript *script)

--- a/dlls/windows.security.authentication.onlineid/authenticator.c
+++ b/dlls/windows.security.authentication.onlineid/authenticator.c
@@ -2811,11 +2811,26 @@ static WCHAR *load_scoped_wam_token( const WCHAR *scopes, ULONGLONG *expires )
     unsigned long long hash = 1469598103934665603ULL;
     char utf8[2048];
     WCHAR name[64];
-    WCHAR *stored, *separator;
+    WCHAR *stored, *separator, *account_id;
     int length;
 
     if (expires) *expires = 0;
     if (!scopes || !*scopes) return NULL;
+
+    /* Must match scope_projection_name() in wine4officeauth: the token is keyed
+     * by account as well as scope so one account never receives another's. */
+    if (!(account_id = load_wam_token_file( L"C:\\wam-account-id.txt" ))) return NULL;
+    length = WideCharToMultiByte( CP_UTF8, 0, account_id, -1, utf8, sizeof(utf8), NULL, NULL );
+    free( account_id );
+    if (!length) return NULL;
+    for (int i = 0; i < length - 1; i++)
+    {
+        hash ^= (unsigned char)utf8[i];
+        hash *= 1099511628211ULL;
+    }
+    hash ^= '\n';
+    hash *= 1099511628211ULL;
+
     if (!(length = WideCharToMultiByte( CP_UTF8, 0, scopes, -1, utf8, sizeof(utf8), NULL, NULL )))
         return NULL;
     for (int i = 0; i < length - 1; i++)
@@ -3668,12 +3683,13 @@ static ULONGLONG get_unix_time(void)
     return (value.QuadPart - 116444736000000000ULL) / 10000000ULL;
 }
 
-/* Consumer Microsoft accounts authenticate with the legacy 16 hex digit Live ID
- * app id rather than an AAD GUID. */
+/* Consumer Microsoft accounts authenticate with this Live ID application rather
+ * than an AAD GUID. Match it exactly so unrelated clients keep the AAD path. */
+static const WCHAR consumer_client_id[] = L"00000000480728C5";
+
 static BOOL is_consumer_wam_client( const WCHAR *client_id )
 {
-    return client_id && wcslen( client_id ) == 16 &&
-           wcsspn( client_id, L"0123456789abcdefABCDEF" ) == 16;
+    return client_id && !wcsicmp( client_id, consumer_client_id );
 }
 
 static BOOL is_supported_wam_client( const WCHAR *client_id )
@@ -4747,8 +4763,13 @@ static HRESULT WINAPI web_manager_FindAllAccountsWithClientIdAsync(
         /* Consumer Microsoft accounts use the legacy 16 hex digit app id and
          * are not homed in the work/school authority, so the AAD test above
          * would hide a signed-in personal account from Office. */
-        BOOL consumer = id && wcslen( id ) == 16 &&
-                        wcsspn( id, L"0123456789abcdefABCDEF" ) == 16;
+        /* Only report a consumer account to the consumer provider; otherwise a
+         * work/school provider could be handed an account it never asked for. */
+        const WCHAR *provider_id = WindowsGetStringRawBuffer(
+                ((struct web_account_provider *)provider)->id, NULL );
+        BOOL consumer = id && !wcsicmp( id, consumer_client_id ) &&
+                        ((provider_id && !wcsicmp( provider_id, L"https://login.windows.local" )) ||
+                         (authority && wcsstr( authority, L"consumers" ) != NULL));
         BOOL work = (!wcsicmp( id, L"d3590ed6-52b3-4102-aeff-aad2292ab01c" ) ||
                      !wcsicmp( id, L"1fec8e78-bce4-4aaf-ab1b-5451cc387264" )) &&
                     authority && wcsstr( authority, L"organizations" ) != NULL;

--- a/dlls/windows.security.authentication.onlineid/authenticator.c
+++ b/dlls/windows.security.authentication.onlineid/authenticator.c
@@ -2206,6 +2206,16 @@ static HRESULT web_account_create( IInspectable **out )
 {
     static const WCHAR provider_id[] = L"https://login.microsoft.com";
     static const WCHAR provider_authority[] = L"organizations";
+    /* A consumer Microsoft account lives in the MSA tenant and is published
+     * under the consumer provider. Describing it as a work/school account
+     * makes Office discard it, so the account never appears as signed in. */
+    static const WCHAR msa_tenant_id[] = L"9188040d-6c67-4c5b-b112-36a304b66dad";
+    static const WCHAR consumer_provider_id[] = L"https://login.windows.local";
+    static const WCHAR consumer_authority[] = L"consumers";
+    const WCHAR *use_provider_id = provider_id;
+    const WCHAR *use_authority = provider_authority;
+    size_t provider_id_length = ARRAY_SIZE(provider_id) - 1;
+    size_t authority_length = ARRAY_SIZE(provider_authority) - 1;
     WCHAR *username = NULL, *account_id = NULL, *oid = NULL, *tid = NULL, *authority = NULL;
     WCHAR *first_name = NULL, *last_name = NULL, *display_name = NULL;
     struct web_account *impl = NULL;
@@ -2223,6 +2233,14 @@ static HRESULT web_account_create( IInspectable **out )
         hr = HRESULT_FROM_WIN32( ERROR_FILE_NOT_FOUND );
         goto done;
     }
+    if (!wcsicmp( tid, msa_tenant_id ))
+    {
+        use_provider_id = consumer_provider_id;
+        use_authority = consumer_authority;
+        provider_id_length = ARRAY_SIZE(consumer_provider_id) - 1;
+        authority_length = ARRAY_SIZE(consumer_authority) - 1;
+        TRACE( "publishing a consumer account under %s.\n", debugstr_w( use_provider_id ) );
+    }
     first_name = load_wam_token_file( L"C:\\wam-account-first-name.txt" );
     last_name = load_wam_token_file( L"C:\\wam-account-last-name.txt" );
     display_name = load_wam_token_file( L"C:\\wam-account-display-name.txt" );
@@ -2235,8 +2253,8 @@ static HRESULT web_account_create( IInspectable **out )
     impl->lpVtbl = &web_account_vtbl;
     impl->IWebAccount2_iface.lpVtbl = &web_account2_vtbl;
     impl->ref = 1;
-    if (FAILED(hr = WindowsCreateString( provider_id, ARRAY_SIZE(provider_id) - 1, &id )) ||
-        FAILED(hr = WindowsCreateString( provider_authority, ARRAY_SIZE(provider_authority) - 1, &auth )) ||
+    if (FAILED(hr = WindowsCreateString( use_provider_id, provider_id_length, &id )) ||
+        FAILED(hr = WindowsCreateString( use_authority, authority_length, &auth )) ||
         FAILED(hr = web_account_provider_create( id, auth, &impl->provider )) ||
         FAILED(hr = WindowsCreateString( username, wcslen( username ), &impl->username )) ||
         FAILED(hr = WindowsCreateString( account_id, wcslen( account_id ), &impl->id )) ||
@@ -2784,6 +2802,40 @@ static const struct web_token_request_result_vtbl token_result_vtbl =
     token_result_get_ResponseError, token_result_InvalidateCacheAsync,
 };
 
+
+/* Office requests several scopes and the projection stores a single access
+ * token, so each refresh overwrote the previous scope's token and Office kept
+ * rejecting the mismatched result. Key each token by its scope instead. */
+static WCHAR *load_scoped_wam_token( const WCHAR *scopes, ULONGLONG *expires )
+{
+    unsigned long long hash = 1469598103934665603ULL;
+    char utf8[2048];
+    WCHAR name[64];
+    WCHAR *stored, *separator;
+    int length;
+
+    if (expires) *expires = 0;
+    if (!scopes || !*scopes) return NULL;
+    if (!(length = WideCharToMultiByte( CP_UTF8, 0, scopes, -1, utf8, sizeof(utf8), NULL, NULL )))
+        return NULL;
+    for (int i = 0; i < length - 1; i++)
+    {
+        hash ^= (unsigned char)utf8[i];
+        hash *= 1099511628211ULL;
+    }
+    swprintf( name, ARRAY_SIZE(name), L"C:\\wam-scope-%016llx.txt", hash );
+    if (!(stored = load_wam_token_file( name ))) return NULL;
+    if (!(separator = wcschr( stored, '|' )))
+    {
+        free( stored );
+        return NULL;
+    }
+    *separator = 0;
+    if (expires) *expires = _wcstoui64( stored, NULL, 10 );
+    memmove( stored, separator + 1, (wcslen( separator + 1 ) + 1) * sizeof(WCHAR) );
+    return stored;
+}
+
 static HRESULT web_token_request_result_create( INT32 status, const WCHAR *scopes,
                                                 IInspectable *account, IInspectable **out )
 {
@@ -2799,7 +2851,8 @@ static HRESULT web_token_request_result_create( INT32 status, const WCHAR *scope
     {
         const WCHAR *path = is_office_licensing_scope( scopes ) ?
                             L"C:\\wam-licensing-token.txt" : L"C:\\wam-access-token.txt";
-        WCHAR *token = load_wam_token_file( path );
+        WCHAR *token = load_scoped_wam_token( scopes, NULL );
+        if (!token) token = load_wam_token_file( path );
         if (!token) { token_result_Release( impl ); return HRESULT_FROM_WIN32( ERROR_NOT_FOUND ); }
         hr = token_response_vector_create( token, scopes, account, &impl->responses );
         free( token );
@@ -2819,6 +2872,7 @@ struct interactive_token_context
 {
     struct completed_provider_operation *operation;
     HSTRING scopes;
+    HSTRING client_id;
     HSTRING login_hint;
     HSTRING resource_client_id;
     HSTRING resource_redirect_uri;
@@ -3066,7 +3120,8 @@ static enum helper_result onlineid_wait_for_helper( HANDLE process, HANDLE cance
 
 static enum helper_result run_wine4office_auth( HWND owner, HSTRING login_hint, BOOL interactive, DWORD *exit_code,
                                                 HSTRING scopes, HSTRING resource_client_id,
-                                                HSTRING resource_redirect_uri, HANDLE cancel_event, DWORD timeout )
+                                                HSTRING resource_redirect_uri, HSTRING request_client_id,
+                                                HANDLE cancel_event, DWORD timeout )
 {
     WCHAR command[6 * MAX_PATH], hint_path[MAX_PATH];
     PROCESS_INFORMATION process = {0};
@@ -3107,6 +3162,28 @@ static enum helper_result run_wine4office_auth( HWND owner, HSTRING login_hint, 
                       (ULONG_PTR)owner, hint_path );
         else
             swprintf( command, ARRAY_SIZE(command), L"\"C:\\windows\\system32\\wine4officeauth.exe\" --owner 0x%Ix", (ULONG_PTR)owner );
+
+        /* The requesting app identity decides which endpoint can serve it: a
+         * consumer Microsoft account uses the Live ID app, which the AAD
+         * endpoints reject outright. Without this the helper falls back to its
+         * hardcoded work/school client and personal accounts can never sign in. */
+        {
+            const WCHAR *request_id = WindowsGetStringRawBuffer( request_client_id, NULL );
+            const WCHAR *request_scope = WindowsGetStringRawBuffer( scopes, NULL );
+            size_t used = wcslen( command );
+
+            if (request_id && *request_id && !wcschr( request_id, '"' ) &&
+                used + wcslen( request_id ) + 20 < ARRAY_SIZE(command))
+            {
+                swprintf( command + used, ARRAY_SIZE(command) - used,
+                          L" --client-id \"%s\"", request_id );
+                used = wcslen( command );
+            }
+            if (!resource && request_scope && *request_scope && !wcschr( request_scope, '"' ) &&
+                used + wcslen( request_scope ) + 20 < ARRAY_SIZE(command))
+                swprintf( command + used, ARRAY_SIZE(command) - used,
+                          L" --scope \"%s\"", request_scope );
+        }
     }
     else lstrcpyW( command, L"\"C:\\windows\\system32\\wine4officeauth.exe\" --refresh" );
 
@@ -3159,7 +3236,7 @@ static DWORD WINAPI interactive_token_worker( void *parameter )
 
     if (run_wine4office_auth( context->owner, context->login_hint, TRUE, &exit_code, context->scopes,
                               context->resource_client_id, context->resource_redirect_uri,
-                              NULL, INFINITE ) == HELPER_COMPLETED)
+                              context->client_id, NULL, INFINITE ) == HELPER_COMPLETED)
     {
         if (!exit_code) response_status = 0;
         else if (exit_code == 2) response_status = 1;
@@ -3174,6 +3251,7 @@ static DWORD WINAPI interactive_token_worker( void *parameter )
     if (result) IInspectable_Release( result );
     if (context->account) IInspectable_Release( context->account );
     WindowsDeleteString( context->scopes );
+    WindowsDeleteString( context->client_id );
     WindowsDeleteString( context->login_hint );
     WindowsDeleteString( context->resource_client_id );
     WindowsDeleteString( context->resource_redirect_uri );
@@ -3203,6 +3281,7 @@ static HRESULT create_pending_interactive_token_operation( HWND owner, struct we
     context->operation = impl;
     context->owner = owner;
     if (FAILED(hr = WindowsDuplicateString( request->scope, &context->scopes ))) goto failed;
+    WindowsDuplicateString( request->client_id, &context->client_id );
     token_request_get_login_hint( request, &context->login_hint );
     token_request_get_property( request, L"nestedClientId", &context->resource_client_id );
     token_request_get_property( request, L"nestedRedirectUri", &context->resource_redirect_uri );
@@ -3231,6 +3310,7 @@ static HRESULT create_pending_interactive_token_operation( HWND owner, struct we
 failed:
     if (context->account) IInspectable_Release( context->account );
     WindowsDeleteString( context->scopes );
+    WindowsDeleteString( context->client_id );
     WindowsDeleteString( context->login_hint );
     WindowsDeleteString( context->resource_client_id );
     WindowsDeleteString( context->resource_redirect_uri );
@@ -3588,10 +3668,19 @@ static ULONGLONG get_unix_time(void)
     return (value.QuadPart - 116444736000000000ULL) / 10000000ULL;
 }
 
+/* Consumer Microsoft accounts authenticate with the legacy 16 hex digit Live ID
+ * app id rather than an AAD GUID. */
+static BOOL is_consumer_wam_client( const WCHAR *client_id )
+{
+    return client_id && wcslen( client_id ) == 16 &&
+           wcsspn( client_id, L"0123456789abcdefABCDEF" ) == 16;
+}
+
 static BOOL is_supported_wam_client( const WCHAR *client_id )
 {
     return client_id && (!wcsicmp( client_id, L"d3590ed6-52b3-4102-aeff-aad2292ab01c" ) ||
-                         !wcsicmp( client_id, L"1fec8e78-bce4-4aaf-ab1b-5451cc387264" ));
+                         !wcsicmp( client_id, L"1fec8e78-bce4-4aaf-ab1b-5451cc387264" ) ||
+                         is_consumer_wam_client( client_id ));
 }
 
 static BOOL is_supported_resource_client( const WCHAR *client_id )
@@ -3677,38 +3766,55 @@ static void silent_signal_test_worker_finished(void)
         onlineid_signal_test_event( L"Local\\WineOnlineIdTestWorkerFinished" );
 }
 
-static BOOL prepare_silent_wam_token( const WCHAR *scopes, const WCHAR *client_id, HANDLE cancel_event,
+static BOOL prepare_silent_wam_token( const WCHAR *scopes, const WCHAR *client_id,
+                                      const WCHAR *request_client_id, HANDLE cancel_event,
                                       BOOL *canceled )
 {
     const WCHAR *token_path = scopes && is_office_licensing_scope( scopes ) ?
                               L"C:\\wam-licensing-token.txt" : L"C:\\wam-access-token.txt";
     HANDLE cache_mutex = NULL;
     WCHAR *token = NULL, *expires = NULL, *refresh = NULL;
+    ULONGLONG scoped_expires = 0;
     BOOL have_token = FALSE;
     DWORD exit_code = 3, timeout = onlineid_helper_timeout();
     enum helper_result helper;
 
     *canceled = FALSE;
+    TRACE( "silent request scopes %s resource_client %s request_client %s.\n",
+           debugstr_w( scopes ), debugstr_w( client_id ), debugstr_w( request_client_id ) );
     if (!(cache_mutex = silent_acquire_cache_mutex( cancel_event, canceled ))) goto done;
-    token = load_wam_token_file( token_path );
-    expires = load_wam_token_file( L"C:\\wam-token-expires-on.txt" );
+    if ((token = load_scoped_wam_token( scopes, &scoped_expires )))
+    {
+        WCHAR buffer[32];
+        swprintf( buffer, ARRAY_SIZE(buffer), L"%I64u", scoped_expires );
+        expires = wcsdup( buffer );
+    }
+    else
+    {
+        token = load_wam_token_file( token_path );
+        expires = load_wam_token_file( L"C:\\wam-token-expires-on.txt" );
+    }
     refresh = load_wam_token_file( L"C:\\wam-refresh-token.txt" );
     silent_release_cache_mutex( cache_mutex );
     cache_mutex = NULL;
     have_token = silent_token_is_usable( token, expires );
+    TRACE( "silent cache: token %s expires %s usable %d.\n", token ? "present" : "absent",
+           expires ? "present" : "absent", have_token );
     if (silent_cancel_requested( cancel_event ))
     {
         *canceled = TRUE;
         goto done;
     }
-    if (scopes && *scopes && !is_office_licensing_scope( scopes ))
+    if (scopes && *scopes && !is_office_licensing_scope( scopes ) && !(have_token && scoped_expires))
     {
         /* The projection does not retain the resource scope or client which
          * produced its access token.  A fresh token therefore cannot prove
          * that it is usable for this request; preserve the resource refresh
          * until that identity is published transactionally with the token. */
         have_token = FALSE;
-        helper = run_wine365_resource_refresh( scopes, client_id, cancel_event, timeout, &exit_code );
+        helper = run_wine365_resource_refresh( scopes,
+                                              is_consumer_wam_client( request_client_id ) ? request_client_id : client_id,
+                                              cancel_event, timeout, &exit_code );
         if (helper == HELPER_CANCELED)
         {
             *canceled = TRUE;
@@ -3735,7 +3841,7 @@ static BOOL prepare_silent_wam_token( const WCHAR *scopes, const WCHAR *client_i
     if (have_token) goto done;
     if (refresh)
     {
-        helper = run_wine4office_auth( NULL, NULL, FALSE, &exit_code, NULL, NULL, NULL,
+        helper = run_wine4office_auth( NULL, NULL, FALSE, &exit_code, NULL, NULL, NULL, NULL,
                                        cancel_event, timeout );
         if (helper == HELPER_CANCELED)
         {
@@ -4197,6 +4303,7 @@ static DWORD WINAPI silent_token_worker( void *parameter )
         {
             have_token = prepare_silent_wam_token( WindowsGetStringRawBuffer( impl->scopes, NULL ),
                                                     WindowsGetStringRawBuffer( impl->resource_client_id, NULL ),
+                                                    WindowsGetStringRawBuffer( impl->client_id, NULL ),
                                                     impl->cancel_event, &canceled );
         }
     }
@@ -4633,13 +4740,21 @@ static HRESULT WINAPI web_manager_FindAllAccountsWithClientIdAsync(
            debugstr_hstring( client_id ), operation );
     if (!operation) return E_POINTER;
     *operation = NULL;
-    if (FAILED(hr = find_all_accounts_result_create(
-            (!wcsicmp( WindowsGetStringRawBuffer( client_id, NULL ),
-                       L"d3590ed6-52b3-4102-aeff-aad2292ab01c" ) ||
-             !wcsicmp( WindowsGetStringRawBuffer( client_id, NULL ),
-                       L"1fec8e78-bce4-4aaf-ab1b-5451cc387264" )) &&
-            wcsstr( WindowsGetStringRawBuffer( ((struct web_account_provider *)provider)->authority, NULL ),
-                    L"organizations" ) != NULL, &result ))) return hr;
+    {
+        const WCHAR *id = WindowsGetStringRawBuffer( client_id, NULL );
+        const WCHAR *authority = WindowsGetStringRawBuffer(
+                ((struct web_account_provider *)provider)->authority, NULL );
+        /* Consumer Microsoft accounts use the legacy 16 hex digit app id and
+         * are not homed in the work/school authority, so the AAD test above
+         * would hide a signed-in personal account from Office. */
+        BOOL consumer = id && wcslen( id ) == 16 &&
+                        wcsspn( id, L"0123456789abcdefABCDEF" ) == 16;
+        BOOL work = (!wcsicmp( id, L"d3590ed6-52b3-4102-aeff-aad2292ab01c" ) ||
+                     !wcsicmp( id, L"1fec8e78-bce4-4aaf-ab1b-5451cc387264" )) &&
+                    authority && wcsstr( authority, L"organizations" ) != NULL;
+
+        if (FAILED(hr = find_all_accounts_result_create( work || consumer, &result ))) return hr;
+    }
     hr = completed_provider_operation_create( &async_find_all_accounts_result, result, operation );
     IInspectable_Release( result );
     return hr;

--- a/programs/wine4officeauth/wine4officeauth.cpp
+++ b/programs/wine4officeauth/wine4officeauth.cpp
@@ -52,6 +52,9 @@ static const char teams_client_id[] = "1fec8e78-bce4-4aaf-ab1b-5451cc387264";
 static const char teams_nested_client_id[] = "f4060917-6abe-40d7-baa6-f634c0eda4ac";
 static const char office_scope[] = "https://officeapps.live.com/.default offline_access openid profile";
 static const char licensing_scope[] = "https://licensing.m365.svc.cloud.microsoft/.default";
+/* A consumer subscription is licensed through Live ID, which cannot serve the
+ * AAD licensing scope above. */
+static const char consumer_licensing_scope[] = "service::officeapps.live.com::MBI_SSL";
 static const char redirect_uri[] =
     "ms-appx-web://Microsoft.AAD.BrokerPlugin/d3590ed6-52b3-4102-aeff-aad2292ab01c";
 static const WCHAR redirect_prefix[] = L"ms-appx-web://Microsoft.AAD.BrokerPlugin/";
@@ -67,15 +70,34 @@ static bool oauth_consumer = false;
 
 static std::string oauth_consumer_client_id, oauth_consumer_scope;
 
-/* Consumer Microsoft accounts are served by Live ID, not by the AAD endpoints.
- * Office asks for them with the legacy 16 hex digit app id and an RPS scope
- * ("service::<host>::MBI_SSL*"); the AAD endpoints refuse both outright. */
+/* Consumer Microsoft accounts are served by Live ID, not by the AAD endpoints,
+ * which refuse them outright. Office requests them with this Live ID
+ * application; matching the exact id keeps unrelated clients on the AAD path. */
+static const char consumer_client_id[] = "00000000480728C5";
+
+/* Live ID serves RPS scopes ("service::<host>::MBI_SSL*") plus the OpenID
+ * scopes. An AAD resource scope such as
+ * https://consentservice.microsoft.com/... has no Live ID equivalent, and
+ * asking for one renders a Microsoft error page inside the sign-in window. */
+static bool consumer_scope_supported(const std::string &scope)
+{
+    size_t pos = 0;
+
+    while (pos < scope.size())
+    {
+        size_t end = scope.find(' ', pos);
+        if (end == std::string::npos) end = scope.size();
+        if (scope.compare(pos, 8, "https://") == 0 || scope.compare(pos, 7, "http://") == 0)
+            return false;
+        pos = end + 1;
+    }
+    return true;
+}
+
 static bool is_consumer_identity(const std::string &client_id, const std::string &scope)
 {
-    if (scope.compare(0, 9, "service::") == 0) return true;
-    return client_id.size() == 16 &&
-           std::all_of(client_id.begin(), client_id.end(), [](unsigned char ch)
-               { return std::isxdigit(ch) != 0; });
+    (void)scope;
+    return client_id == consumer_client_id;
 }
 static std::vector<BYTE> pending_auth_post;
 static std::wstring pending_auth_path;
@@ -918,11 +940,20 @@ static void secure_clear(cache_record &record)
 /* Office requests several scopes and the projection stores a single access
  * token, so each refresh overwrote the previous scope's token and Office kept
  * rejecting the mismatched result. Key each token by its scope instead. */
-static std::wstring scope_projection_name(const std::string &scope)
+static std::wstring scope_projection_name(const std::string &scope, const std::string &account_id)
 {
     unsigned long long hash = 1469598103934665603ULL;
-    WCHAR name[40];
+    WCHAR name[48];
 
+    /* Key on the account as well as the scope: a token minted for one account
+     * must never be handed to another that later asks for the same scope. */
+    for (unsigned char ch : account_id)
+    {
+        hash ^= ch;
+        hash *= 1099511628211ULL;
+    }
+    hash ^= '\n';
+    hash *= 1099511628211ULL;
     for (unsigned char ch : scope)
     {
         hash ^= ch;
@@ -930,6 +961,22 @@ static std::wstring scope_projection_name(const std::string &scope)
     }
     swprintf(name, ARRAYSIZE(name), L"wam-scope-%016llx.dat", hash);
     return name;
+}
+
+/* Refresh runs in a separate helper invocation that is given no identity, so
+ * the account's own client id has to survive in the projection. Without it a
+ * consumer refresh token would be replayed against the AAD endpoint and every
+ * silent refresh would fail back to interactive sign-in. */
+static bool remember_consumer_identity(const std::string &client_id, const std::string &scope)
+{
+    return protected_write(L"wam-consumer-client.dat", client_id) &&
+           protected_write(L"wam-consumer-scope.dat", scope);
+}
+
+static bool load_consumer_identity(std::string &client_id, std::string &scope)
+{
+    return protected_read(L"wam-consumer-client.dat", client_id) &&
+           protected_read(L"wam-consumer-scope.dat", scope) && !client_id.empty();
 }
 
 static bool publish_projection(const cache_record &record);
@@ -1298,10 +1345,29 @@ static bool clear_projection(void)
         L"wam-account-username.dat", L"wam-account-id.dat", L"wam-account-oid.dat",
         L"wam-account-tenant-id.dat", L"wam-account-authority.dat", L"wam-client-info.dat",
         L"wam-account-first-name.dat", L"wam-account-last-name.dat",
-        L"wam-account-display-name.dat", L"wam-active-account.dat"
+        L"wam-account-display-name.dat", L"wam-active-account.dat",
+        L"wam-consumer-client.dat", L"wam-consumer-scope.dat"
     };
+    WIN32_FIND_DATAW found;
+    HANDLE search;
+
     for (const WCHAR *name : names)
         if (!delete_cache_file(name)) success = false;
+
+    /* Scope-keyed tokens are named after the scope that produced them, so they
+     * have to be enumerated. Leaving them behind would hand the next account a
+     * live access token belonging to the previous one. */
+    search = FindFirstFileW(cache_file(L"wam-scope-*.dat").c_str(), &found);
+    if (search != INVALID_HANDLE_VALUE)
+    {
+        do
+        {
+            if (!(found.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) &&
+                !delete_cache_file(found.cFileName))
+                success = false;
+        } while (FindNextFileW(search, &found));
+        FindClose(search);
+    }
     return success;
 }
 
@@ -1461,10 +1527,22 @@ static bool exchange_and_save(const std::string &code, const std::string &verifi
         "&code_verifier=" + url_encode(verifier) +
         "&scope=" + url_encode(office_scope);
     bool success = token_request(body, response, oauth_tenant) && parse_token_set(response, office);
-    if (success && !oauth_consumer)
-        success = refresh_scope(office.refresh_token, licensing_scope, licensing, &office);
+    if (success)
+    {
+        if (oauth_consumer)
+        {
+            /* Office reads the licensing ticket from its own projection slot, so
+             * a consumer sign-in must mint it here or Office stays in trial. */
+            if (!refresh_scope(office.refresh_token, consumer_licensing_scope, licensing, &office,
+                               oauth_consumer_client_id.c_str()))
+                licensing = token_set();
+        }
+        else success = refresh_scope(office.refresh_token, licensing_scope, licensing, &office);
+    }
     if (success && !licensing.refresh_token.empty()) office.refresh_token = licensing.refresh_token;
     if (success) success = save_tokens(office, licensing, login_hint);
+    if (success && oauth_consumer)
+        remember_consumer_identity(oauth_consumer_client_id, oauth_consumer_scope);
     secure_clear(body);
     secure_clear(response);
     secure_clear(office);
@@ -1482,9 +1560,23 @@ static bool refresh_and_save(const std::string &login_hint)
     {
         office.refresh_token = previous_record.office.refresh_token;
         office.id_token = previous_record.office.id_token;
-        success = refresh_scope(office.refresh_token, office_scope, office, &office);
+        success = oauth_consumer ?
+            refresh_scope(office.refresh_token, oauth_consumer_scope.c_str(), office, &office,
+                          oauth_consumer_client_id.c_str()) :
+            refresh_scope(office.refresh_token, office_scope, office, &office);
     }
-    if (success) success = refresh_scope(office.refresh_token, licensing_scope, licensing, &office);
+    if (success)
+    {
+        if (oauth_consumer)
+        {
+            /* Live ID cannot serve the AAD licensing scope, and a missing
+             * licensing ticket must not fail the whole refresh. */
+            if (!refresh_scope(office.refresh_token, consumer_licensing_scope, licensing, &office,
+                               oauth_consumer_client_id.c_str()))
+                licensing = token_set();
+        }
+        else success = refresh_scope(office.refresh_token, licensing_scope, licensing, &office);
+    }
     if (success && !licensing.refresh_token.empty()) office.refresh_token = licensing.refresh_token;
     if (success) success = save_tokens(office, licensing, login_hint.empty() ?
                                        previous_record.username : login_hint);
@@ -1526,6 +1618,7 @@ static bool refresh_resource_and_save(const std::string &requested_scope,
     /* An RPS scope is already in its final form; the /.default normalisation
      * only applies to AAD resource scopes. */
     bool consumer = is_consumer_identity(requested_client_id, requested_scope);
+    if (consumer && !consumer_scope_supported(requested_scope)) return false;
     std::string scope = consumer ? requested_scope : normalize_resource_scope(requested_scope);
     bool success = !scope.empty() &&
         (consumer || requested_client_id == client_id || requested_client_id == teams_client_id ||
@@ -1560,8 +1653,12 @@ static bool refresh_resource_and_save(const std::string &requested_scope,
     {
         std::string scoped = std::to_string(unix_time() + resource.expires_in) + "|" +
                              resource.access_token;
-        protected_write(scope_projection_name(requested_scope).c_str(), scoped);
+        success = protected_write(scope_projection_name(requested_scope, account.account_id).c_str(),
+                                  scoped);
         secure_clear(scoped);
+    }
+    if (success)
+    {
         account.office.access_token = resource.access_token;
         account.office.id_token = resource.id_token;
         if (!resource.refresh_token.empty()) account.office.refresh_token = resource.refresh_token;
@@ -2553,6 +2650,14 @@ int WINAPI wWinMain(HINSTANCE instance, HINSTANCE previous, WCHAR *command_line,
     }
     if (argc >= 2 && !wcscmp(argv[1], L"--refresh"))
     {
+        std::string cached_client, cached_scope;
+        if (load_consumer_identity(cached_client, cached_scope) &&
+            is_consumer_identity(cached_client, cached_scope))
+        {
+            oauth_consumer = true;
+            oauth_consumer_client_id = cached_client;
+            oauth_consumer_scope = cached_scope;
+        }
         success = refresh_and_save({});
         LocalFree(argv);
         return success ? 0 : 3;
@@ -2594,6 +2699,14 @@ int WINAPI wWinMain(HINSTANCE instance, HINSTANCE previous, WCHAR *command_line,
     oauth_consumer = !resource_mode && is_consumer_identity(request_client_id, request_scope);
     if (oauth_consumer)
     {
+        if (!consumer_scope_supported(request_scope))
+        {
+            /* Report "no token" rather than opening a browser that can only
+             * render a Microsoft error page for this scope. */
+            OleUninitialize();
+            CoUninitialize();
+            return 3;
+        }
         oauth_consumer_client_id = request_client_id;
         oauth_consumer_scope = request_scope;
     }

--- a/programs/wine4officeauth/wine4officeauth.cpp
+++ b/programs/wine4officeauth/wine4officeauth.cpp
@@ -47,6 +47,7 @@ extern "C" BOOL WINAPI InternetCloseHandle(HINTERNET);
 #define HTTP_QUERY_FLAG_NUMBER 0x20000000
 
 static const char client_id[] = "d3590ed6-52b3-4102-aeff-aad2292ab01c";
+static const char consumer_redirect_uri[] = "https://login.live.com/oauth20_desktop.srf";
 static const char teams_client_id[] = "1fec8e78-bce4-4aaf-ab1b-5451cc387264";
 static const char teams_nested_client_id[] = "f4060917-6abe-40d7-baa6-f634c0eda4ac";
 static const char office_scope[] = "https://officeapps.live.com/.default offline_access openid profile";
@@ -62,6 +63,20 @@ static IConnectionPoint *browser_connection;
 static DWORD browser_connection_cookie;
 static HWND host_window, owner_window;
 static std::string oauth_state, oauth_code, oauth_tenant = "organizations";
+static bool oauth_consumer = false;
+
+static std::string oauth_consumer_client_id, oauth_consumer_scope;
+
+/* Consumer Microsoft accounts are served by Live ID, not by the AAD endpoints.
+ * Office asks for them with the legacy 16 hex digit app id and an RPS scope
+ * ("service::<host>::MBI_SSL*"); the AAD endpoints refuse both outright. */
+static bool is_consumer_identity(const std::string &client_id, const std::string &scope)
+{
+    if (scope.compare(0, 9, "service::") == 0) return true;
+    return client_id.size() == 16 &&
+           std::all_of(client_id.begin(), client_id.end(), [](unsigned char ch)
+               { return std::isxdigit(ch) != 0; });
+}
 static std::vector<BYTE> pending_auth_post;
 static std::wstring pending_auth_path;
 static bool oauth_error, oauth_cancelled;
@@ -796,13 +811,33 @@ static bool discover_tenant(const std::string &domain, std::string &tenant)
     size_t end = issuer.find('/', prefix.size());
     if (end == std::string::npos || end == prefix.size()) return false;
     tenant = issuer.substr(prefix.size(), end - prefix.size());
-    return std::all_of(tenant.begin(), tenant.end(), [](unsigned char ch)
-        { return std::isalnum(ch) || ch == '-'; });
+    if (!std::all_of(tenant.begin(), tenant.end(), [](unsigned char ch)
+        { return std::isalnum(ch) || ch == '-'; }))
+        return false;
+
+    /* Personal Microsoft accounts discover one of the MSA passthrough tenants.
+     * Authorizing against those tenant GUIDs directly fails with AADSTS50020
+     * because an MSA user is not a directory object in them; the /consumers
+     * endpoint is what accepts personal accounts. */
+    {
+        static const char *const msa_tenants[] = {
+            "f8cdef31-a31e-4b4a-93e4-5f571e91255a",
+            "9188040d-6c67-4c5b-b112-36a304b66dad",
+        };
+        std::string lowered = tenant;
+        std::transform(lowered.begin(), lowered.end(), lowered.begin(),
+            [](unsigned char ch) { return (char)std::tolower(ch); });
+        for (const char *msa : msa_tenants)
+            if (lowered == msa) { tenant = "common"; break; }
+    }
+    return true;
 }
 
 static bool token_request(const std::string &body, std::string &response,
                           const std::string &tenant = "organizations")
 {
+    if (oauth_consumer)
+        return http_post(L"login.live.com", L"/oauth20_token.srf", body, response);
     std::wstring path = utf8_to_wide("/" + tenant + "/oauth2/v2.0/token");
     return http_post(L"login.microsoftonline.com", path.c_str(), body, response);
 }
@@ -879,6 +914,24 @@ static void secure_clear(cache_record &record)
     secure_clear(record.client_info);
     record.expires = 0;
 }
+
+/* Office requests several scopes and the projection stores a single access
+ * token, so each refresh overwrote the previous scope's token and Office kept
+ * rejecting the mismatched result. Key each token by its scope instead. */
+static std::wstring scope_projection_name(const std::string &scope)
+{
+    unsigned long long hash = 1469598103934665603ULL;
+    WCHAR name[40];
+
+    for (unsigned char ch : scope)
+    {
+        hash ^= ch;
+        hash *= 1099511628211ULL;
+    }
+    swprintf(name, ARRAYSIZE(name), L"wam-scope-%016llx.dat", hash);
+    return name;
+}
+
 static bool publish_projection(const cache_record &record);
 static bool clear_projection(void);
 
@@ -1395,13 +1448,21 @@ static bool exchange_and_save(const std::string &code, const std::string &verifi
 {
     token_set office, licensing;
     std::string response;
-    std::string body = "client_id=" + std::string(client_id) +
+    /* The Live ID exchange must echo the identity the authorize call used, and
+     * has no AAD licensing scope to chain onto. */
+    std::string body = oauth_consumer ?
+        "client_id=" + oauth_consumer_client_id +
+        "&grant_type=authorization_code&code=" + url_encode(code) +
+        "&redirect_uri=" + url_encode(consumer_redirect_uri) +
+        "&scope=" + url_encode(oauth_consumer_scope) :
+        "client_id=" + std::string(client_id) +
         "&grant_type=authorization_code&code=" + url_encode(code) +
         "&redirect_uri=" + url_encode(redirect_uri) +
         "&code_verifier=" + url_encode(verifier) +
         "&scope=" + url_encode(office_scope);
     bool success = token_request(body, response, oauth_tenant) && parse_token_set(response, office);
-    if (success) success = refresh_scope(office.refresh_token, licensing_scope, licensing, &office);
+    if (success && !oauth_consumer)
+        success = refresh_scope(office.refresh_token, licensing_scope, licensing, &office);
     if (success && !licensing.refresh_token.empty()) office.refresh_token = licensing.refresh_token;
     if (success) success = save_tokens(office, licensing, login_hint);
     secure_clear(body);
@@ -1462,20 +1523,29 @@ static bool refresh_resource_and_save(const std::string &requested_scope,
 {
     cache_record account;
     token_set resource;
-    std::string scope = normalize_resource_scope(requested_scope);
+    /* An RPS scope is already in its final form; the /.default normalisation
+     * only applies to AAD resource scopes. */
+    bool consumer = is_consumer_identity(requested_client_id, requested_scope);
+    std::string scope = consumer ? requested_scope : normalize_resource_scope(requested_scope);
     bool success = !scope.empty() &&
-        (requested_client_id == client_id || requested_client_id == teams_client_id ||
+        (consumer || requested_client_id == client_id || requested_client_id == teams_client_id ||
          requested_client_id == teams_nested_client_id) &&
         cache_record_load(login_hint, account);
 
+    if (consumer)
+    {
+        oauth_consumer = true;
+        oauth_consumer_client_id = requested_client_id;
+        oauth_consumer_scope = requested_scope;
+    }
     if (success)
     {
-        std::string oidc_scope = scope + " offline_access openid profile";
+        std::string oidc_scope = consumer ? scope : scope + " offline_access openid profile";
         success = refresh_scope(account.office.refresh_token, oidc_scope.c_str(), resource, NULL,
                                 requested_client_id.c_str());
         secure_clear(oidc_scope);
     }
-    if (success)
+    if (success && !consumer)
     {
         std::string payload, audience;
         success = jwt_payload(resource.id_token, payload) &&
@@ -1484,8 +1554,14 @@ static bool refresh_resource_and_save(const std::string &requested_scope,
         secure_clear(payload);
         secure_clear(audience);
     }
+    else if (success)
+        success = cache_record_identity_valid(account, login_hint);
     if (success)
     {
+        std::string scoped = std::to_string(unix_time() + resource.expires_in) + "|" +
+                             resource.access_token;
+        protected_write(scope_projection_name(requested_scope).c_str(), scoped);
+        secure_clear(scoped);
         account.office.access_token = resource.access_token;
         account.office.id_token = resource.id_token;
         if (!resource.refresh_token.empty()) account.office.refresh_token = resource.refresh_token;
@@ -1534,7 +1610,13 @@ static bool exchange_resource_and_save(const std::string &code, const std::strin
 
 static bool handle_redirect(const WCHAR *location)
 {
-    if (!location || _wcsnicmp(location, redirect_prefix, ARRAYSIZE(redirect_prefix) - 1))
+    static const WCHAR consumer_prefix[] = L"https://login.live.com/oauth20_desktop.srf";
+
+    if (!location) return false;
+    /* Live ID returns the code on a real https callback rather than the broker
+     * URI the AAD flow uses. */
+    if (oauth_consumer ? _wcsnicmp(location, consumer_prefix, ARRAYSIZE(consumer_prefix) - 1) != 0
+                       : _wcsnicmp(location, redirect_prefix, ARRAYSIZE(redirect_prefix) - 1) != 0)
         return false;
     std::string url = wide_to_utf8(location);
     std::string state = query_value(url, "state");
@@ -1930,6 +2012,7 @@ static bool run_owned_oauth(HINSTANCE instance, HWND owner, const std::string &l
     SecureZeroMemory(random, sizeof(random));
 
     oauth_tenant = "organizations";
+    if (!oauth_consumer)
     {
         size_t at = login_hint.rfind('@');
         if (at != std::string::npos && at + 1 < login_hint.size())
@@ -1941,11 +2024,17 @@ static bool run_owned_oauth(HINSTANCE instance, HWND owner, const std::string &l
                 return false;
         }
     }
-    authorize_url = "https://login.microsoftonline.com/" + oauth_tenant +
-        "/oauth2/v2.0/authorize?client_id=" + requested_client_id +
-        "&response_type=code&response_mode=query&redirect_uri=" +
-        url_encode(requested_redirect_uri) + "&scope=" + url_encode(requested_scope) +
-        "&code_challenge=" + challenge + "&code_challenge_method=S256&state=" + oauth_state;
+    if (oauth_consumer)
+        authorize_url = "https://login.live.com/oauth20_authorize.srf?client_id=" +
+            requested_client_id + "&response_type=code&redirect_uri=" +
+            url_encode(requested_redirect_uri) + "&scope=" + url_encode(requested_scope) +
+            "&state=" + oauth_state;
+    else
+        authorize_url = "https://login.microsoftonline.com/" + oauth_tenant +
+            "/oauth2/v2.0/authorize?client_id=" + requested_client_id +
+            "&response_type=code&response_mode=query&redirect_uri=" +
+            url_encode(requested_redirect_uri) + "&scope=" + url_encode(requested_scope) +
+            "&code_challenge=" + challenge + "&code_challenge_method=S256&state=" + oauth_state;
     if (!login_hint.empty()) authorize_url += "&login_hint=" + url_encode(login_hint);
     authorize_url_w = utf8_to_wide(authorize_url);
     if (authorize_url_w.empty()) return false;
@@ -2313,6 +2402,7 @@ int WINAPI wWinMain(HINSTANCE instance, HINSTANCE previous, WCHAR *command_line,
     int argc;
     WCHAR **argv = CommandLineToArgvW(GetCommandLineW(), &argc);
     std::string verifier, login_hint, resource_scope, resource_client_id, resource_redirect_uri;
+    std::string request_client_id, request_scope;
     bool success;
     (void)previous; (void)command_line; (void)show;
     if (!argv) return 3;
@@ -2489,12 +2579,24 @@ int WINAPI wWinMain(HINSTANCE instance, HINSTANCE previous, WCHAR *command_line,
             resource_client_id = wide_to_utf8(argv[++i]);
         else if (!wcscmp(argv[i], L"--resource-redirect-uri") && i + 1 < argc)
             resource_redirect_uri = wide_to_utf8(argv[++i]);
+        else if (!wcscmp(argv[i], L"--client-id") && i + 1 < argc)
+            request_client_id = wide_to_utf8(argv[++i]);
+        else if (!wcscmp(argv[i], L"--scope") && i + 1 < argc)
+            request_scope = wide_to_utf8(argv[++i]);
     }
     LocalFree(argv);
     if (FAILED(CoInitializeEx(NULL, COINIT_APARTMENTTHREADED))) return 3;
     OleInitialize(NULL);
     bool resource_mode = !resource_scope.empty() && !resource_client_id.empty() &&
                          !resource_redirect_uri.empty();
+    /* A consumer request must keep the app identity Office asked with; the
+     * hardcoded work/school client is rejected for personal accounts. */
+    oauth_consumer = !resource_mode && is_consumer_identity(request_client_id, request_scope);
+    if (oauth_consumer)
+    {
+        oauth_consumer_client_id = request_client_id;
+        oauth_consumer_scope = request_scope;
+    }
     if (cached_account_matches(login_hint))
     {
         success = resource_mode ? refresh_resource_and_save(resource_scope, resource_client_id, login_hint) :
@@ -2507,9 +2609,12 @@ int WINAPI wWinMain(HINSTANCE instance, HINSTANCE previous, WCHAR *command_line,
         }
     }
     success = run_owned_oauth(instance, owner_window, login_hint,
-                              resource_mode ? resource_client_id : client_id,
-                              resource_mode ? resource_scope + " offline_access openid profile" : office_scope,
-                              resource_mode ? resource_redirect_uri : redirect_uri, verifier);
+                              resource_mode ? resource_client_id :
+                                  oauth_consumer ? request_client_id : client_id,
+                              resource_mode ? resource_scope + " offline_access openid profile" :
+                                  oauth_consumer ? request_scope : office_scope,
+                              resource_mode ? resource_redirect_uri :
+                                  oauth_consumer ? consumer_redirect_uri : redirect_uri, verifier);
     if (success)
         success = resource_mode ? exchange_resource_and_save(oauth_code, verifier, resource_scope,
                                                               resource_client_id, resource_redirect_uri,
@@ -2520,6 +2625,8 @@ int WINAPI wWinMain(HINSTANCE instance, HINSTANCE previous, WCHAR *command_line,
     secure_clear(resource_scope);
     secure_clear(resource_client_id);
     secure_clear(resource_redirect_uri);
+    secure_clear(request_client_id);
+    secure_clear(request_scope);
     OleUninitialize();
     CoUninitialize();
     if (!success && !oauth_cancelled)

--- a/tools/wine4office-manager/wine4office_backend.py
+++ b/tools/wine4office-manager/wine4office_backend.py
@@ -169,13 +169,13 @@ APP_META = {
 OFFICE_CUSTOMIZATION_URL = "https://config.office.com/deploymentsettings"
 OFFICE_PRODUCTS = (
     {
-        "label": "Microsoft 365 Personal/Family (consumer subscription)",
-        "product_id": "O365HomePremRetail",
+        "label": "Microsoft 365 Apps for enterprise",
+        "product_id": "O365ProPlusRetail",
         "channel": "Current",
     },
     {
-        "label": "Microsoft 365 Apps for enterprise",
-        "product_id": "O365ProPlusRetail",
+        "label": "Microsoft 365 Personal/Family (consumer subscription)",
+        "product_id": "O365HomePremRetail",
         "channel": "Current",
     },
     {
@@ -1438,7 +1438,10 @@ def create_environment(prefix_value: str, wine_value: str, recreate: bool, outpu
             cancel_event=cancel_event, process_callback=process_callback)
         # Wine writes system.reg and user.reg only when the server shuts down, so
         # the prefix cannot be classified as valid while it is still running.
-        stop_wine(str(prefix), str(wine), progress_callback=progress_callback)
+        # A packaging layout without a sibling wineserver must not turn a
+        # successful creation into a failure that discards the new prefix.
+        if sibling_tool(wine, "wineserver"):
+            stop_wine(str(prefix), str(wine), progress_callback=progress_callback)
         if classify_prefix(str(prefix)) != "valid":
             raise RuntimeError(f"Wine initialization did not create a valid prefix at: {prefix}")
         ensure_safe_x11_defaults(

--- a/tools/wine4office-manager/wine4office_backend.py
+++ b/tools/wine4office-manager/wine4office_backend.py
@@ -169,6 +169,11 @@ APP_META = {
 OFFICE_CUSTOMIZATION_URL = "https://config.office.com/deploymentsettings"
 OFFICE_PRODUCTS = (
     {
+        "label": "Microsoft 365 Personal/Family (consumer subscription)",
+        "product_id": "O365HomePremRetail",
+        "channel": "Current",
+    },
+    {
         "label": "Microsoft 365 Apps for enterprise",
         "product_id": "O365ProPlusRetail",
         "channel": "Current",
@@ -1431,6 +1436,9 @@ def create_environment(prefix_value: str, wine_value: str, recreate: bool, outpu
             "/d", "x11,wayland", "/f",
         ], wine_environment(prefix, wine, _manager_create=True), output,
             cancel_event=cancel_event, process_callback=process_callback)
+        # Wine writes system.reg and user.reg only when the server shuts down, so
+        # the prefix cannot be classified as valid while it is still running.
+        stop_wine(str(prefix), str(wine), progress_callback=progress_callback)
         if classify_prefix(str(prefix)) != "valid":
             raise RuntimeError(f"Wine initialization did not create a valid prefix at: {prefix}")
         ensure_safe_x11_defaults(


### PR DESCRIPTION
## Summary

Personal (consumer) Microsoft accounts could not sign in to Office. This series
makes that work end to end and fixes four Wine bugs found along the way.

Office was already asking for the consumer identity correctly. With a personal
account signed in it creates the token request with client id
`00000000480728C5` and an RPS scope such as
`service::ssl.live.com::MBI_SSL_SHORT`, and looks the provider up as
`https://login.windows.local`. That identity was then dropped at every stage of
`onlineid`, so the browser helper fell back to its hardcoded work/school client
and Microsoft answered:

> You can't sign in here with a personal account. Use your work or school account instead.

Deriving the tenant from the address instead produced `AADSTS50020`, because
consumer domains resolve to the MSA passthrough tenant
`f8cdef31-a31e-4b4a-93e4-5f571e91255a` and an MSA user is not a directory object
in it.

## The chain, and how each step was established

Every step below was observed in a trace, not inferred.

1. **Script errors were invisible.** `ActiveScriptSite_OnScriptError` was a bare
   `FIXME` that discarded every error, so a failing login page could only be
   seen as a blank window. Making it log turned the whole problem diagnosable
   and produced the next three findings directly.
2. **`'ErrorEvent' is undefined`** (`800a1391`) — the `login_v2` bundle
   references it unguarded and aborts before painting.
3. **`Function.prototype.apply(this, undefined)` threw.** ECMA-262 15.3.4.3 says
   a null or undefined `argArray` means an empty argument list. Microsoft's 1DS
   telemetry SDK does exactly that call, so its init threw and every dependent
   module collapsed. This one is a plain upstream Wine bug affecting any modern
   JS bundle.
4. **No `Intl` (ECMA-402)**, which surfaced as Microsoft's generic
   "Something went wrong" page. Found by implementing `console.error`, which was
   a stub silently dropping unhandled promise rejections.
5. **The consumer identity never reached the helper.** `run_wine4office_auth`
   forwarded only the nested (Teams) client id.
6. **The account was published as work/school.** `web_account_create` stamped
   every account with `https://login.microsoft.com` / `organizations`, so an
   account in the MSA tenant never matched the provider Office asked for.
7. **The silent path rejected the consumer client** in
   `is_supported_wam_client` and `FindAllAccountsWithClientIdAsync`.
8. **One token, many scopes.** The projection stored a single access token under
   a fixed name, so each scope refresh overwrote the previous one and Office kept
   rejecting the mismatched token and retrying. Tokens are now keyed by scope.

## Reproducing

Requires a personal Microsoft account (Microsoft 365 Personal or Family).

```sh
git clone https://github.com/ttv20/wine4office.git
mkdir wine4office-build && cd wine4office-build
CPPFLAGS="-I../wine4office/tools/wine4office-manager/packaging/linux-uapi" \
  ../wine4office/configure --prefix="$HOME/.local/share/wine4office/runner" \
  --enable-archs=i386,x86_64 --with-gssapi --with-krb5
make -j"$(nproc)" && make install

python3 -m pip install --user -r ../wine4office/tools/wine4office-manager/requirements-gui.txt
../wine4office/tools/wine4office-manager/install-user.sh
```

Then install **Microsoft 365 Personal/Family (consumer subscription)** in the
Manager and sign in from Word. Before this series the sign-in dialog is blank or
is refused by the server; after it, the account appears in **File > Account**.

Useful while testing:

```sh
WINEDEBUG=-all,warn+mshtml   # script errors from the login page
WINEDEBUG=-all,trace+onlineid # which client id and scopes Office requests
WINE_ONLINEID_HELPER_TIMEOUT_MS=8000
```

## Tested

Fedora 44, NVIDIA RTX 4070 on XWayland, Microsoft 365 Family,
`O365HomePremRetail` 16.0.20326.20112, combined WoW64 build.

- Word renders and runs well, with no `renderer=gl` or Vulkan ICD pinning — the
  workarounds previously needed on this hardware are no longer necessary.
- Sign-in completes against Live ID and the account shows in **File > Account**.
- Live ID grants the scopes Office then asks for: `substrate.office.com`,
  `messaging.engagement.office.com`, `ads.arcct.msn.com`, and Graph delegation.
- The `apply` fix is verified directly under `cscript`:
  `apply(undefined): 0 | apply(null): 0 | apply([1,2]): 2 | apply(42) throws`.

## Not resolved

- **Licensing.** Office still reports a trial and "stored credentials are out of
  date". The licensing token is fetched with the AAD scope
  `https://licensing.m365.svc.cloud.microsoft/.default`, which Live ID cannot
  serve; a consumer subscription needs
  `service::officeapps.live.com::MBI_SSL`. The sign-in half is what this series
  covers.
- `https://consentservice.microsoft.com/checkin/UnifiedUserConsent.Read` is an
  AAD-style scope that Live ID legitimately refuses.
- The `Intl` shim is deliberately minimal and approximates locale-aware
  formatting and collation.
- Only the consumer flow above was exercised on real hardware. The work/school
  path is unchanged in behaviour but was not re-tested.

## Note

Written with AI assistance (Claude). Every claim above corresponds to an
observed trace rather than a guess, but the C and C++ deserves a careful human
review before it is trusted, particularly the token lifetime and cleanup paths in
`authenticator.c`.

## Summary by Sourcery

Support end-to-end Office sign-in with personal Microsoft accounts while improving the JavaScript and token handling required by the consumer authentication flow.

New Features:
- Enable sign-in for personal Microsoft accounts in Office through the Live ID consumer authentication flow.
- Add Microsoft 365 Personal/Family as an available Manager installation option.

Bug Fixes:
- Fix JavaScript compatibility issues that prevented modern Microsoft sign-in pages from rendering, including undefined ErrorEvent, incorrect Function.apply handling, and missing Intl support.
- Preserve consumer account identity and provider metadata through onlineid so personal accounts are discovered and surfaced correctly.
- Return tokens for the requested scopes instead of allowing different scope refreshes to overwrite one another.

Enhancements:
- Improve script and console error reporting to make browser authentication failures diagnosable.
- Support consumer-specific silent authentication, token refresh, account lookup, and licensing-scope handling while retaining existing work/school behavior.

Chores:
- Make Wine prefix creation validation work with packaging layouts that do not provide a sibling wineserver.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Microsoft consumer accounts, including Microsoft 365 Personal and Family subscriptions.
  - Improved OAuth sign-in, token handling, and account discovery for consumer services.
  - Added an `ErrorEvent` constructor in IE10 compatibility mode.
  - Added a minimal `Intl` compatibility layer for JavaScript applications.

- **Bug Fixes**
  - Improved JavaScript error reporting with messages, source locations, and stack details.
  - `Function.apply` now correctly handles null or undefined argument lists.
  - Console error logging now reports supplied values instead of silently ignoring them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->