### PR TITLE
server: reset queue masks after retrieving messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Reduce memory use and latency when drawing complex antialiased Direct2D geometry.
 - Reduce Word CPU use by coalescing Office timers that allow delayed delivery.
+- Reduce message-loop server calls after retrieving queued messages.
 - Respect Direct2D stroke join styles while keeping sharp WordArt corners bounded.
 - Keep Word responsive while Microsoft 365 tokens are checked or refreshed in the background.
 - Keep Microsoft 365 account and token data consistent when sign-in and background refresh overlap.

--- a/dlls/user32/tests/msg.c
+++ b/dlls/user32/tests/msg.c
@@ -5514,6 +5514,20 @@ static void test_MsgWaitForMultipleObjects(HWND hwnd)
     ret = MsgWaitForMultipleObjects(0, NULL, FALSE, 0, QS_POSTMESSAGE);
     ok(ret == WAIT_TIMEOUT, "MsgWaitForMultipleObjects returned %lx\n", ret);
 
+    PostMessageA(hwnd, WM_USER, 1, 0);
+    PostMessageA(hwnd, WM_USER, 2, 0);
+
+    ok(PeekMessageA( &msg, 0, 0, 0, PM_REMOVE ), "PeekMessage should succeed\n");
+    ok(msg.message == WM_USER && msg.wParam == 1,
+       "got %04x wParam %Ix instead of WM_USER wParam 1\n", msg.message, msg.wParam);
+
+    ret = MsgWaitForMultipleObjectsEx( 0, NULL, 0, QS_POSTMESSAGE, MWMO_INPUTAVAILABLE );
+    ok(ret == WAIT_OBJECT_0, "MsgWaitForMultipleObjectsEx returned %lx\n", ret);
+
+    ok(PeekMessageA( &msg, 0, 0, 0, PM_REMOVE ), "PeekMessage should succeed\n");
+    ok(msg.message == WM_USER && msg.wParam == 2,
+       "got %04x wParam %Ix instead of WM_USER wParam 2\n", msg.message, msg.wParam);
+
     PostMessageA(hwnd, WM_USER, 0, 0);
 
     ret = MsgWaitForMultipleObjects(0, NULL, FALSE, 0, QS_POSTMESSAGE);

--- a/server/queue.c
+++ b/server/queue.c
@@ -708,6 +708,21 @@ static inline int get_queue_status( struct msg_queue *queue )
             queue_shm->internal_bits;
 }
 
+/* update the queue masks and corresponding synchronization state */
+static void set_queue_masks( struct msg_queue *queue, unsigned int wake_mask,
+                             unsigned int changed_mask )
+{
+    SHARED_WRITE_BEGIN( queue->shared, queue_shm_t )
+    {
+        shared->wake_mask = wake_mask;
+        shared->changed_mask = changed_mask;
+    }
+    SHARED_WRITE_END;
+
+    if (!get_queue_status( queue )) reset_sync( queue->sync );
+    else signal_sync( queue->sync );
+}
+
 /* set some queue bits */
 static inline void set_queue_bits( struct msg_queue *queue, unsigned int bits )
 {
@@ -3357,22 +3372,22 @@ DECL_HANDLER(get_message)
     /* then check for posted messages */
     if ((filter & QS_POSTMESSAGE) &&
         get_posted_message( queue, get_win, req->get_first, req->get_last, req->flags, reply ))
-        return;
+        goto found;
 
     if ((filter & QS_HOTKEY) && queue->hotkey_count &&
         req->get_first <= WM_HOTKEY && req->get_last >= WM_HOTKEY &&
         get_posted_message( queue, get_win, WM_HOTKEY, WM_HOTKEY, req->flags, reply ))
-        return;
+        goto found;
 
     /* only check for quit messages if not posted messages pending */
     if ((filter & QS_POSTMESSAGE) && get_quit_message( queue, req->flags, reply ))
-        return;
+        goto found;
 
     /* then check for any raw hardware message */
     if ((filter & QS_INPUT) &&
         filter_contains_hw_range( req->get_first, req->get_last ) &&
         get_hardware_message( current, req->hw_id, get_win, req->get_first, req->get_last, req->flags, reply ))
-        return;
+        goto found;
 
     /* now check for WM_PAINT */
     if ((filter & QS_PAINT) &&
@@ -3385,7 +3400,7 @@ DECL_HANDLER(get_message)
         reply->wparam = 0;
         reply->lparam = 0;
         get_message_defaults( queue, &reply->x, &reply->y, &reply->time );
-        return;
+        goto found;
     }
 
     /* now check for timer */
@@ -3399,19 +3414,16 @@ DECL_HANDLER(get_message)
         reply->wparam = timer->id;
         reply->lparam = timer->lparam;
         get_message_defaults( queue, &reply->x, &reply->y, &reply->time );
-        return;
+        goto found;
     }
 
-    SHARED_WRITE_BEGIN( queue_shm, queue_shm_t )
-    {
-        shared->wake_mask = req->wake_mask;
-        shared->changed_mask = req->changed_mask;
-    }
-    SHARED_WRITE_END;
-
-    if (!get_queue_status( queue )) reset_sync( queue->sync );
-    else signal_sync( queue->sync );
+    set_queue_masks( queue, req->wake_mask, req->changed_mask );
     set_error( STATUS_PENDING );  /* FIXME */
+    return;
+
+found:
+    /* The client processes a returned message without waiting on the queue. */
+    set_queue_masks( queue, 0, 0 );
 }
 
 

--- a/server/queue.c
+++ b/server/queue.c
@@ -3423,7 +3423,7 @@ DECL_HANDLER(get_message)
 
 found:
     /* The client processes a returned message without waiting on the queue. */
-    set_queue_masks( queue, 0, 0 );
+    if (!get_error()) set_queue_masks( queue, 0, 0 );
 }
 
 


### PR DESCRIPTION
## Purpose

Avoid a redundant synchronous `set_queue_mask(0, 0)` server request after a
normal message is retrieved. The server now leaves the shared queue masks in
the state the client immediately requests after processing the returned
message.

Internal driver messages and reentrant sent-message processing retain their
existing mask behavior.

## Changes

- Clear queue masks after returning posted, hotkey, quit, hardware, paint, or
  timer messages.
- Keep the queue synchronization object consistent with the updated masks.
- Add a public user32 regression proving that a second posted message remains
  observable through `MWMO_INPUTAVAILABLE` after the first is removed.
- Add a concise changelog entry.

## Validation

- Focused `server/queue.o` and `server/wineserver` build passed in the canonical
  combined WoW64 build environment.
- Standalone public-API regression passed on x86-64 and i386.
- The x86-64 user32 `msg` suite reached and passed the changed and timer regions
  without a new failure. Its remaining 269 KDE GUI failures are pre-existing.
- The i386 suite passed the changed and timer regions, then timed out later amid
  the existing unrelated window-creation failures.
- Five-second exact-timer trace reduced
  `set_queue_mask + get_message + select` requests from 2,001 to 1,515 (24.3%).
- In matched 30-second Word-home samples, queue-mask-only reduced combined Word
  and wineserver CPU from 19.83% to 7.00% of one core (64.7%) and voluntary
  context switches by 67.8%.

## Risk and limitations

This changes generic Wine server queue state after successful message
retrieval, so the regression specifically verifies that unread queued input
remains visible. Office activation prevented opening the WordArt document in
the fresh environment; the performance comparison used the visually matched
Word home screen where the same message-loop churn is active.

## Summary by Sourcery

Reduce message-loop server synchronization overhead by updating queue masks when messages are retrieved while preserving correct queue notification state.

Bug Fixes:
- Preserve visibility of remaining queued messages when message-loop wait APIs use MWMO_INPUTAVAILABLE after retrieving a message.

Enhancements:
- Reduce redundant server queue-mask synchronization after successfully returning posted, hotkey, quit, hardware, paint, and timer messages while preserving existing behavior for internal and reentrant processing.

Tests:
- Add a user32 regression covering observability of a second posted message after the first is removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced unnecessary background processing when retrieving queued messages, improving message-loop efficiency.

* **Bug Fixes**
  * Improved handling of queued input so applications can detect and retrieve subsequent messages reliably after processing an earlier message.

* **Tests**
  * Added coverage for message retrieval and input-availability notifications to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->