### PR TITLE
Fix Word stack overflow after Microsoft 365 sign-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Respect Direct2D stroke join styles while keeping sharp WordArt corners bounded.
 - Keep Word responsive while Microsoft 365 tokens are checked or refreshed in the background.
 - Keep Microsoft 365 account and token data consistent when sign-in and background refresh overlap.
+- Prevent Word from getting stuck on "Just a moment" after signing in to Microsoft 365.
 - Build Wine4Office releases and agent runners from the same reproducible 18-job environment.
 - Display background-service RAM without reclaimable inactive file cache and hide it when the service is stopped.
 - Activate Microsoft 365 licenses after signing in to Office.

--- a/dlls/kernel32/tests/locale.c
+++ b/dlls/kernel32/tests/locale.c
@@ -2908,6 +2908,12 @@ static void test_LCMapStringEx(void)
     ok(!ret, "LCMapStringEx should fail with bad locale name\n");
     ok(GetLastError() == ERROR_INVALID_PARAMETER, "unexpected error code %ld\n", GetLastError());
 
+    ret = pLCMapStringEx(L"en-US", LCMAP_LOWERCASE,
+                         upper_case, -1, buf, ARRAY_SIZE(buf), NULL, NULL, 0);
+    ok(ret == lstrlenW(upper_case) + 1, "ret %d, error %ld, expected value %d\n",
+       ret, GetLastError(), lstrlenW(upper_case) + 1);
+    ok(!lstrcmpW(buf, lower_case), "string compare mismatch\n");
+
     SetLastError(0xdeadbeef);
     ret = pLCMapStringEx(invalidW, LCMAP_HIRAGANA,
                          upper_case, -1, buf, ARRAY_SIZE(buf), NULL, NULL, 0);

--- a/dlls/kernelbase/locale.c
+++ b/dlls/kernelbase/locale.c
@@ -6874,6 +6874,7 @@ INT WINAPI DECLSPEC_HOTPATCH LCMapStringEx( const WCHAR *locale, DWORD flags, co
                                             void *reserved, LPARAM handle )
 {
     const struct sortguid *sortid = NULL;
+    LCID lcid;
 
     if (version) FIXME( "unsupported version structure %p\n", version );
     if (reserved) FIXME( "unsupported reserved pointer %p\n", reserved );
@@ -6901,9 +6902,17 @@ INT WINAPI DECLSPEC_HOTPATCH LCMapStringEx( const WCHAR *locale, DWORD flags, co
         SetLastError( ERROR_INVALID_FLAGS );
         return 0;
     }
-    if (flags & (LCMAP_LOWERCASE | LCMAP_UPPERCASE | LCMAP_SORTKEY))
+    /* Plain case mapping uses the default case table and does not need locale sort data. */
+    if ((flags & LCMAP_SORTKEY) ||
+        ((flags & (LCMAP_LOWERCASE | LCMAP_UPPERCASE)) && (flags & LCMAP_LINGUISTIC_CASING)))
     {
         if (!(sortid = get_language_sort( locale ))) return 0;
+    }
+    else if ((flags & (LCMAP_LOWERCASE | LCMAP_UPPERCASE)) && !get_locale_by_name( locale, &lcid ))
+    {
+        WARN( "unknown locale %s\n", debugstr_w(locale) );
+        SetLastError( ERROR_INVALID_PARAMETER );
+        return 0;
     }
     if (flags & LCMAP_HASH)
     {


### PR DESCRIPTION
## Purpose

Fix Word's post-sign-in stack overflow and ghost "Just a moment" window.

Plain `LCMapStringEx()` lower/upper conversion does not use locale sort data,
but Wine resolved that data through `Sorting\\Ids` anyway. Under Office's App-V
registry hook, the registry lookup re-entered `_wcsicmp()` and plain lowercase
mapping, producing an unbounded registry/locale recursion.

## Change

- Validate explicit locales for ordinary lower/upper mapping without resolving
  a sort GUID.
- Continue resolving sort data for sort keys and linguistic casing.
- Cover successful plain case mapping with an explicit locale name.
- Add a user-facing changelog entry.

## Validation

- Canonical combined WoW64 build from `origin/main` at `297a8ee7ac7`.
- Rebuilt `kernelbase.dll` and `kernel32_test.exe` for x86-64 and i386.
- Fresh-prefix `kernel32_test.exe locale` on both architectures:
  2,306,976 assertions, 17 existing todo results, 0 failures.
- Clean-auth main A/B using full runners from the same source revision and
  prefixes with the same `MachineGuid`:
  - baseline: SSO published WAM/OneAuth, Word became a zombie, and the log
    contained six stack overflows, including the main thread;
  - fixed: SSO published WAM/OneAuth, Word returned to Home, remained live for
    13 samples over 120 seconds with zero stack overflows, displayed the
    connected licensed account, opened a document, and relaunched from cached
    sign-in with zero stack overflows.
- External review confirmed locale acceptance, aliases/sentinels, LastError
  ordering, null-sort safety, and unchanged concurrency behavior. Its focused
  test feedback was applied.
- `git diff --check` passes.

## Risk

Low and localized to the `LCMapStringEx()` dispatch decision. Ordinary case
mapping continues to use the same default case table and retains invalid-locale
validation. Linguistic casing and sort-key behavior remain on the existing
sort-resolution path.

## Summary by Sourcery

Prevent recursive locale handling from causing Word to stack overflow after Microsoft 365 sign-in.

Bug Fixes:
- Prevent Word from hanging after Microsoft 365 sign-in by avoiding recursive locale-sort resolution during ordinary case mapping.

Enhancements:
- Preserve locale validation for plain case conversion while retaining sort-data resolution for sort keys and linguistic casing.

Documentation:
- Document the Microsoft 365 sign-in fix in the changelog.

Tests:
- Cover successful explicit-locale lowercase mapping in the locale tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where Word could remain stuck on the “Just a moment” screen after signing in to Microsoft 365.
  * Improved lowercase text conversion for valid locales, including English (United States).
  * Improved handling of locale validation during text case conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->