### PR TITLE
d2d1: Render tiny WIC glyph transactions on the CPU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Speed up small Office gallery images rendered through Direct2D.
 - Reduce memory use and latency when drawing complex antialiased Direct2D geometry.
 - Reduce Word CPU use by coalescing Office timers that allow delayed delivery.
 - Reduce message-loop server calls after retrieving queued messages.

--- a/dlls/d2d1/bitmap.c
+++ b/dlls/d2d1/bitmap.c
@@ -199,7 +199,7 @@ static HRESULT STDMETHODCALLTYPE d2d_bitmap_CopyFromRenderTarget(ID2D1Bitmap1 *i
         return hr;
     }
 
-    if (FAILED(hr = d2d_device_context_flush_cpu_transaction(device_context)))
+    if (FAILED(hr = d2d_device_context_prepare_target_read(device_context)))
     {
         ID2D1DeviceContext_Release(device_context);
         return hr;

--- a/dlls/d2d1/bitmap.c
+++ b/dlls/d2d1/bitmap.c
@@ -199,6 +199,12 @@ static HRESULT STDMETHODCALLTYPE d2d_bitmap_CopyFromRenderTarget(ID2D1Bitmap1 *i
         return hr;
     }
 
+    if (FAILED(hr = d2d_device_context_flush_cpu_transaction(device_context)))
+    {
+        ID2D1DeviceContext_Release(device_context);
+        return hr;
+    }
+
     ID2D1DeviceContext_GetTarget(device_context, &target);
     ID2D1DeviceContext_Release(device_context);
 

--- a/dlls/d2d1/d2d1_private.h
+++ b/dlls/d2d1/d2d1_private.h
@@ -173,6 +173,7 @@ struct d2d_device_context_ops
     HRESULT (*device_context_prepare_gpu_draw)(IUnknown *outer_unknown,
             struct d2d_device_context *context);
     BOOL (*queue_cpu_clear)(IUnknown *outer_unknown, const D2D1_COLOR_F *colour);
+    void (*device_context_target_exposed)(IUnknown *outer_unknown);
 };
 
 enum d2d_device_context_sampler_limits
@@ -344,6 +345,7 @@ struct d2d_wic_render_target
     BOOL cpu_clear_pending;
     BOOL gpu_fallback;
     BOOL gpu_stale;
+    BOOL target_exposed;
     unsigned int width;
     unsigned int height;
     unsigned int bpp;

--- a/dlls/d2d1/d2d1_private.h
+++ b/dlls/d2d1/d2d1_private.h
@@ -309,7 +309,7 @@ HRESULT d2d_d3d_create_render_target(struct d2d_device *device, IDXGISurface *su
         void **render_target);
 HRESULT d2d_device_context_replay_cpu_glyph(struct d2d_device_context *context,
         const RECT *bounds, const BYTE *values, unsigned int pitch, const D2D1_COLOR_F *colour);
-HRESULT d2d_device_context_flush_cpu_transaction(ID2D1DeviceContext *iface);
+HRESULT d2d_device_context_prepare_target_read(ID2D1DeviceContext *iface);
 
 static inline BOOL d2d_device_context_is_dxgi_target(const struct d2d_device_context *context)
 {

--- a/dlls/d2d1/d2d1_private.h
+++ b/dlls/d2d1/d2d1_private.h
@@ -161,12 +161,18 @@ struct d2d_vs_cb
     struct d2d_vec4 transform_rty;
 };
 
+struct d2d_device_context;
+
 struct d2d_device_context_ops
 {
     HRESULT (*device_context_present)(IUnknown *outer_unknown);
     BOOL (*queue_cpu_glyph)(IUnknown *outer_unknown, const RECT *bounds,
             const BYTE *values, unsigned int pitch, const D2D1_COLOR_F *colour);
     BOOL batch_small_draws;
+    void (*device_context_begin_draw)(IUnknown *outer_unknown);
+    HRESULT (*device_context_prepare_gpu_draw)(IUnknown *outer_unknown,
+            struct d2d_device_context *context);
+    BOOL (*queue_cpu_clear)(IUnknown *outer_unknown, const D2D1_COLOR_F *colour);
 };
 
 enum d2d_device_context_sampler_limits
@@ -239,6 +245,8 @@ struct d2d_device_context
     ID3D11DeviceContext1 *batched_context;
     ID3DDeviceContextState *batched_prev_state;
     BOOL batched_draw;
+    ID2D1Image *cpu_transaction_target;
+    BOOL cpu_transaction;
     unsigned int draw_depth;
     BOOL invalid_draw_sequence;
     struct
@@ -299,11 +307,23 @@ struct d2d_device_context
 HRESULT d2d_d3d_create_render_target(struct d2d_device *device, IDXGISurface *surface, IUnknown *outer_unknown,
         const struct d2d_device_context_ops *ops, const D2D1_RENDER_TARGET_PROPERTIES *desc,
         void **render_target);
+HRESULT d2d_device_context_replay_cpu_glyph(struct d2d_device_context *context,
+        const RECT *bounds, const BYTE *values, unsigned int pitch, const D2D1_COLOR_F *colour);
+HRESULT d2d_device_context_flush_cpu_transaction(ID2D1DeviceContext *iface);
 
 static inline BOOL d2d_device_context_is_dxgi_target(const struct d2d_device_context *context)
 {
     return !context->ops;
 }
+
+struct d2d_wic_cpu_glyph
+{
+    struct d2d_wic_cpu_glyph *next;
+    RECT bounds;
+    D2D1_COLOR_F colour;
+    unsigned int pitch;
+    BYTE values[];
+};
 
 struct d2d_wic_render_target
 {
@@ -315,6 +335,15 @@ struct d2d_wic_render_target
     IUnknown *dxgi_inner;
     ID3D10Texture2D *readback_texture;
     IWICBitmap *bitmap;
+    struct d2d_wic_cpu_glyph *cpu_glyphs;
+    struct d2d_wic_cpu_glyph **cpu_glyph_tail;
+    unsigned int cpu_glyph_count;
+    D2D1_COLOR_F cpu_clear;
+    D2D1_PIXEL_FORMAT pixel_format;
+    D2D1_RENDER_TARGET_USAGE usage;
+    BOOL cpu_clear_pending;
+    BOOL gpu_fallback;
+    BOOL gpu_stale;
     unsigned int width;
     unsigned int height;
     unsigned int bpp;

--- a/dlls/d2d1/device.c
+++ b/dlls/d2d1/device.c
@@ -380,6 +380,41 @@ static inline struct d2d_device_context *impl_from_ID2D1DeviceContext(ID2D1Devic
     return CONTAINING_RECORD(iface, struct d2d_device_context, ID2D1DeviceContext6_iface);
 }
 
+static HRESULT d2d_device_context_prepare_gpu_draw(struct d2d_device_context *context)
+{
+    HRESULT hr;
+
+    if (!context->cpu_transaction || context->target.object != context->cpu_transaction_target
+            || !context->ops || !context->ops->device_context_prepare_gpu_draw)
+        return S_OK;
+
+    context->cpu_transaction = FALSE;
+    if (FAILED(hr = context->ops->device_context_prepare_gpu_draw(context->outer_unknown, context)))
+        d2d_device_context_set_error(context, hr);
+    return hr;
+}
+
+HRESULT d2d_device_context_flush_cpu_transaction(ID2D1DeviceContext *iface)
+{
+    return d2d_device_context_prepare_gpu_draw(
+            impl_from_ID2D1DeviceContext((ID2D1DeviceContext6 *)iface));
+}
+
+static BOOL d2d_device_context_cpu_transaction_matches(const struct d2d_device_context *context)
+{
+    return context->cpu_transaction && context->target.object == context->cpu_transaction_target;
+}
+
+static void d2d_device_context_end_cpu_transaction(struct d2d_device_context *context)
+{
+    context->cpu_transaction = FALSE;
+    if (context->cpu_transaction_target)
+    {
+        ID2D1Image_Release(context->cpu_transaction_target);
+        context->cpu_transaction_target = NULL;
+    }
+}
+
 static void d2d_device_context_end_batch(struct d2d_device_context *context)
 {
     if (!context->batched_draw)
@@ -469,6 +504,10 @@ static ULONG STDMETHODCALLTYPE d2d_device_context_inner_Release(IUnknown *iface)
     {
         unsigned int i, j, k;
 
+        /* BeginDraw() may have borrowed the immediate context for a small
+         * batched target. Restore it even if the caller abandons the draw. */
+        d2d_device_context_end_batch(context);
+        d2d_device_context_end_cpu_transaction(context);
         d2d_clip_stack_cleanup(&context->clip_stack);
         IDWriteRenderingParams_Release(context->default_text_rendering_params);
         if (context->text_rendering_params)
@@ -1118,6 +1157,9 @@ static void d2d_device_context_draw_geometry(struct d2d_device_context *render_t
     D3D11_BUFFER_DESC buffer_desc;
     ID3D11Buffer *ib, *vb;
     HRESULT hr;
+
+    if (FAILED(d2d_device_context_prepare_gpu_draw(render_target)))
+        return;
 
     if (FAILED(hr = d2d_geometry_build_outline_mesh(geometry, stroke_width, stroke_style, &mesh)))
     {
@@ -2234,6 +2276,9 @@ static void d2d_device_context_fill_geometry(struct d2d_device_context *render_t
     ID3D11Buffer *ib, *vb;
     HRESULT hr;
 
+    if (FAILED(d2d_device_context_prepare_gpu_draw(render_target)))
+        return;
+
     buffer_desc.Usage = D3D11_USAGE_DEFAULT;
     buffer_desc.CPUAccessFlags = 0;
     buffer_desc.MiscFlags = 0;
@@ -2427,6 +2472,9 @@ static void d2d_device_context_draw_bitmap(struct d2d_device_context *context, I
     D2D1_SIZE_F size;
     D2D1_RECT_F s, d;
     HRESULT hr;
+
+    if (FAILED(d2d_device_context_prepare_gpu_draw(context)))
+        return;
 
     if (perspective_transform)
         FIXME("Perspective transform is ignored.\n");
@@ -2642,6 +2690,9 @@ static void d2d_device_context_draw_glyph_run_outline(struct d2d_device_context 
     ID2D1PathGeometry *geometry;
     HRESULT hr;
 
+    if (FAILED(d2d_device_context_prepare_gpu_draw(context)))
+        return;
+
     if (FAILED(hr = d2d_device_context_get_glyph_run_geometry(context, glyph_run, &geometry)))
     {
         ERR("Failed to create geometry, hr %#lx.\n", hr);
@@ -2762,8 +2813,10 @@ static BOOL d2d_device_context_draw_cached_glyph(struct d2d_device_context *cont
             ? context->text_rendering_params : context->default_text_rendering_params;
     D2D1_COLOR_F colour;
 
-    if (!brush_impl || brush_impl->type != D2D_BRUSH_TYPE_SOLID || !context->ops
+    if (!brush_impl || brush_impl->type != D2D_BRUSH_TYPE_SOLID
+            || !d2d_device_context_cpu_transaction_matches(context) || !context->ops
             || !context->ops->queue_cpu_glyph || context->clip_stack.count || !cache->values
+            || context->drawing_state.primitiveBlend != D2D1_PRIMITIVE_BLEND_SOURCE_OVER
             || cache->text_antialias_mode != context->drawing_state.textAntialiasMode
             || cache->rendering_params != rendering_params
             || !d2d_glyph_bitmap_cache_matches(cache, context, baseline_origin, run,
@@ -2919,7 +2972,9 @@ static void d2d_device_context_draw_glyph_run_bitmap(struct d2d_device_context *
 
     if (texture_type == DWRITE_TEXTURE_ALIASED_1x1 && brush_impl
             && brush_impl->type == D2D_BRUSH_TYPE_SOLID && context->ops
-            && context->ops->queue_cpu_glyph && !context->clip_stack.count)
+            && context->ops->queue_cpu_glyph && !context->clip_stack.count
+            && context->drawing_state.primitiveBlend == D2D1_PRIMITIVE_BLEND_SOURCE_OVER
+            && d2d_device_context_cpu_transaction_matches(context))
     {
         colour = brush_impl->u.solid.color;
         colour.a *= brush_impl->opacity;
@@ -2933,6 +2988,9 @@ static void d2d_device_context_draw_glyph_run_bitmap(struct d2d_device_context *
             goto done;
         }
     }
+
+    if (FAILED(d2d_device_context_prepare_gpu_draw(context)))
+        goto done;
 
     bitmap_desc.pixelFormat.format = DXGI_FORMAT_A8_UNORM;
     bitmap_desc.pixelFormat.alphaMode = D2D1_ALPHA_MODE_PREMULTIPLIED;
@@ -2989,6 +3047,73 @@ done:
         ID2D1Bitmap_Release(opacity_bitmap);
     free(opacity_values);
     IDWriteGlyphRunAnalysis_Release(analysis);
+}
+
+HRESULT d2d_device_context_replay_cpu_glyph(struct d2d_device_context *context,
+        const RECT *bounds, const BYTE *values, unsigned int pitch, const D2D1_COLOR_F *colour)
+{
+    ID2D1RectangleGeometry *geometry = NULL;
+    ID2D1SolidColorBrush *colour_brush = NULL;
+    ID2D1BitmapBrush *opacity_brush = NULL;
+    D2D1_BITMAP_PROPERTIES bitmap_desc;
+    ID2D1Bitmap *opacity_bitmap = NULL;
+    D2D1_BRUSH_PROPERTIES brush_desc;
+    D2D1_MATRIX_3X2_F *transform, saved_transform;
+    D2D1_SIZE_U bitmap_size;
+    D2D1_RECT_F run_rect;
+    float scale_x, scale_y;
+    HRESULT hr;
+
+    d2d_size_set(&bitmap_size, bounds->right - bounds->left, bounds->bottom - bounds->top);
+    if (!bitmap_size.width || !bitmap_size.height)
+        return S_OK;
+
+    bitmap_desc.pixelFormat.format = DXGI_FORMAT_A8_UNORM;
+    bitmap_desc.pixelFormat.alphaMode = D2D1_ALPHA_MODE_PREMULTIPLIED;
+    bitmap_desc.dpiX = context->desc.dpiX;
+    bitmap_desc.dpiY = context->desc.dpiY;
+    if (FAILED(hr = d2d_device_context_CreateBitmap(&context->ID2D1DeviceContext6_iface,
+            bitmap_size, values, pitch, &bitmap_desc, &opacity_bitmap)))
+        goto done;
+
+    scale_x = context->desc.dpiX / 96.0f;
+    scale_y = context->desc.dpiY / 96.0f;
+    d2d_rect_set(&run_rect, bounds->left / scale_x, bounds->top / scale_y,
+            bounds->right / scale_x, bounds->bottom / scale_y);
+
+    brush_desc.opacity = 1.0f;
+    brush_desc.transform = identity;
+    brush_desc.transform._31 = run_rect.left;
+    brush_desc.transform._32 = run_rect.top;
+    if (FAILED(hr = d2d_device_context_CreateBitmapBrush(&context->ID2D1DeviceContext6_iface,
+            opacity_bitmap, NULL, &brush_desc, &opacity_brush)))
+        goto done;
+    if (FAILED(hr = d2d_device_context_CreateSolidColorBrush(&context->ID2D1DeviceContext6_iface,
+            colour, NULL, &colour_brush)))
+        goto done;
+    if (FAILED(hr = ID2D1Factory_CreateRectangleGeometry(context->factory, &run_rect, &geometry)))
+        goto done;
+
+    transform = &context->drawing_state.transform;
+    saved_transform = *transform;
+    *transform = identity;
+    d2d_device_context_fill_geometry(context,
+            unsafe_impl_from_ID2D1Geometry((ID2D1Geometry *)geometry),
+            unsafe_impl_from_ID2D1Brush((ID2D1Brush *)colour_brush),
+            unsafe_impl_from_ID2D1Brush((ID2D1Brush *)opacity_brush));
+    *transform = saved_transform;
+    hr = context->error.code;
+
+done:
+    if (geometry)
+        ID2D1RectangleGeometry_Release(geometry);
+    if (colour_brush)
+        ID2D1SolidColorBrush_Release(colour_brush);
+    if (opacity_brush)
+        ID2D1BitmapBrush_Release(opacity_brush);
+    if (opacity_bitmap)
+        ID2D1Bitmap_Release(opacity_bitmap);
+    return hr;
 }
 
 static HRESULT d2d_device_context_get_text_rendering_mode(struct d2d_device_context *context,
@@ -3131,6 +3256,9 @@ static void STDMETHODCALLTYPE d2d_device_context_SetTransform(ID2D1DeviceContext
 
     TRACE("iface %p, transform %p.\n", iface, transform);
 
+    if (FAILED(d2d_device_context_prepare_gpu_draw(context)))
+        return;
+
     if (context->target.type == D2D_TARGET_COMMAND_LIST)
         d2d_command_list_set_transform(context->target.command_list, transform);
 
@@ -3155,6 +3283,9 @@ static void STDMETHODCALLTYPE d2d_device_context_SetAntialiasMode(ID2D1DeviceCon
 
     TRACE("iface %p, antialias_mode %#x stub!\n", iface, antialias_mode);
 
+    if (FAILED(d2d_device_context_prepare_gpu_draw(context)))
+        return;
+
     if (context->target.type == D2D_TARGET_COMMAND_LIST)
         d2d_command_list_set_antialias_mode(context->target.command_list, antialias_mode);
 
@@ -3177,6 +3308,9 @@ static void STDMETHODCALLTYPE d2d_device_context_SetTextAntialiasMode(ID2D1Devic
 
     TRACE("iface %p, antialias_mode %#x.\n", iface, antialias_mode);
 
+    if (FAILED(d2d_device_context_prepare_gpu_draw(context)))
+        return;
+
     if (context->target.type == D2D_TARGET_COMMAND_LIST)
         d2d_command_list_set_text_antialias_mode(context->target.command_list, antialias_mode);
 
@@ -3198,6 +3332,9 @@ static void STDMETHODCALLTYPE d2d_device_context_SetTextRenderingParams(ID2D1Dev
     struct d2d_device_context *context = impl_from_ID2D1DeviceContext(iface);
 
     TRACE("iface %p, text_rendering_params %p.\n", iface, text_rendering_params);
+
+    if (FAILED(d2d_device_context_prepare_gpu_draw(context)))
+        return;
 
     if (context->target.type == D2D_TARGET_COMMAND_LIST)
         d2d_command_list_set_text_rendering_params(context->target.command_list, text_rendering_params);
@@ -3249,6 +3386,9 @@ static void STDMETHODCALLTYPE d2d_device_context_PushLayer(ID2D1DeviceContext6 *
     struct d2d_device_context *context = impl_from_ID2D1DeviceContext(iface);
 
     FIXME("iface %p, layer_parameters %p, layer %p stub!\n", iface, layer_parameters, layer);
+
+    if (FAILED(d2d_device_context_prepare_gpu_draw(context)))
+        return;
 
     if (context->target.type == D2D_TARGET_COMMAND_LIST)
     {
@@ -3308,6 +3448,8 @@ static void STDMETHODCALLTYPE d2d_device_context_RestoreDrawingState(ID2D1Device
     TRACE("iface %p, state_block %p.\n", iface, state_block);
 
     if (!(state_block_impl = unsafe_impl_from_ID2D1DrawingStateBlock(state_block))) return;
+    if (FAILED(d2d_device_context_prepare_gpu_draw(context)))
+        return;
     if (context->target.type == D2D_TARGET_COMMAND_LIST)
     {
         struct d2d_command_list *command_list = context->target.command_list;
@@ -3339,6 +3481,9 @@ static void STDMETHODCALLTYPE d2d_device_context_PushAxisAlignedClip(ID2D1Device
     D2D1_POINT_2F point;
 
     TRACE("iface %p, clip_rect %s, antialias_mode %#x.\n", iface, debug_d2d_rect_f(clip_rect), antialias_mode);
+
+    if (FAILED(d2d_device_context_prepare_gpu_draw(context)))
+        return;
 
     if (context->target.type == D2D_TARGET_COMMAND_LIST)
         d2d_command_list_push_clip(context->target.command_list, clip_rect, antialias_mode);
@@ -3408,6 +3553,13 @@ static void STDMETHODCALLTYPE d2d_device_context_Clear(ID2D1DeviceContext6 *ifac
         return;
     }
 
+    if (d2d_device_context_cpu_transaction_matches(context) && !context->clip_stack.count
+            && context->ops && context->ops->queue_cpu_clear
+            && context->ops->queue_cpu_clear(context->outer_unknown, colour))
+        return;
+    if (FAILED(d2d_device_context_prepare_gpu_draw(context)))
+        return;
+
     ID3D11Device1_GetImmediateContext(context->d3d_device, &d3d_context);
 
     if (FAILED(hr = ID3D11DeviceContext_Map(d3d_context, (ID3D11Resource *)context->vs_cb,
@@ -3475,8 +3627,27 @@ static void STDMETHODCALLTYPE d2d_device_context_BeginDraw(ID2D1DeviceContext6 *
 
     TRACE("iface %p.\n", iface);
 
-    if (context->draw_depth++)
+    if (!context->draw_depth)
+    {
+        context->invalid_draw_sequence = FALSE;
+        memset(&context->error, 0, sizeof(context->error));
+    }
+    else
         context->invalid_draw_sequence = TRUE;
+    ++context->draw_depth;
+
+    if (context->draw_depth == 1)
+    {
+        d2d_device_context_end_cpu_transaction(context);
+        if (context->target.type == D2D_TARGET_BITMAP && context->ops
+                && context->ops->device_context_begin_draw)
+        {
+            context->cpu_transaction_target = context->target.object;
+            ID2D1Image_AddRef(context->cpu_transaction_target);
+            context->cpu_transaction = TRUE;
+            context->ops->device_context_begin_draw(context->outer_unknown);
+        }
+    }
 
     d2d_device_context_atlas_log_rect(context, "BeginDraw", NULL);
 
@@ -3487,7 +3658,7 @@ static void STDMETHODCALLTYPE d2d_device_context_BeginDraw(ID2D1DeviceContext6 *
      * shared immediate-context state around every primitive in one transaction. */
     if (context->ops && context->ops->batch_small_draws
             && context->pixel_size.width <= 32 && context->pixel_size.height <= 32
-            && !context->batched_draw)
+            && context->draw_depth == 1 && !context->batched_draw)
     {
         if (context->cs)
             EnterCriticalSection(context->cs);
@@ -3497,7 +3668,6 @@ static void STDMETHODCALLTYPE d2d_device_context_BeginDraw(ID2D1DeviceContext6 *
         context->batched_draw = TRUE;
     }
 
-    memset(&context->error, 0, sizeof(context->error));
 }
 
 static HRESULT STDMETHODCALLTYPE d2d_device_context_EndDraw(ID2D1DeviceContext6 *iface,
@@ -3518,12 +3688,16 @@ static HRESULT STDMETHODCALLTYPE d2d_device_context_EndDraw(ID2D1DeviceContext6 
     if (tag2)
         *tag2 = context->error.tag2;
 
-    if (context->target.type == D2D_TARGET_COMMAND_LIST)
-        return context->error.code;
-
     /* Restore the D3D context before WIC readback. CopyResource/Map may wait
      * for work which cannot complete while the immediate context is borrowed. */
     d2d_device_context_end_batch(context);
+    d2d_device_context_end_cpu_transaction(context);
+
+    if (context->invalid_draw_sequence)
+        return D2DERR_WRONG_STATE;
+
+    if (context->target.type == D2D_TARGET_COMMAND_LIST)
+        return context->error.code;
 
     if (context->ops && context->ops->device_context_present)
     {
@@ -3548,7 +3722,7 @@ static D2D1_PIXEL_FORMAT * STDMETHODCALLTYPE d2d_device_context_GetPixelFormat(I
 
 static void STDMETHODCALLTYPE d2d_device_context_SetDpi(ID2D1DeviceContext6 *iface, float dpi_x, float dpi_y)
 {
-    struct d2d_device_context *render_target = impl_from_ID2D1DeviceContext(iface);
+    struct d2d_device_context *context = impl_from_ID2D1DeviceContext(iface);
 
     TRACE("iface %p, dpi_x %.8e, dpi_y %.8e.\n", iface, dpi_x, dpi_y);
 
@@ -3560,8 +3734,11 @@ static void STDMETHODCALLTYPE d2d_device_context_SetDpi(ID2D1DeviceContext6 *ifa
     else if (dpi_x <= 0.0f || dpi_y <= 0.0f)
         return;
 
-    render_target->desc.dpiX = dpi_x;
-    render_target->desc.dpiY = dpi_y;
+    if (FAILED(d2d_device_context_prepare_gpu_draw(context)))
+        return;
+
+    context->desc.dpiX = dpi_x;
+    context->desc.dpiY = dpi_y;
 }
 
 static void STDMETHODCALLTYPE d2d_device_context_GetDpi(ID2D1DeviceContext6 *iface, float *dpi_x, float *dpi_y)
@@ -4024,6 +4201,9 @@ static void STDMETHODCALLTYPE d2d_device_context_SetTarget(ID2D1DeviceContext6 *
 
     TRACE("iface %p, target %p.\n", iface, target);
 
+    if (FAILED(d2d_device_context_prepare_gpu_draw(context)))
+        return;
+
     if (!target)
     {
         if (GetEnvironmentVariableA("WINE_D2D_TARGET_DIAG", NULL, 0))
@@ -4122,6 +4302,9 @@ static void STDMETHODCALLTYPE d2d_device_context_SetPrimitiveBlend(ID2D1DeviceCo
         return;
     }
 
+    if (FAILED(d2d_device_context_prepare_gpu_draw(context)))
+        return;
+
     if (context->target.type == D2D_TARGET_COMMAND_LIST)
         d2d_command_list_set_primitive_blend(context->target.command_list, primitive_blend);
 
@@ -4148,6 +4331,9 @@ static void STDMETHODCALLTYPE d2d_device_context_SetUnitMode(ID2D1DeviceContext6
         WARN("Unknown unit mode %#x.\n", unit_mode);
         return;
     }
+
+    if (FAILED(d2d_device_context_prepare_gpu_draw(context)))
+        return;
 
     if (context->target.type == D2D_TARGET_COMMAND_LIST)
         d2d_command_list_set_unit_mode(context->target.command_list, unit_mode);
@@ -5149,6 +5335,9 @@ static void STDMETHODCALLTYPE d2d_device_context_ID2D1DeviceContext_PushLayer(ID
     struct d2d_device_context *context = impl_from_ID2D1DeviceContext(iface);
 
     FIXME("iface %p, layer_parameters %p, layer %p stub!\n", iface, layer_parameters, layer);
+
+    if (FAILED(d2d_device_context_prepare_gpu_draw(context)))
+        return;
 
     if (context->target.type == D2D_TARGET_COMMAND_LIST)
         d2d_command_list_push_layer(context->target.command_list, context, layer_parameters);

--- a/dlls/d2d1/device.c
+++ b/dlls/d2d1/device.c
@@ -399,6 +399,10 @@ HRESULT d2d_device_context_prepare_target_read(ID2D1DeviceContext *iface)
     struct d2d_device_context *context =
             impl_from_ID2D1DeviceContext((ID2D1DeviceContext6 *)iface);
 
+    if (context->ops && context->ops->device_context_target_exposed)
+        context->ops->device_context_target_exposed(context->outer_unknown);
+    if (FAILED(context->error.code))
+        return context->error.code;
     if (context->cpu_transaction)
         return d2d_device_context_prepare_gpu_draw(context);
     if (context->ops && context->ops->device_context_prepare_gpu_draw)
@@ -3416,13 +3420,20 @@ static void STDMETHODCALLTYPE d2d_device_context_PopLayer(ID2D1DeviceContext6 *i
 static HRESULT STDMETHODCALLTYPE d2d_device_context_Flush(ID2D1DeviceContext6 *iface, D2D1_TAG *tag1, D2D1_TAG *tag2)
 {
     struct d2d_device_context *context = impl_from_ID2D1DeviceContext(iface);
+    HRESULT hr = context->error.code;
 
     FIXME("iface %p, tag1 %p, tag2 %p stub!\n", iface, tag1, tag2);
 
-    if (context->ops && context->ops->device_context_present)
-        context->ops->device_context_present(context->outer_unknown);
+    if (SUCCEEDED(hr) && context->ops && context->ops->device_context_present
+            && FAILED(hr = context->ops->device_context_present(context->outer_unknown)))
+        d2d_device_context_set_error(context, hr);
 
-    return S_OK;
+    if (tag1)
+        *tag1 = context->error.tag1;
+    if (tag2)
+        *tag2 = context->error.tag2;
+
+    return hr;
 }
 
 static void STDMETHODCALLTYPE d2d_device_context_SaveDrawingState(ID2D1DeviceContext6 *iface,
@@ -3697,7 +3708,10 @@ static HRESULT STDMETHODCALLTYPE d2d_device_context_EndDraw(ID2D1DeviceContext6 
     d2d_device_context_end_cpu_transaction(context);
 
     if (context->invalid_draw_sequence)
+    {
+        d2d_device_context_set_error(context, D2DERR_WRONG_STATE);
         return D2DERR_WRONG_STATE;
+    }
 
     if (context->target.type == D2D_TARGET_COMMAND_LIST)
         return context->error.code;
@@ -3740,6 +3754,8 @@ static void STDMETHODCALLTYPE d2d_device_context_SetDpi(ID2D1DeviceContext6 *ifa
     if (FAILED(d2d_device_context_prepare_gpu_draw(context)))
         return;
 
+    if (context->desc.dpiX != dpi_x || context->desc.dpiY != dpi_y)
+        d2d_glyph_bitmap_cache_cleanup(&context->glyph_bitmap_cache);
     context->desc.dpiX = dpi_x;
     context->desc.dpiY = dpi_y;
 }
@@ -4272,12 +4288,18 @@ static void STDMETHODCALLTYPE d2d_device_context_SetTarget(ID2D1DeviceContext6 *
 static void STDMETHODCALLTYPE d2d_device_context_GetTarget(ID2D1DeviceContext6 *iface, ID2D1Image **target)
 {
     struct d2d_device_context *context = impl_from_ID2D1DeviceContext(iface);
+    HRESULT hr;
 
     TRACE("iface %p, target %p.\n", iface, target);
 
     *target = context->target.object ? context->target.object : NULL;
     if (*target)
+    {
+        if (FAILED(hr = d2d_device_context_prepare_target_read((ID2D1DeviceContext *)iface))
+                && SUCCEEDED(context->error.code))
+            d2d_device_context_set_error(context, hr);
         ID2D1Image_AddRef(*target);
+    }
 }
 
 static void STDMETHODCALLTYPE d2d_device_context_SetRenderingControls(ID2D1DeviceContext6 *iface,

--- a/dlls/d2d1/device.c
+++ b/dlls/d2d1/device.c
@@ -3339,9 +3339,6 @@ static void STDMETHODCALLTYPE d2d_device_context_SetTextRenderingParams(ID2D1Dev
 
     TRACE("iface %p, text_rendering_params %p.\n", iface, text_rendering_params);
 
-    if (FAILED(d2d_device_context_prepare_gpu_draw(context)))
-        return;
-
     if (context->target.type == D2D_TARGET_COMMAND_LIST)
         d2d_command_list_set_text_rendering_params(context->target.command_list, text_rendering_params);
 

--- a/dlls/d2d1/device.c
+++ b/dlls/d2d1/device.c
@@ -394,10 +394,16 @@ static HRESULT d2d_device_context_prepare_gpu_draw(struct d2d_device_context *co
     return hr;
 }
 
-HRESULT d2d_device_context_flush_cpu_transaction(ID2D1DeviceContext *iface)
+HRESULT d2d_device_context_prepare_target_read(ID2D1DeviceContext *iface)
 {
-    return d2d_device_context_prepare_gpu_draw(
-            impl_from_ID2D1DeviceContext((ID2D1DeviceContext6 *)iface));
+    struct d2d_device_context *context =
+            impl_from_ID2D1DeviceContext((ID2D1DeviceContext6 *)iface);
+
+    if (context->cpu_transaction)
+        return d2d_device_context_prepare_gpu_draw(context);
+    if (context->ops && context->ops->device_context_prepare_gpu_draw)
+        return context->ops->device_context_prepare_gpu_draw(context->outer_unknown, context);
+    return S_OK;
 }
 
 static BOOL d2d_device_context_cpu_transaction_matches(const struct d2d_device_context *context)

--- a/dlls/d2d1/tests/Makefile.in
+++ b/dlls/d2d1/tests/Makefile.in
@@ -2,4 +2,5 @@ TESTDLL   = d2d1.dll
 IMPORTS   = d2d1 d3d10_1 d3d11 dwrite dxguid uuid user32 advapi32 ole32 gdi32 d3dcompiler
 
 SOURCES = \
-	d2d1.c
+	d2d1.c \
+	wic.c

--- a/dlls/d2d1/tests/wic.c
+++ b/dlls/d2d1/tests/wic.c
@@ -44,6 +44,7 @@ struct benchmark_context
     ID2D1PathGeometry *geometry;
     IDWriteFactory *dwrite_factory;
     IDWriteTextFormat *text_format;
+    IDWriteRenderingParams *rendering_params;
     D2D1_RENDER_TARGET_PROPERTIES target_desc;
 };
 
@@ -185,13 +186,16 @@ static HRESULT init_benchmark_context(struct benchmark_context *ctx, D2D1_FACTOR
     if (FAILED(hr = DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED,
             &IID_IDWriteFactory, (IUnknown **)&ctx->dwrite_factory)))
         return hr;
-    return IDWriteFactory_CreateTextFormat(ctx->dwrite_factory, L"Tahoma", NULL,
+    if (FAILED(hr = IDWriteFactory_CreateTextFormat(ctx->dwrite_factory, L"Tahoma", NULL,
             DWRITE_FONT_WEIGHT_NORMAL, DWRITE_FONT_STYLE_NORMAL, DWRITE_FONT_STRETCH_NORMAL,
-            7.0f, L"en-us", &ctx->text_format);
+            7.0f, L"en-us", &ctx->text_format)))
+        return hr;
+    return IDWriteFactory_CreateRenderingParams(ctx->dwrite_factory, &ctx->rendering_params);
 }
 
 static void release_benchmark_context(struct benchmark_context *ctx)
 {
+    if (ctx->rendering_params) IDWriteRenderingParams_Release(ctx->rendering_params);
     if (ctx->text_format) IDWriteTextFormat_Release(ctx->text_format);
     if (ctx->dwrite_factory) IDWriteFactory_Release(ctx->dwrite_factory);
     if (ctx->geometry) ID2D1PathGeometry_Release(ctx->geometry);
@@ -483,6 +487,7 @@ static HRESULT draw_office_glyph_thumbnail(struct benchmark_context *ctx,
     if (FAILED(hr = ID2D1RenderTarget_CreateSolidColorBrush(target, &ink, NULL, &brush)))
         goto done;
     ID2D1RenderTarget_SetTextAntialiasMode(target, D2D1_TEXT_ANTIALIAS_MODE_ALIASED);
+    ID2D1RenderTarget_SetTextRenderingParams(target, ctx->rendering_params);
     sample->target_ms = now_ms() - t;
 
     t = now_ms();
@@ -498,6 +503,7 @@ static HRESULT draw_office_glyph_thumbnail(struct benchmark_context *ctx,
     ID2D1RenderTarget_DrawText(target, text, ARRAY_SIZE(text) - 1, ctx->text_format,
             &text_rect, (ID2D1Brush *)brush, D2D1_DRAW_TEXT_OPTIONS_NONE,
             DWRITE_MEASURING_MODE_NATURAL);
+    ID2D1RenderTarget_SetTextRenderingParams(target, NULL);
     sample->primitive_ms = now_ms() - t;
 
     t = now_ms();
@@ -903,11 +909,13 @@ static void test_tiny_wic_sequences(void)
                 ok(0, "Failed to read the clipped pixel, hr %#lx.\n", hr);
 
             ID2D1RenderTarget_SetTextAntialiasMode(target, D2D1_TEXT_ANTIALIAS_MODE_ALIASED);
+            ID2D1RenderTarget_SetTextRenderingParams(target, ctx.rendering_params);
             ID2D1RenderTarget_BeginDraw(target);
             ID2D1RenderTarget_Clear(target, NULL);
             ID2D1RenderTarget_DrawText(target, L"A", 1, ctx.text_format, &rect,
                     (ID2D1Brush *)brush, D2D1_DRAW_TEXT_OPTIONS_NONE,
                     DWRITE_MEASURING_MODE_NATURAL);
+            ID2D1RenderTarget_SetTextRenderingParams(target, NULL);
             hr = ID2D1RenderTarget_EndDraw(target, NULL, NULL);
             ok(hr == S_OK, "Failed to complete the CPU glyph transaction, hr %#lx.\n", hr);
             if (SUCCEEDED(hr = count_nonzero_alpha(bitmap, 17, 17, &nonzero_alpha)))

--- a/dlls/d2d1/tests/wic.c
+++ b/dlls/d2d1/tests/wic.c
@@ -686,10 +686,13 @@ static void test_tiny_wic_sequences(void)
     const D2D1_COLOR_F red = {1.0f, 0.0f, 0.0f, 1.0f};
     const D2D1_COLOR_F blue = {0.0f, 0.0f, 1.0f, 1.0f};
     struct benchmark_context ctx;
+    ID2D1Bitmap *copied_bitmap = NULL;
     ID2D1RenderTarget *target = NULL;
     ID2D1SolidColorBrush *brush = NULL;
     IWICBitmap *bitmap = NULL;
+    D2D1_BITMAP_PROPERTIES bitmap_props;
     D2D1_MATRIX_3X2_F transform, identity;
+    D2D1_SIZE_U bitmap_size;
     D2D1_RECT_F rect;
     D2D1_TAG tag1, tag2;
     BYTE pixel[4];
@@ -822,6 +825,21 @@ static void test_tiny_wic_sequences(void)
             hr = ID2D1RenderTarget_EndDraw(target, NULL, NULL);
             ok(hr == S_OK, "Failed to complete the CPU WIC transaction, hr %#lx.\n", hr);
 
+            memset(&bitmap_props, 0, sizeof(bitmap_props));
+            bitmap_props.pixelFormat = ctx.target_desc.pixelFormat;
+            bitmap_props.dpiX = 96.0f;
+            bitmap_props.dpiY = 96.0f;
+            bitmap_size.width = 17;
+            bitmap_size.height = 17;
+            hr = ID2D1RenderTarget_CreateBitmap(target, bitmap_size, NULL, 0,
+                    &bitmap_props, &copied_bitmap);
+            ok(hr == S_OK, "Failed to create the WIC copy bitmap, hr %#lx.\n", hr);
+            if (SUCCEEDED(hr))
+            {
+                hr = ID2D1Bitmap_CopyFromRenderTarget(copied_bitmap, NULL, target, NULL);
+                ok(hr == S_OK, "Failed to copy from the CPU WIC target, hr %#lx.\n", hr);
+            }
+
             rect.left = 0.0f;
             rect.top = 0.0f;
             rect.right = 8.0f;
@@ -843,6 +861,22 @@ static void test_tiny_wic_sequences(void)
                         pixel[0], pixel[1], pixel[2], pixel[3]);
             else
                 ok(0, "Failed to read the preserved pixel, hr %#lx.\n", hr);
+
+            if (copied_bitmap)
+            {
+                ID2D1RenderTarget_BeginDraw(target);
+                ID2D1RenderTarget_Clear(target, &blue);
+                ID2D1RenderTarget_DrawBitmap(target, copied_bitmap, NULL, 1.0f,
+                        D2D1_BITMAP_INTERPOLATION_MODE_LINEAR, NULL);
+                hr = ID2D1RenderTarget_EndDraw(target, NULL, NULL);
+                ok(hr == S_OK, "Failed to draw the copied WIC contents, hr %#lx.\n", hr);
+                if (SUCCEEDED(hr = get_bitmap_pixel(bitmap, 8, 8, pixel)))
+                    ok(!pixel[0] && !pixel[1] && pixel[2] == 255 && pixel[3] == 255,
+                            "Unexpected copied pixel %u,%u,%u,%u.\n",
+                            pixel[0], pixel[1], pixel[2], pixel[3]);
+                else
+                    ok(0, "Failed to read the copied pixel, hr %#lx.\n", hr);
+            }
 
             rect.left = 1.0f;
             rect.top = 1.0f;
@@ -883,6 +917,7 @@ static void test_tiny_wic_sequences(void)
         }
     }
 
+    if (copied_bitmap) ID2D1Bitmap_Release(copied_bitmap);
     if (brush) ID2D1SolidColorBrush_Release(brush);
     if (target) ID2D1RenderTarget_Release(target);
     if (bitmap) IWICBitmap_Release(bitmap);

--- a/dlls/d2d1/tests/wic.c
+++ b/dlls/d2d1/tests/wic.c
@@ -1,0 +1,1011 @@
+/*
+ * Direct2D tiny WIC render-target tests and benchmark.
+ *
+ * Copyright 2026 Elkana Bardugo
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ */
+
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define COBJMACROS
+#include "d2d1.h"
+#include "dwrite.h"
+#include "wincrypt.h"
+#include "wincodec.h"
+#include "wine/test.h"
+
+#define HISTORICAL_ITERATIONS 400
+#define REPRESENTATIVE_ITERATIONS 200
+#define OFFICE_GLYPH_ITERATIONS 543
+
+struct benchmark_sample
+{
+    double bitmap_ms;
+    double target_ms;
+    double begin_ms;
+    double primitive_ms;
+    double end_ms;
+    double inspect_ms;
+    double release_ms;
+    double total_ms;
+};
+
+struct benchmark_context
+{
+    ID2D1Factory *factory;
+    IWICImagingFactory *wic_factory;
+    ID2D1PathGeometry *geometry;
+    IDWriteFactory *dwrite_factory;
+    IDWriteTextFormat *text_format;
+    D2D1_RENDER_TARGET_PROPERTIES target_desc;
+};
+
+enum benchmark_metric
+{
+    METRIC_BITMAP,
+    METRIC_TARGET,
+    METRIC_BEGIN,
+    METRIC_PRIMITIVE,
+    METRIC_END,
+    METRIC_INSPECT,
+    METRIC_RELEASE,
+    METRIC_TOTAL,
+};
+
+static double performance_frequency;
+
+static double now_ms(void)
+{
+    LARGE_INTEGER counter;
+
+    QueryPerformanceCounter(&counter);
+    return counter.QuadPart * 1000.0 / performance_frequency;
+}
+
+static int compare_double(const void *a, const void *b)
+{
+    const double *value_a = a, *value_b = b;
+
+    return (*value_a > *value_b) - (*value_a < *value_b);
+}
+
+static unsigned int percentile_index(unsigned int count, unsigned int percentile)
+{
+    return (count * percentile + 99) / 100 - 1;
+}
+
+static double get_sample_metric(const struct benchmark_sample *sample, enum benchmark_metric metric)
+{
+    switch (metric)
+    {
+        case METRIC_BITMAP: return sample->bitmap_ms;
+        case METRIC_TARGET: return sample->target_ms;
+        case METRIC_BEGIN: return sample->begin_ms;
+        case METRIC_PRIMITIVE: return sample->primitive_ms;
+        case METRIC_END: return sample->end_ms;
+        case METRIC_INSPECT: return sample->inspect_ms;
+        case METRIC_RELEASE: return sample->release_ms;
+        case METRIC_TOTAL: return sample->total_ms;
+    }
+    return 0.0;
+}
+
+static const char *get_metric_name(enum benchmark_metric metric)
+{
+    static const char *const names[] =
+    {
+        "bitmap", "target", "begin", "primitive", "end", "inspect", "release", "total",
+    };
+
+    return names[metric];
+}
+
+static void set_identity(D2D1_MATRIX_3X2_F *matrix)
+{
+    memset(matrix, 0, sizeof(*matrix));
+    matrix->_11 = 1.0f;
+    matrix->_22 = 1.0f;
+}
+
+static void set_target_desc(D2D1_RENDER_TARGET_PROPERTIES *desc)
+{
+    memset(desc, 0, sizeof(*desc));
+    desc->type = D2D1_RENDER_TARGET_TYPE_DEFAULT;
+    desc->pixelFormat.format = DXGI_FORMAT_B8G8R8A8_UNORM;
+    desc->pixelFormat.alphaMode = D2D1_ALPHA_MODE_PREMULTIPLIED;
+    desc->dpiX = 96.0f;
+    desc->dpiY = 96.0f;
+    desc->usage = D2D1_RENDER_TARGET_USAGE_NONE;
+    desc->minLevel = D2D1_FEATURE_LEVEL_DEFAULT;
+}
+
+static HRESULT create_test_geometry(ID2D1Factory *factory, ID2D1PathGeometry **geometry)
+{
+    D2D1_QUADRATIC_BEZIER_SEGMENT curve;
+    ID2D1GeometrySink *sink = NULL;
+    D2D1_POINT_2F point;
+    HRESULT hr;
+
+    *geometry = NULL;
+    if (FAILED(hr = ID2D1Factory_CreatePathGeometry(factory, geometry)))
+        return hr;
+    if (FAILED(hr = ID2D1PathGeometry_Open(*geometry, &sink)))
+        goto done;
+
+    point.x = 3.25f;
+    point.y = 25.5f;
+    ID2D1GeometrySink_BeginFigure(sink, point, D2D1_FIGURE_BEGIN_FILLED);
+    point.x = 9.5f;
+    point.y = 4.25f;
+    ID2D1GeometrySink_AddLine(sink, point);
+    curve.point1.x = 17.0f;
+    curve.point1.y = 15.0f;
+    curve.point2.x = 28.25f;
+    curve.point2.y = 7.5f;
+    ID2D1GeometrySink_AddQuadraticBezier(sink, &curve);
+    point.x = 24.5f;
+    point.y = 27.25f;
+    ID2D1GeometrySink_AddLine(sink, point);
+    ID2D1GeometrySink_EndFigure(sink, D2D1_FIGURE_END_CLOSED);
+    hr = ID2D1GeometrySink_Close(sink);
+
+done:
+    if (sink) ID2D1GeometrySink_Release(sink);
+    if (FAILED(hr))
+    {
+        ID2D1PathGeometry_Release(*geometry);
+        *geometry = NULL;
+    }
+    return hr;
+}
+
+static HRESULT init_benchmark_context(struct benchmark_context *ctx, D2D1_FACTORY_TYPE factory_type)
+{
+    D2D1_FACTORY_OPTIONS factory_options = {0};
+    HRESULT hr;
+
+    memset(ctx, 0, sizeof(*ctx));
+    set_target_desc(&ctx->target_desc);
+
+    if (FAILED(hr = D2D1CreateFactory(factory_type, &IID_ID2D1Factory,
+            &factory_options, (void **)&ctx->factory)))
+        return hr;
+    if (FAILED(hr = CoCreateInstance(&CLSID_WICImagingFactory, NULL, CLSCTX_INPROC_SERVER,
+            &IID_IWICImagingFactory, (void **)&ctx->wic_factory)))
+        return hr;
+    if (FAILED(hr = create_test_geometry(ctx->factory, &ctx->geometry)))
+        return hr;
+    if (FAILED(hr = DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED,
+            &IID_IDWriteFactory, (IUnknown **)&ctx->dwrite_factory)))
+        return hr;
+    return IDWriteFactory_CreateTextFormat(ctx->dwrite_factory, L"Tahoma", NULL,
+            DWRITE_FONT_WEIGHT_NORMAL, DWRITE_FONT_STYLE_NORMAL, DWRITE_FONT_STRETCH_NORMAL,
+            7.0f, L"en-us", &ctx->text_format);
+}
+
+static void release_benchmark_context(struct benchmark_context *ctx)
+{
+    if (ctx->text_format) IDWriteTextFormat_Release(ctx->text_format);
+    if (ctx->dwrite_factory) IDWriteFactory_Release(ctx->dwrite_factory);
+    if (ctx->geometry) ID2D1PathGeometry_Release(ctx->geometry);
+    if (ctx->wic_factory) IWICImagingFactory_Release(ctx->wic_factory);
+    if (ctx->factory) ID2D1Factory_Release(ctx->factory);
+}
+
+static HRESULT inspect_bitmap(IWICBitmap *bitmap, unsigned int width, unsigned int height,
+        const D2D1_COLOR_F *background, HCRYPTHASH hash, unsigned int *invalid_pixels)
+{
+    IWICBitmapLock *lock = NULL;
+    UINT buffer_size, pitch;
+    BYTE *data;
+    HRESULT hr;
+    unsigned int x, y;
+
+    *invalid_pixels = 0;
+    if (FAILED(hr = IWICBitmap_Lock(bitmap, NULL, WICBitmapLockRead, &lock)))
+        return hr;
+    if (FAILED(hr = IWICBitmapLock_GetDataPointer(lock, &buffer_size, &data)))
+        goto done;
+    if (FAILED(hr = IWICBitmapLock_GetStride(lock, &pitch)))
+        goto done;
+
+    for (y = 0; y < height; ++y)
+    {
+        const BYTE *row = data + (size_t)y * pitch;
+
+        for (x = 0; x < width; ++x)
+        {
+            const BYTE *pixel = row + x * 4;
+            if (pixel[0] > pixel[3] || pixel[1] > pixel[3] || pixel[2] > pixel[3])
+                ++*invalid_pixels;
+        }
+        if (hash && !CryptHashData(hash, row, width * 4, 0))
+        {
+            hr = HRESULT_FROM_WIN32(GetLastError());
+            goto done;
+        }
+    }
+
+    /* The representative drawing never touches the upper-left pixel. */
+    if (background)
+    {
+        const BYTE *pixel = data;
+        BYTE expected_b = background->b * 255.0f + 0.5f;
+        BYTE expected_g = background->g * 255.0f + 0.5f;
+        BYTE expected_r = background->r * 255.0f + 0.5f;
+        BYTE expected_a = background->a * 255.0f + 0.5f;
+
+        if (abs(pixel[0] - expected_b) > 1 || abs(pixel[1] - expected_g) > 1
+                || abs(pixel[2] - expected_r) > 1 || abs(pixel[3] - expected_a) > 1)
+            ++*invalid_pixels;
+    }
+    hr = S_OK;
+
+done:
+    IWICBitmapLock_Release(lock);
+    return hr;
+}
+
+static HRESULT get_bitmap_pixel(IWICBitmap *bitmap, unsigned int x, unsigned int y, BYTE pixel[4])
+{
+    IWICBitmapLock *lock = NULL;
+    UINT buffer_size, pitch;
+    BYTE *data;
+    HRESULT hr;
+
+    if (FAILED(hr = IWICBitmap_Lock(bitmap, NULL, WICBitmapLockRead, &lock)))
+        return hr;
+    if (FAILED(hr = IWICBitmapLock_GetDataPointer(lock, &buffer_size, &data))
+            || FAILED(hr = IWICBitmapLock_GetStride(lock, &pitch)))
+        goto done;
+    memcpy(pixel, data + (size_t)y * pitch + x * 4, 4);
+
+done:
+    IWICBitmapLock_Release(lock);
+    return hr;
+}
+
+static HRESULT count_nonzero_alpha(IWICBitmap *bitmap, unsigned int width,
+        unsigned int height, unsigned int *count)
+{
+    IWICBitmapLock *lock = NULL;
+    UINT buffer_size, pitch;
+    BYTE *data;
+    unsigned int x, y;
+    HRESULT hr;
+
+    *count = 0;
+    if (FAILED(hr = IWICBitmap_Lock(bitmap, NULL, WICBitmapLockRead, &lock)))
+        return hr;
+    if (FAILED(hr = IWICBitmapLock_GetDataPointer(lock, &buffer_size, &data))
+            || FAILED(hr = IWICBitmapLock_GetStride(lock, &pitch)))
+        goto done;
+    for (y = 0; y < height; ++y)
+    {
+        const BYTE *row = data + (size_t)y * pitch;
+
+        for (x = 0; x < width; ++x)
+            if (row[x * 4 + 3])
+                ++*count;
+    }
+
+done:
+    IWICBitmapLock_Release(lock);
+    return hr;
+}
+
+static HRESULT draw_historical_thumbnail(struct benchmark_context *ctx,
+        unsigned int iteration, unsigned int size, struct benchmark_sample *sample)
+{
+    const D2D1_COLOR_F black = {0.05f, 0.05f, 0.05f, 1.0f};
+    const D2D1_COLOR_F white = {1.0f, 1.0f, 1.0f, 1.0f};
+    ID2D1SolidColorBrush *brush = NULL;
+    ID2D1RenderTarget *target = NULL;
+    IWICBitmap *bitmap = NULL;
+    D2D1_ELLIPSE ellipse;
+    double start, t;
+    unsigned int j;
+    HRESULT hr;
+
+    (void)iteration;
+    memset(sample, 0, sizeof(*sample));
+    start = now_ms();
+    t = start;
+    if (FAILED(hr = IWICImagingFactory_CreateBitmap(ctx->wic_factory, size, size,
+            &GUID_WICPixelFormat32bppPBGRA, WICBitmapCacheOnLoad, &bitmap)))
+        goto done;
+    sample->bitmap_ms = now_ms() - t;
+
+    t = now_ms();
+    if (FAILED(hr = ID2D1Factory_CreateWicBitmapRenderTarget(ctx->factory,
+            bitmap, &ctx->target_desc, &target)))
+        goto done;
+    if (FAILED(hr = ID2D1RenderTarget_CreateSolidColorBrush(target, &black, NULL, &brush)))
+        goto done;
+    sample->target_ms = now_ms() - t;
+
+    ellipse.point.x = size / 2.0f;
+    ellipse.point.y = size / 2.0f;
+    ellipse.radiusX = size == 17 ? 6.5f : size * 0.38f;
+    ellipse.radiusY = ellipse.radiusX;
+    t = now_ms();
+    ID2D1RenderTarget_BeginDraw(target);
+    sample->begin_ms = now_ms() - t;
+
+    t = now_ms();
+    ID2D1RenderTarget_Clear(target, &white);
+    for (j = 0; j < 3; ++j)
+    {
+        ellipse.point.x = size / 2.0f + ((int)j - 1) * 0.5f;
+        ID2D1RenderTarget_DrawEllipse(target, &ellipse, (ID2D1Brush *)brush, 1.0f, NULL);
+    }
+    sample->primitive_ms = now_ms() - t;
+
+    t = now_ms();
+    hr = ID2D1RenderTarget_EndDraw(target, NULL, NULL);
+    sample->end_ms = now_ms() - t;
+
+done:
+    t = now_ms();
+    if (brush) ID2D1SolidColorBrush_Release(brush);
+    if (target) ID2D1RenderTarget_Release(target);
+    if (bitmap) IWICBitmap_Release(bitmap);
+    sample->release_ms = now_ms() - t;
+    sample->total_ms = now_ms() - start;
+    return hr;
+}
+
+static HRESULT draw_representative_thumbnail(struct benchmark_context *ctx,
+        unsigned int iteration, unsigned int size, HCRYPTHASH hash,
+        struct benchmark_sample *sample, unsigned int *invalid_pixels)
+{
+    static const WCHAR text[] = L"Ab";
+    const D2D1_COLOR_F red = {0.85f, 0.05f, 0.02f, 1.0f};
+    const D2D1_COLOR_F blue = {0.02f, 0.15f, 0.85f, 1.0f};
+    const D2D1_COLOR_F ink = {0.08f, 0.9f, 0.25f, 0.75f};
+    const D2D1_COLOR_F *background = iteration & 1 ? &blue : &red;
+    ID2D1SolidColorBrush *brush = NULL;
+    ID2D1RenderTarget *target = NULL;
+    IWICBitmap *bitmap = NULL;
+    D2D1_MATRIX_3X2_F transform;
+    D2D1_ELLIPSE ellipse;
+    D2D1_RECT_F clip, text_rect;
+    double start, t;
+    HRESULT hr;
+
+    memset(sample, 0, sizeof(*sample));
+    start = now_ms();
+    t = start;
+    if (FAILED(hr = IWICImagingFactory_CreateBitmap(ctx->wic_factory, size, size,
+            &GUID_WICPixelFormat32bppPBGRA, WICBitmapCacheOnLoad, &bitmap)))
+        goto done;
+    sample->bitmap_ms = now_ms() - t;
+
+    t = now_ms();
+    if (FAILED(hr = ID2D1Factory_CreateWicBitmapRenderTarget(ctx->factory,
+            bitmap, &ctx->target_desc, &target)))
+        goto done;
+    if (FAILED(hr = ID2D1RenderTarget_CreateSolidColorBrush(target, &ink, NULL, &brush)))
+        goto done;
+    sample->target_ms = now_ms() - t;
+
+    t = now_ms();
+    ID2D1RenderTarget_BeginDraw(target);
+    sample->begin_ms = now_ms() - t;
+
+    t = now_ms();
+    ID2D1RenderTarget_Clear(target, background);
+    clip.left = 1.0f;
+    clip.top = 1.0f;
+    clip.right = size - 1.0f;
+    clip.bottom = size - 1.0f;
+    ID2D1RenderTarget_PushAxisAlignedClip(target, &clip, D2D1_ANTIALIAS_MODE_ALIASED);
+    set_identity(&transform);
+    transform._11 = iteration & 2 ? 0.95f : 1.0f;
+    transform._22 = iteration & 2 ? 1.05f : 1.0f;
+    transform._31 = iteration & 4 ? 0.35f : 0.0f;
+    transform._32 = iteration & 4 ? 0.2f : 0.0f;
+    ID2D1RenderTarget_SetTransform(target, &transform);
+    ellipse.point.x = size * 0.5f;
+    ellipse.point.y = size * 0.5f;
+    ellipse.radiusX = size * 0.32f;
+    ellipse.radiusY = size * 0.27f;
+    ID2D1RenderTarget_FillEllipse(target, &ellipse, (ID2D1Brush *)brush);
+    ID2D1RenderTarget_DrawEllipse(target, &ellipse, (ID2D1Brush *)brush, 1.0f, NULL);
+    ID2D1RenderTarget_FillGeometry(target, (ID2D1Geometry *)ctx->geometry,
+            (ID2D1Brush *)brush, NULL);
+    set_identity(&transform);
+    ID2D1RenderTarget_SetTransform(target, &transform);
+    text_rect.left = 2.0f;
+    text_rect.top = size > 17 ? size - 11.0f : size - 9.0f;
+    text_rect.right = size - 2.0f;
+    text_rect.bottom = size - 1.0f;
+    ID2D1RenderTarget_DrawText(target, text, ARRAY_SIZE(text) - 1, ctx->text_format,
+            &text_rect, (ID2D1Brush *)brush, D2D1_DRAW_TEXT_OPTIONS_CLIP,
+            DWRITE_MEASURING_MODE_NATURAL);
+    ID2D1RenderTarget_PopAxisAlignedClip(target);
+    sample->primitive_ms = now_ms() - t;
+
+    t = now_ms();
+    hr = ID2D1RenderTarget_EndDraw(target, NULL, NULL);
+    sample->end_ms = now_ms() - t;
+    if (FAILED(hr))
+        goto done;
+
+    t = now_ms();
+    hr = inspect_bitmap(bitmap, size, size, background, hash, invalid_pixels);
+    sample->inspect_ms = now_ms() - t;
+
+done:
+    t = now_ms();
+    if (brush) ID2D1SolidColorBrush_Release(brush);
+    if (target) ID2D1RenderTarget_Release(target);
+    if (bitmap) IWICBitmap_Release(bitmap);
+    sample->release_ms = now_ms() - t;
+    sample->total_ms = now_ms() - start;
+    return hr;
+}
+
+static HRESULT draw_office_glyph_thumbnail(struct benchmark_context *ctx,
+        unsigned int iteration, unsigned int size, HCRYPTHASH hash,
+        struct benchmark_sample *sample, unsigned int *invalid_pixels)
+{
+    static const WCHAR text[] = L"Ab";
+    const D2D1_COLOR_F clear = {0.0f, 0.0f, 0.0f, 0.0f};
+    const D2D1_COLOR_F ink = {0.1f, 0.1f, 0.1f, 1.0f};
+    ID2D1SolidColorBrush *brush = NULL;
+    ID2D1RenderTarget *target = NULL;
+    IWICBitmap *bitmap = NULL;
+    D2D1_RECT_F text_rect;
+    double start, t;
+    HRESULT hr;
+
+    (void)iteration;
+    memset(sample, 0, sizeof(*sample));
+    start = now_ms();
+    t = start;
+    if (FAILED(hr = IWICImagingFactory_CreateBitmap(ctx->wic_factory, size, size,
+            &GUID_WICPixelFormat32bppPBGRA, WICBitmapCacheOnLoad, &bitmap)))
+        goto done;
+    sample->bitmap_ms = now_ms() - t;
+
+    t = now_ms();
+    if (FAILED(hr = ID2D1Factory_CreateWicBitmapRenderTarget(ctx->factory,
+            bitmap, &ctx->target_desc, &target)))
+        goto done;
+    if (FAILED(hr = ID2D1RenderTarget_CreateSolidColorBrush(target, &ink, NULL, &brush)))
+        goto done;
+    ID2D1RenderTarget_SetTextAntialiasMode(target, D2D1_TEXT_ANTIALIAS_MODE_ALIASED);
+    sample->target_ms = now_ms() - t;
+
+    t = now_ms();
+    ID2D1RenderTarget_BeginDraw(target);
+    sample->begin_ms = now_ms() - t;
+
+    t = now_ms();
+    ID2D1RenderTarget_Clear(target, &clear);
+    text_rect.left = 0.0f;
+    text_rect.top = 0.0f;
+    text_rect.right = size;
+    text_rect.bottom = size;
+    ID2D1RenderTarget_DrawText(target, text, ARRAY_SIZE(text) - 1, ctx->text_format,
+            &text_rect, (ID2D1Brush *)brush, D2D1_DRAW_TEXT_OPTIONS_NONE,
+            DWRITE_MEASURING_MODE_NATURAL);
+    sample->primitive_ms = now_ms() - t;
+
+    t = now_ms();
+    hr = ID2D1RenderTarget_EndDraw(target, NULL, NULL);
+    sample->end_ms = now_ms() - t;
+    if (FAILED(hr))
+        goto done;
+
+    t = now_ms();
+    hr = inspect_bitmap(bitmap, size, size, NULL, hash, invalid_pixels);
+    sample->inspect_ms = now_ms() - t;
+
+done:
+    t = now_ms();
+    if (brush) ID2D1SolidColorBrush_Release(brush);
+    if (target) ID2D1RenderTarget_Release(target);
+    if (bitmap) IWICBitmap_Release(bitmap);
+    sample->release_ms = now_ms() - t;
+    sample->total_ms = now_ms() - start;
+    return hr;
+}
+
+static void print_summary(const char *mode, unsigned int size,
+        const struct benchmark_sample *samples, unsigned int count)
+{
+    double *values;
+    enum benchmark_metric metric;
+    unsigned int i, warm_count = count - 1;
+
+    if (!(values = malloc(warm_count * sizeof(*values))))
+        return;
+
+    for (metric = METRIC_BITMAP; metric <= METRIC_TOTAL; ++metric)
+    {
+        double sum = 0.0;
+
+        for (i = 0; i < warm_count; ++i)
+        {
+            values[i] = get_sample_metric(&samples[i + 1], metric);
+            sum += values[i];
+        }
+        qsort(values, warm_count, sizeof(*values), compare_double);
+        printf("tiny_wic_summary,mode=%s,size=%u,metric=%s,count=%u,cold_ms=%.6f,"
+                "warm_mean_ms=%.6f,warm_p50_ms=%.6f,warm_p95_ms=%.6f,warm_p99_ms=%.6f,"
+                "warm_max_ms=%.6f,historical_baseline_ms=11.3,optimized_0_1_10_ms=2.2\n",
+                mode, size, get_metric_name(metric), count, get_sample_metric(&samples[0], metric),
+                sum / warm_count, values[percentile_index(warm_count, 50)],
+                values[percentile_index(warm_count, 95)], values[percentile_index(warm_count, 99)],
+                values[warm_count - 1]);
+    }
+    free(values);
+}
+
+static unsigned int get_iteration_count(unsigned int default_count)
+{
+    const char *value = getenv("WINETEST_WIC_ITERATIONS");
+    char *end;
+    unsigned long count;
+
+    if (!value || !*value)
+        return default_count;
+    count = strtoul(value, &end, 10);
+    if (*end || count < 2 || count > 10000)
+    {
+        printf("tiny_wic_error,invalid_iterations=%s\n", value);
+        return default_count;
+    }
+    return count;
+}
+
+static void run_benchmark_mode(struct benchmark_context *ctx, const char *mode,
+        unsigned int size, unsigned int default_count)
+{
+    HCRYPTPROV provider = 0;
+    HCRYPTHASH hash = 0;
+    struct benchmark_sample *samples;
+    unsigned int *sample_invalid_pixels;
+    unsigned int attempted, completed, count, i, invalid_pixels = 0;
+    HRESULT hr = S_OK;
+    BYTE digest[20];
+    DWORD digest_size;
+    char digest_string[41];
+    double wall_elapsed, wall_start;
+
+    count = get_iteration_count(default_count);
+    if (!(samples = calloc(count, sizeof(*samples))))
+    {
+        printf("tiny_wic_error,mode=%s,size=%u,out_of_memory=1\n", mode, size);
+        return;
+    }
+    if (!(sample_invalid_pixels = calloc(count, sizeof(*sample_invalid_pixels))))
+    {
+        printf("tiny_wic_error,mode=%s,size=%u,out_of_memory=1\n", mode, size);
+        free(samples);
+        return;
+    }
+
+    if (!strcmp(mode, "representative") || !strcmp(mode, "office-glyph"))
+    {
+        if (!CryptAcquireContextW(&provider, NULL, NULL, PROV_RSA_AES, CRYPT_VERIFYCONTEXT)
+                || !CryptCreateHash(provider, CALG_SHA1, 0, 0, &hash))
+        {
+            printf("tiny_wic_error,mode=%s,size=%u,crypto_error=%lu\n", mode, size, GetLastError());
+            goto done;
+        }
+    }
+
+    wall_start = now_ms();
+    for (i = 0; i < count; ++i)
+    {
+        unsigned int sample_invalid = 0;
+
+        if (!strcmp(mode, "historical"))
+            hr = draw_historical_thumbnail(ctx, i, size, &samples[i]);
+        else if (!strcmp(mode, "office-glyph"))
+            hr = draw_office_glyph_thumbnail(ctx, i, size, hash,
+                    &samples[i], &sample_invalid);
+        else
+            hr = draw_representative_thumbnail(ctx, i, size, hash, &samples[i], &sample_invalid);
+        invalid_pixels += sample_invalid;
+        sample_invalid_pixels[i] = sample_invalid;
+        if (FAILED(hr))
+            break;
+    }
+    wall_elapsed = now_ms() - wall_start;
+    attempted = i < count ? i + 1 : count;
+    completed = FAILED(hr) ? i : count;
+    for (i = 0; i < attempted; ++i)
+        printf("tiny_wic_sample,mode=%s,size=%u,index=%u,bitmap_ms=%.6f,target_ms=%.6f,"
+                "begin_ms=%.6f,primitive_ms=%.6f,end_ms=%.6f,inspect_ms=%.6f,"
+                "release_ms=%.6f,total_ms=%.6f,invalid_pixels=%u\n",
+                mode, size, i, samples[i].bitmap_ms, samples[i].target_ms,
+                samples[i].begin_ms, samples[i].primitive_ms, samples[i].end_ms,
+                samples[i].inspect_ms, samples[i].release_ms, samples[i].total_ms,
+                sample_invalid_pixels[i]);
+    printf("tiny_wic_run,mode=%s,size=%u,completed=%u,requested=%u,hr=%#lx,wall_ms=%.6f,"
+            "per_target_ms=%.6f,invalid_pixels=%u,historical_baseline_ms=11.3,"
+            "optimized_0_1_10_ms=2.2\n", mode, size, completed, count, hr, wall_elapsed,
+            completed ? wall_elapsed / completed : 0.0, invalid_pixels);
+    if (completed > 1)
+        print_summary(mode, size, samples, completed);
+
+    if (hash && completed == count)
+    {
+        digest_size = sizeof(digest);
+        if (CryptGetHashParam(hash, HP_HASHVAL, digest, &digest_size, 0))
+        {
+            for (i = 0; i < digest_size; ++i)
+                sprintf(digest_string + i * 2, "%02x", digest[i]);
+            digest_string[digest_size * 2] = 0;
+            printf("tiny_wic_pixels,mode=%s,size=%u,sha1=%s,invalid_pixels=%u\n",
+                    mode, size, digest_string, invalid_pixels);
+        }
+    }
+
+done:
+    if (hash) CryptDestroyHash(hash);
+    if (provider) CryptReleaseContext(provider, 0);
+    free(sample_invalid_pixels);
+    free(samples);
+}
+
+static HRESULT draw_and_check_solid(struct benchmark_context *ctx, IWICBitmap *bitmap,
+        const D2D1_COLOR_F *colour)
+{
+    ID2D1RenderTarget *target = NULL;
+    unsigned int invalid_pixels;
+    HRESULT hr;
+
+    if (FAILED(hr = ID2D1Factory_CreateWicBitmapRenderTarget(ctx->factory,
+            bitmap, &ctx->target_desc, &target)))
+        return hr;
+    ID2D1RenderTarget_BeginDraw(target);
+    ID2D1RenderTarget_Clear(target, colour);
+    hr = ID2D1RenderTarget_EndDraw(target, NULL, NULL);
+    if (SUCCEEDED(hr))
+        hr = inspect_bitmap(bitmap, 17, 17, colour, 0, &invalid_pixels);
+    if (SUCCEEDED(hr) && invalid_pixels)
+        hr = E_FAIL;
+    ID2D1RenderTarget_Release(target);
+    return hr;
+}
+
+static void test_tiny_wic_sequences(void)
+{
+    const D2D1_COLOR_F red = {1.0f, 0.0f, 0.0f, 1.0f};
+    const D2D1_COLOR_F blue = {0.0f, 0.0f, 1.0f, 1.0f};
+    struct benchmark_context ctx;
+    ID2D1RenderTarget *target = NULL;
+    ID2D1SolidColorBrush *brush = NULL;
+    IWICBitmap *bitmap = NULL;
+    D2D1_MATRIX_3X2_F transform, identity;
+    D2D1_RECT_F rect;
+    D2D1_TAG tag1, tag2;
+    BYTE pixel[4];
+    unsigned int nonzero_alpha;
+    HRESULT hr, nested_hr1, nested_hr2;
+
+    hr = init_benchmark_context(&ctx, D2D1_FACTORY_TYPE_SINGLE_THREADED);
+    ok(hr == S_OK, "Failed to initialize the WIC test context, hr %#lx.\n", hr);
+    if (FAILED(hr))
+    {
+        release_benchmark_context(&ctx);
+        return;
+    }
+
+    hr = IWICImagingFactory_CreateBitmap(ctx.wic_factory, 17, 17,
+            &GUID_WICPixelFormat32bppPBGRA, WICBitmapCacheOnLoad, &bitmap);
+    ok(hr == S_OK, "Failed to create a WIC bitmap, hr %#lx.\n", hr);
+    if (SUCCEEDED(hr))
+    {
+        hr = draw_and_check_solid(&ctx, bitmap, &red);
+        ok(hr == S_OK, "Failed to draw the initial WIC contents, hr %#lx.\n", hr);
+        IWICBitmap_Release(bitmap);
+        bitmap = NULL;
+    }
+
+    /* Releasing a target with an abandoned draw must not retain a WIC lock or
+     * poison later independent targets. */
+    hr = IWICImagingFactory_CreateBitmap(ctx.wic_factory, 17, 17,
+            &GUID_WICPixelFormat32bppPBGRA, WICBitmapCacheOnLoad, &bitmap);
+    ok(hr == S_OK, "Failed to create a WIC bitmap, hr %#lx.\n", hr);
+    if (SUCCEEDED(hr))
+        hr = ID2D1Factory_CreateWicBitmapRenderTarget(ctx.factory,
+                bitmap, &ctx.target_desc, &target);
+    ok(hr == S_OK, "Failed to create a WIC target, hr %#lx.\n", hr);
+    if (SUCCEEDED(hr))
+    {
+        ID2D1RenderTarget_BeginDraw(target);
+        ID2D1RenderTarget_Clear(target, &red);
+        ID2D1RenderTarget_Release(target);
+        target = NULL;
+        hr = draw_and_check_solid(&ctx, bitmap, &blue);
+        ok(hr == S_OK, "An abandoned draw poisoned the next WIC target, hr %#lx.\n", hr);
+    }
+    if (bitmap)
+    {
+        IWICBitmap_Release(bitmap);
+        bitmap = NULL;
+    }
+
+    hr = IWICImagingFactory_CreateBitmap(ctx.wic_factory, 17, 17,
+            &GUID_WICPixelFormat32bppPBGRA, WICBitmapCacheOnLoad, &bitmap);
+    ok(hr == S_OK, "Failed to create a WIC bitmap, hr %#lx.\n", hr);
+    if (SUCCEEDED(hr))
+        hr = ID2D1Factory_CreateWicBitmapRenderTarget(ctx.factory,
+                bitmap, &ctx.target_desc, &target);
+    ok(hr == S_OK, "Failed to create a WIC target, hr %#lx.\n", hr);
+    if (SUCCEEDED(hr))
+    {
+        ID2D1RenderTarget_BeginDraw(target);
+        ID2D1RenderTarget_BeginDraw(target);
+        ID2D1RenderTarget_Clear(target, &red);
+        nested_hr1 = ID2D1RenderTarget_EndDraw(target, NULL, NULL);
+        nested_hr2 = ID2D1RenderTarget_EndDraw(target, NULL, NULL);
+        ok(nested_hr1 == D2DERR_WRONG_STATE,
+                "Got unexpected first nested EndDraw result %#lx.\n", nested_hr1);
+        ok(nested_hr2 == D2DERR_WRONG_STATE,
+                "Got unexpected second nested EndDraw result %#lx.\n", nested_hr2);
+
+        ID2D1RenderTarget_BeginDraw(target);
+        ID2D1RenderTarget_Clear(target, &blue);
+        hr = ID2D1RenderTarget_EndDraw(target, NULL, NULL);
+        ok(hr == S_OK, "The WIC target did not recover after nested BeginDraw, hr %#lx.\n", hr);
+        ID2D1RenderTarget_Release(target);
+        target = NULL;
+    }
+    if (bitmap)
+    {
+        IWICBitmap_Release(bitmap);
+        bitmap = NULL;
+    }
+
+    /* Fresh wrappers must start with default drawing state. */
+    hr = IWICImagingFactory_CreateBitmap(ctx.wic_factory, 17, 17,
+            &GUID_WICPixelFormat32bppPBGRA, WICBitmapCacheOnLoad, &bitmap);
+    ok(hr == S_OK, "Failed to create a WIC bitmap, hr %#lx.\n", hr);
+    if (SUCCEEDED(hr))
+        hr = ID2D1Factory_CreateWicBitmapRenderTarget(ctx.factory,
+                bitmap, &ctx.target_desc, &target);
+    ok(hr == S_OK, "Failed to create a WIC target, hr %#lx.\n", hr);
+    if (SUCCEEDED(hr))
+    {
+        set_identity(&transform);
+        transform._11 = 2.0f;
+        transform._22 = 2.0f;
+        transform._31 = 3.0f;
+        transform._32 = 4.0f;
+        ID2D1RenderTarget_SetTransform(target, &transform);
+        ID2D1RenderTarget_SetTags(target, 123, 456);
+        ID2D1RenderTarget_SetAntialiasMode(target, D2D1_ANTIALIAS_MODE_ALIASED);
+        ID2D1RenderTarget_Release(target);
+        target = NULL;
+        IWICBitmap_Release(bitmap);
+        bitmap = NULL;
+    }
+
+    hr = IWICImagingFactory_CreateBitmap(ctx.wic_factory, 17, 17,
+            &GUID_WICPixelFormat32bppPBGRA, WICBitmapCacheOnLoad, &bitmap);
+    ok(hr == S_OK, "Failed to create a WIC bitmap, hr %#lx.\n", hr);
+    if (SUCCEEDED(hr))
+        hr = ID2D1Factory_CreateWicBitmapRenderTarget(ctx.factory,
+                bitmap, &ctx.target_desc, &target);
+    ok(hr == S_OK, "Failed to create a WIC target, hr %#lx.\n", hr);
+    if (SUCCEEDED(hr))
+    {
+        ID2D1RenderTarget_GetTransform(target, &transform);
+        set_identity(&identity);
+        ok(!memcmp(&transform, &identity, sizeof(identity)), "Unexpected initial WIC transform.\n");
+        ID2D1RenderTarget_GetTags(target, &tag1, &tag2);
+        ok(!tag1 && !tag2, "Unexpected initial WIC tags %s, %s.\n",
+                wine_dbgstr_longlong(tag1), wine_dbgstr_longlong(tag2));
+        ok(ID2D1RenderTarget_GetAntialiasMode(target) == D2D1_ANTIALIAS_MODE_PER_PRIMITIVE,
+                "Unexpected initial WIC antialias mode.\n");
+
+        hr = ID2D1RenderTarget_CreateSolidColorBrush(target, &blue, NULL, &brush);
+        ok(hr == S_OK, "Failed to create a fallback brush, hr %#lx.\n", hr);
+        if (SUCCEEDED(hr))
+        {
+            ID2D1RenderTarget_BeginDraw(target);
+            ID2D1RenderTarget_Clear(target, &red);
+            hr = ID2D1RenderTarget_EndDraw(target, NULL, NULL);
+            ok(hr == S_OK, "Failed to complete the CPU WIC transaction, hr %#lx.\n", hr);
+
+            rect.left = 0.0f;
+            rect.top = 0.0f;
+            rect.right = 8.0f;
+            rect.bottom = 17.0f;
+            ID2D1RenderTarget_BeginDraw(target);
+            ID2D1RenderTarget_FillRectangle(target, &rect, (ID2D1Brush *)brush);
+            hr = ID2D1RenderTarget_EndDraw(target, NULL, NULL);
+            ok(hr == S_OK, "Failed to complete the GPU fallback transaction, hr %#lx.\n", hr);
+
+            if (SUCCEEDED(hr = get_bitmap_pixel(bitmap, 2, 8, pixel)))
+                ok(pixel[0] == 255 && !pixel[1] && !pixel[2] && pixel[3] == 255,
+                        "Unexpected fallback pixel %u,%u,%u,%u.\n",
+                        pixel[0], pixel[1], pixel[2], pixel[3]);
+            else
+                ok(0, "Failed to read the fallback pixel, hr %#lx.\n", hr);
+            if (SUCCEEDED(hr = get_bitmap_pixel(bitmap, 14, 8, pixel)))
+                ok(!pixel[0] && !pixel[1] && pixel[2] == 255 && pixel[3] == 255,
+                        "Unexpected preserved pixel %u,%u,%u,%u.\n",
+                        pixel[0], pixel[1], pixel[2], pixel[3]);
+            else
+                ok(0, "Failed to read the preserved pixel, hr %#lx.\n", hr);
+
+            rect.left = 1.0f;
+            rect.top = 1.0f;
+            rect.right = 16.0f;
+            rect.bottom = 16.0f;
+            ID2D1RenderTarget_BeginDraw(target);
+            ID2D1RenderTarget_Clear(target, &red);
+            ID2D1RenderTarget_PushAxisAlignedClip(target, &rect, D2D1_ANTIALIAS_MODE_ALIASED);
+            ID2D1RenderTarget_Clear(target, &blue);
+            ID2D1RenderTarget_PopAxisAlignedClip(target);
+            hr = ID2D1RenderTarget_EndDraw(target, NULL, NULL);
+            ok(hr == S_OK, "Failed to complete the clipped fallback transaction, hr %#lx.\n", hr);
+            if (SUCCEEDED(hr = get_bitmap_pixel(bitmap, 0, 0, pixel)))
+                ok(!pixel[0] && !pixel[1] && pixel[2] == 255 && pixel[3] == 255,
+                        "Unexpected unclipped pixel %u,%u,%u,%u.\n",
+                        pixel[0], pixel[1], pixel[2], pixel[3]);
+            else
+                ok(0, "Failed to read the unclipped pixel, hr %#lx.\n", hr);
+            if (SUCCEEDED(hr = get_bitmap_pixel(bitmap, 8, 8, pixel)))
+                ok(pixel[0] == 255 && !pixel[1] && !pixel[2] && pixel[3] == 255,
+                        "Unexpected clipped pixel %u,%u,%u,%u.\n",
+                        pixel[0], pixel[1], pixel[2], pixel[3]);
+            else
+                ok(0, "Failed to read the clipped pixel, hr %#lx.\n", hr);
+
+            ID2D1RenderTarget_SetTextAntialiasMode(target, D2D1_TEXT_ANTIALIAS_MODE_ALIASED);
+            ID2D1RenderTarget_BeginDraw(target);
+            ID2D1RenderTarget_Clear(target, NULL);
+            ID2D1RenderTarget_DrawText(target, L"A", 1, ctx.text_format, &rect,
+                    (ID2D1Brush *)brush, D2D1_DRAW_TEXT_OPTIONS_NONE,
+                    DWRITE_MEASURING_MODE_NATURAL);
+            hr = ID2D1RenderTarget_EndDraw(target, NULL, NULL);
+            ok(hr == S_OK, "Failed to complete the CPU glyph transaction, hr %#lx.\n", hr);
+            if (SUCCEEDED(hr = count_nonzero_alpha(bitmap, 17, 17, &nonzero_alpha)))
+                ok(nonzero_alpha, "The CPU glyph transaction produced no visible pixels.\n");
+            else
+                ok(0, "Failed to inspect the CPU glyph transaction, hr %#lx.\n", hr);
+        }
+    }
+
+    if (brush) ID2D1SolidColorBrush_Release(brush);
+    if (target) ID2D1RenderTarget_Release(target);
+    if (bitmap) IWICBitmap_Release(bitmap);
+    release_benchmark_context(&ctx);
+}
+
+struct thread_test_context
+{
+    ID2D1Factory *factory;
+    D2D1_RENDER_TARGET_PROPERTIES target_desc;
+    LONG failures;
+};
+
+static DWORD WINAPI wic_thread_proc(void *param)
+{
+    struct thread_test_context *ctx = param;
+    const D2D1_COLOR_F colour = {0.2f, 0.4f, 0.8f, 1.0f};
+    IWICImagingFactory *wic_factory = NULL;
+    unsigned int i;
+    HRESULT hr;
+
+    CoInitializeEx(NULL, COINIT_MULTITHREADED);
+    hr = CoCreateInstance(&CLSID_WICImagingFactory, NULL, CLSCTX_INPROC_SERVER,
+            &IID_IWICImagingFactory, (void **)&wic_factory);
+    if (FAILED(hr))
+        InterlockedIncrement(&ctx->failures);
+
+    for (i = 0; i < 8 && wic_factory; ++i)
+    {
+        ID2D1RenderTarget *target = NULL;
+        IWICBitmap *bitmap = NULL;
+
+        hr = IWICImagingFactory_CreateBitmap(wic_factory, 32, 32,
+                &GUID_WICPixelFormat32bppPBGRA, WICBitmapCacheOnLoad, &bitmap);
+        if (SUCCEEDED(hr))
+            hr = ID2D1Factory_CreateWicBitmapRenderTarget(ctx->factory,
+                    bitmap, &ctx->target_desc, &target);
+        if (SUCCEEDED(hr))
+        {
+            ID2D1RenderTarget_BeginDraw(target);
+            ID2D1RenderTarget_Clear(target, &colour);
+            hr = ID2D1RenderTarget_EndDraw(target, NULL, NULL);
+        }
+        if (FAILED(hr))
+            InterlockedIncrement(&ctx->failures);
+        if (target) ID2D1RenderTarget_Release(target);
+        if (bitmap) IWICBitmap_Release(bitmap);
+    }
+
+    if (wic_factory) IWICImagingFactory_Release(wic_factory);
+    CoUninitialize();
+    return 0;
+}
+
+static void test_tiny_wic_multithreaded(void)
+{
+    D2D1_FACTORY_OPTIONS factory_options = {0};
+    struct thread_test_context ctx;
+    HANDLE threads[2];
+    HRESULT hr;
+    DWORD ret;
+    unsigned int i;
+
+    memset(&ctx, 0, sizeof(ctx));
+    memset(threads, 0, sizeof(threads));
+    set_target_desc(&ctx.target_desc);
+    hr = D2D1CreateFactory(D2D1_FACTORY_TYPE_MULTI_THREADED,
+            &IID_ID2D1Factory, &factory_options, (void **)&ctx.factory);
+    ok(hr == S_OK, "Failed to create a multithreaded D2D factory, hr %#lx.\n", hr);
+    if (FAILED(hr))
+        return;
+
+    for (i = 0; i < ARRAY_SIZE(threads); ++i)
+    {
+        threads[i] = CreateThread(NULL, 0, wic_thread_proc, &ctx, 0, NULL);
+        ok(!!threads[i], "Failed to create WIC worker %u.\n", i);
+    }
+    for (i = 0; i < ARRAY_SIZE(threads); ++i)
+    {
+        if (!threads[i])
+            continue;
+        ret = WaitForSingleObject(threads[i], 30000);
+        ok(ret == WAIT_OBJECT_0, "Unexpected WIC worker %u wait result %#lx.\n", i, ret);
+        CloseHandle(threads[i]);
+    }
+    ok(!ctx.failures, "Got %ld multithreaded WIC failures.\n", ctx.failures);
+    ID2D1Factory_Release(ctx.factory);
+}
+
+START_TEST(wic)
+{
+    const char *mode;
+    struct benchmark_context ctx;
+    LARGE_INTEGER frequency;
+    HRESULT hr;
+
+    QueryPerformanceFrequency(&frequency);
+    performance_frequency = frequency.QuadPart;
+    CoInitializeEx(NULL, COINIT_APARTMENTTHREADED);
+
+    if (getenv("WINETEST_WIC_BENCHMARK"))
+    {
+        hr = init_benchmark_context(&ctx, D2D1_FACTORY_TYPE_SINGLE_THREADED);
+        ok(hr == S_OK, "Failed to initialize the WIC benchmark, hr %#lx.\n", hr);
+        if (SUCCEEDED(hr))
+        {
+            mode = getenv("WINETEST_WIC_MODE");
+            if (!mode || !strcmp(mode, "all") || !strcmp(mode, "historical"))
+                run_benchmark_mode(&ctx, "historical", 17, HISTORICAL_ITERATIONS);
+            if (!mode || !strcmp(mode, "all") || !strcmp(mode, "representative"))
+            {
+                run_benchmark_mode(&ctx, "representative", 17, REPRESENTATIVE_ITERATIONS);
+                run_benchmark_mode(&ctx, "representative", 32, REPRESENTATIVE_ITERATIONS);
+            }
+            if (!mode || !strcmp(mode, "all") || !strcmp(mode, "office-glyph"))
+                run_benchmark_mode(&ctx, "office-glyph", 17, OFFICE_GLYPH_ITERATIONS);
+            release_benchmark_context(&ctx);
+        }
+        CoUninitialize();
+        return;
+    }
+
+    test_tiny_wic_sequences();
+    test_tiny_wic_multithreaded();
+    CoUninitialize();
+}

--- a/dlls/d2d1/tests/wic.c
+++ b/dlls/d2d1/tests/wic.c
@@ -16,6 +16,7 @@
 
 #define COBJMACROS
 #include "d2d1.h"
+#include "d2d1_1.h"
 #include "dwrite.h"
 #include "wincrypt.h"
 #include "wincodec.h"
@@ -693,8 +694,13 @@ static void test_tiny_wic_sequences(void)
     const D2D1_COLOR_F blue = {0.0f, 0.0f, 1.0f, 1.0f};
     struct benchmark_context ctx;
     ID2D1Bitmap *copied_bitmap = NULL;
+    ID2D1Bitmap *direct_copied_bitmap = NULL;
+    ID2D1Bitmap *target_bitmap = NULL;
+    ID2D1DeviceContext *device_context = NULL;
+    ID2D1Image *target_image = NULL;
     ID2D1RenderTarget *target = NULL;
     ID2D1SolidColorBrush *brush = NULL;
+    IWICBitmapLock *bitmap_lock = NULL;
     IWICBitmap *bitmap = NULL;
     D2D1_BITMAP_PROPERTIES bitmap_props;
     D2D1_MATRIX_3X2_F transform, identity;
@@ -758,6 +764,11 @@ static void test_tiny_wic_sequences(void)
     if (SUCCEEDED(hr))
     {
         ID2D1RenderTarget_BeginDraw(target);
+        ID2D1RenderTarget_Clear(target, &blue);
+        hr = ID2D1RenderTarget_EndDraw(target, NULL, NULL);
+        ok(hr == S_OK, "Failed to initialize the nested-draw target, hr %#lx.\n", hr);
+
+        ID2D1RenderTarget_BeginDraw(target);
         ID2D1RenderTarget_BeginDraw(target);
         ID2D1RenderTarget_Clear(target, &red);
         nested_hr1 = ID2D1RenderTarget_EndDraw(target, NULL, NULL);
@@ -766,6 +777,15 @@ static void test_tiny_wic_sequences(void)
                 "Got unexpected first nested EndDraw result %#lx.\n", nested_hr1);
         ok(nested_hr2 == D2DERR_WRONG_STATE,
                 "Got unexpected second nested EndDraw result %#lx.\n", nested_hr2);
+        hr = ID2D1RenderTarget_Flush(target, NULL, NULL);
+        ok(hr == D2DERR_WRONG_STATE,
+                "Got unexpected Flush result after nested BeginDraw %#lx.\n", hr);
+        if (SUCCEEDED(hr = get_bitmap_pixel(bitmap, 8, 8, pixel)))
+            ok(pixel[0] == 255 && !pixel[1] && !pixel[2] && pixel[3] == 255,
+                    "Invalid nested draw changed pixel %u,%u,%u,%u.\n",
+                    pixel[0], pixel[1], pixel[2], pixel[3]);
+        else
+            ok(0, "Failed to inspect the nested-draw target, hr %#lx.\n", hr);
 
         ID2D1RenderTarget_BeginDraw(target);
         ID2D1RenderTarget_Clear(target, &blue);
@@ -831,12 +851,78 @@ static void test_tiny_wic_sequences(void)
             hr = ID2D1RenderTarget_EndDraw(target, NULL, NULL);
             ok(hr == S_OK, "Failed to complete the CPU WIC transaction, hr %#lx.\n", hr);
 
+            hr = ID2D1RenderTarget_QueryInterface(target, &IID_ID2D1DeviceContext,
+                    (void **)&device_context);
+            ok(hr == S_OK, "Failed to query the WIC device context, hr %#lx.\n", hr);
+            if (SUCCEEDED(hr))
+            {
+                ID2D1DeviceContext_GetTarget(device_context, &target_image);
+                ok(!!target_image, "The WIC device context has no target image.\n");
+                if (target_image)
+                {
+                    hr = ID2D1Image_QueryInterface(target_image, &IID_ID2D1Bitmap,
+                            (void **)&target_bitmap);
+                    ok(hr == S_OK, "Failed to query the WIC target bitmap, hr %#lx.\n", hr);
+                }
+            }
+
             memset(&bitmap_props, 0, sizeof(bitmap_props));
             bitmap_props.pixelFormat = ctx.target_desc.pixelFormat;
             bitmap_props.dpiX = 96.0f;
             bitmap_props.dpiY = 96.0f;
             bitmap_size.width = 17;
             bitmap_size.height = 17;
+            hr = ID2D1RenderTarget_CreateBitmap(target, bitmap_size, NULL, 0,
+                    &bitmap_props, &direct_copied_bitmap);
+            ok(hr == S_OK, "Failed to create the direct WIC copy bitmap, hr %#lx.\n", hr);
+            if (SUCCEEDED(hr) && target_bitmap)
+            {
+                hr = ID2D1Bitmap_CopyFromBitmap(direct_copied_bitmap, NULL, target_bitmap, NULL);
+                ok(hr == S_OK, "Failed to copy from the WIC target bitmap, hr %#lx.\n", hr);
+            }
+            if (direct_copied_bitmap)
+            {
+                ID2D1RenderTarget_BeginDraw(target);
+                ID2D1RenderTarget_Clear(target, &blue);
+                ID2D1RenderTarget_DrawBitmap(target, direct_copied_bitmap, NULL, 1.0f,
+                        D2D1_BITMAP_INTERPOLATION_MODE_LINEAR, NULL);
+                hr = ID2D1RenderTarget_EndDraw(target, NULL, NULL);
+                ok(hr == S_OK, "Failed to draw the direct WIC copy, hr %#lx.\n", hr);
+                if (SUCCEEDED(hr = get_bitmap_pixel(bitmap, 8, 8, pixel)))
+                    ok(!pixel[0] && !pixel[1] && pixel[2] == 255 && pixel[3] == 255,
+                            "Unexpected direct-copy pixel %u,%u,%u,%u.\n",
+                            pixel[0], pixel[1], pixel[2], pixel[3]);
+                else
+                    ok(0, "Failed to read the direct-copy pixel, hr %#lx.\n", hr);
+            }
+
+            ID2D1RenderTarget_BeginDraw(target);
+            ID2D1RenderTarget_Clear(target, &blue);
+            hr = ID2D1RenderTarget_EndDraw(target, NULL, NULL);
+            ok(hr == S_OK, "Failed to update the held WIC target, hr %#lx.\n", hr);
+            if (direct_copied_bitmap && target_bitmap)
+            {
+                hr = ID2D1Bitmap_CopyFromBitmap(direct_copied_bitmap, NULL, target_bitmap, NULL);
+                ok(hr == S_OK, "Failed to copy from the held WIC target, hr %#lx.\n", hr);
+                ID2D1RenderTarget_BeginDraw(target);
+                ID2D1RenderTarget_Clear(target, &red);
+                ID2D1RenderTarget_DrawBitmap(target, direct_copied_bitmap, NULL, 1.0f,
+                        D2D1_BITMAP_INTERPOLATION_MODE_LINEAR, NULL);
+                hr = ID2D1RenderTarget_EndDraw(target, NULL, NULL);
+                ok(hr == S_OK, "Failed to draw the held-target copy, hr %#lx.\n", hr);
+                if (SUCCEEDED(hr = get_bitmap_pixel(bitmap, 8, 8, pixel)))
+                    ok(pixel[0] == 255 && !pixel[1] && !pixel[2] && pixel[3] == 255,
+                            "Unexpected held-target pixel %u,%u,%u,%u.\n",
+                            pixel[0], pixel[1], pixel[2], pixel[3]);
+                else
+                    ok(0, "Failed to read the held-target pixel, hr %#lx.\n", hr);
+            }
+
+            ID2D1RenderTarget_BeginDraw(target);
+            ID2D1RenderTarget_Clear(target, &red);
+            hr = ID2D1RenderTarget_EndDraw(target, NULL, NULL);
+            ok(hr == S_OK, "Failed to restore the CPU WIC contents, hr %#lx.\n", hr);
+
             hr = ID2D1RenderTarget_CreateBitmap(target, bitmap_size, NULL, 0,
                     &bitmap_props, &copied_bitmap);
             ok(hr == S_OK, "Failed to create the WIC copy bitmap, hr %#lx.\n", hr);
@@ -922,9 +1008,113 @@ static void test_tiny_wic_sequences(void)
                 ok(nonzero_alpha, "The CPU glyph transaction produced no visible pixels.\n");
             else
                 ok(0, "Failed to inspect the CPU glyph transaction, hr %#lx.\n", hr);
+
+            ID2D1RenderTarget_SetTextRenderingParams(target, ctx.rendering_params);
+            ID2D1RenderTarget_SetDpi(target, 96.0f, 96.0f);
+            ID2D1RenderTarget_BeginDraw(target);
+            ID2D1RenderTarget_Clear(target, NULL);
+            ID2D1RenderTarget_DrawText(target, L"A", 1, ctx.text_format, &rect,
+                    (ID2D1Brush *)brush, D2D1_DRAW_TEXT_OPTIONS_NONE,
+                    DWRITE_MEASURING_MODE_NATURAL);
+            hr = ID2D1RenderTarget_EndDraw(target, NULL, NULL);
+            ok(hr == S_OK, "Failed to cache the 96-DPI glyph, hr %#lx.\n", hr);
+
+            ID2D1RenderTarget_SetDpi(target, 192.0f, 192.0f);
+            ID2D1RenderTarget_BeginDraw(target);
+            ID2D1RenderTarget_Clear(target, NULL);
+            ID2D1RenderTarget_DrawText(target, L"A", 1, ctx.text_format, &rect,
+                    (ID2D1Brush *)brush, D2D1_DRAW_TEXT_OPTIONS_NONE,
+                    DWRITE_MEASURING_MODE_NATURAL);
+            hr = ID2D1RenderTarget_EndDraw(target, NULL, NULL);
+            ok(hr == S_OK, "Failed to draw the 192-DPI glyph, hr %#lx.\n", hr);
+            ID2D1RenderTarget_SetTextRenderingParams(target, NULL);
+            ID2D1RenderTarget_SetDpi(target, 96.0f, 96.0f);
+
+            ID2D1RenderTarget_BeginDraw(target);
+            ID2D1RenderTarget_Clear(target, &red);
+            hr = ID2D1RenderTarget_EndDraw(target, NULL, NULL);
+            ok(hr == S_OK, "Failed to prepare the locked-upload test, hr %#lx.\n", hr);
+            hr = IWICBitmap_Lock(bitmap, NULL, WICBitmapLockWrite, &bitmap_lock);
+            ok(hr == S_OK, "Failed to lock the WIC bitmap for writing, hr %#lx.\n", hr);
+            if (SUCCEEDED(hr))
+            {
+                rect.left = 0.0f;
+                rect.top = 0.0f;
+                rect.right = 8.0f;
+                rect.bottom = 17.0f;
+                ID2D1RenderTarget_BeginDraw(target);
+                ID2D1RenderTarget_FillRectangle(target, &rect, (ID2D1Brush *)brush);
+                hr = ID2D1RenderTarget_EndDraw(target, NULL, NULL);
+                ok(FAILED(hr), "Locked WIC upload unexpectedly succeeded.\n");
+                IWICBitmapLock_Release(bitmap_lock);
+                bitmap_lock = NULL;
+
+                rect.left = 8.0f;
+                rect.right = 17.0f;
+                ID2D1RenderTarget_BeginDraw(target);
+                ID2D1RenderTarget_FillRectangle(target, &rect, (ID2D1Brush *)brush);
+                hr = ID2D1RenderTarget_EndDraw(target, NULL, NULL);
+                ok(hr == S_OK, "Failed to retry the locked WIC upload, hr %#lx.\n", hr);
+                if (SUCCEEDED(hr = get_bitmap_pixel(bitmap, 2, 8, pixel)))
+                    ok(!pixel[0] && !pixel[1] && pixel[2] == 255 && pixel[3] == 255,
+                            "Unexpected preserved pixel %u,%u,%u,%u.\n",
+                            pixel[0], pixel[1], pixel[2], pixel[3]);
+                else
+                    ok(0, "Failed to inspect the preserved pixel, hr %#lx.\n", hr);
+                if (SUCCEEDED(hr = get_bitmap_pixel(bitmap, 14, 8, pixel)))
+                    ok(pixel[0] == 255 && !pixel[1] && !pixel[2] && pixel[3] == 255,
+                            "Unexpected retried upload pixel %u,%u,%u,%u.\n",
+                            pixel[0], pixel[1], pixel[2], pixel[3]);
+                else
+                    ok(0, "Failed to inspect the retried upload pixel, hr %#lx.\n", hr);
+            }
+
+            ID2D1RenderTarget_BeginDraw(target);
+            ID2D1RenderTarget_Clear(target, &red);
+            hr = ID2D1RenderTarget_EndDraw(target, NULL, NULL);
+            ok(hr == S_OK, "Failed to prepare the locked-present test, hr %#lx.\n", hr);
+            hr = ID2D1Bitmap_CopyFromRenderTarget(copied_bitmap, NULL, target, NULL);
+            ok(hr == S_OK, "Failed to synchronize the locked-present test, hr %#lx.\n", hr);
+            hr = IWICBitmap_Lock(bitmap, NULL, WICBitmapLockWrite, &bitmap_lock);
+            ok(hr == S_OK, "Failed to lock the synchronized WIC bitmap, hr %#lx.\n", hr);
+            if (SUCCEEDED(hr))
+            {
+                rect.left = 0.0f;
+                rect.right = 8.0f;
+                ID2D1RenderTarget_BeginDraw(target);
+                ID2D1RenderTarget_FillRectangle(target, &rect, (ID2D1Brush *)brush);
+                hr = ID2D1RenderTarget_EndDraw(target, NULL, NULL);
+                ok(FAILED(hr), "Locked WIC present unexpectedly succeeded.\n");
+                IWICBitmapLock_Release(bitmap_lock);
+                bitmap_lock = NULL;
+
+                rect.left = 8.0f;
+                rect.right = 17.0f;
+                ID2D1RenderTarget_BeginDraw(target);
+                ID2D1RenderTarget_FillRectangle(target, &rect, (ID2D1Brush *)brush);
+                hr = ID2D1RenderTarget_EndDraw(target, NULL, NULL);
+                ok(hr == S_OK, "Failed to retry the locked WIC present, hr %#lx.\n", hr);
+                if (SUCCEEDED(hr = get_bitmap_pixel(bitmap, 2, 8, pixel)))
+                    ok(!pixel[0] && !pixel[1] && pixel[2] == 255 && pixel[3] == 255,
+                            "Unexpected discarded GPU pixel %u,%u,%u,%u.\n",
+                            pixel[0], pixel[1], pixel[2], pixel[3]);
+                else
+                    ok(0, "Failed to inspect the discarded GPU pixel, hr %#lx.\n", hr);
+                if (SUCCEEDED(hr = get_bitmap_pixel(bitmap, 14, 8, pixel)))
+                    ok(pixel[0] == 255 && !pixel[1] && !pixel[2] && pixel[3] == 255,
+                            "Unexpected retried present pixel %u,%u,%u,%u.\n",
+                            pixel[0], pixel[1], pixel[2], pixel[3]);
+                else
+                    ok(0, "Failed to inspect the retried present pixel, hr %#lx.\n", hr);
+            }
         }
     }
 
+    if (bitmap_lock) IWICBitmapLock_Release(bitmap_lock);
+    if (target_bitmap) ID2D1Bitmap_Release(target_bitmap);
+    if (target_image) ID2D1Image_Release(target_image);
+    if (device_context) ID2D1DeviceContext_Release(device_context);
+    if (direct_copied_bitmap) ID2D1Bitmap_Release(direct_copied_bitmap);
     if (copied_bitmap) ID2D1Bitmap_Release(copied_bitmap);
     if (brush) ID2D1SolidColorBrush_Release(brush);
     if (target) ID2D1RenderTarget_Release(target);

--- a/dlls/d2d1/wic_render_target.c
+++ b/dlls/d2d1/wic_render_target.c
@@ -204,6 +204,8 @@ static void d2d_wic_render_target_apply_cpu_glyphs(struct d2d_wic_render_target 
     }
 }
 
+static HRESULT d2d_wic_render_target_upload_bitmap(struct d2d_wic_render_target *render_target);
+
 static HRESULT d2d_wic_render_target_present_cpu(struct d2d_wic_render_target *render_target)
 {
     IWICBitmapLock *bitmap_lock;
@@ -242,8 +244,10 @@ static HRESULT d2d_wic_render_target_present_cpu(struct d2d_wic_render_target *r
     }
     d2d_wic_render_target_apply_cpu_glyphs(render_target, dst, dst_pitch);
     IWICBitmapLock_Release(bitmap_lock);
-    hr = S_OK;
+    bitmap_lock = NULL;
     render_target->gpu_stale = TRUE;
+    hr = render_target->target_exposed
+            ? d2d_wic_render_target_upload_bitmap(render_target) : S_OK;
 
 done:
     d2d_wic_render_target_discard_cpu_glyphs(render_target);
@@ -255,8 +259,9 @@ done:
 static HRESULT d2d_wic_render_target_upload_bitmap(struct d2d_wic_render_target *render_target)
 {
     IWICBitmapLock *bitmap_lock = NULL;
-    ID3D10Resource *resource = NULL;
-    ID3D10Device *device = NULL;
+    ID3D11DeviceContext *context = NULL;
+    ID3D11Resource *resource = NULL;
+    ID3D11Device *device = NULL;
     UINT data_size, stride;
     WICRect rect;
     BYTE *data;
@@ -273,19 +278,23 @@ static HRESULT d2d_wic_render_target_upload_bitmap(struct d2d_wic_render_target 
             || FAILED(hr = IWICBitmapLock_GetStride(bitmap_lock, &stride)))
         goto done;
     if (FAILED(hr = IDXGISurface_QueryInterface(render_target->dxgi_surface,
-            &IID_ID3D10Resource, (void **)&resource)))
+            &IID_ID3D11Resource, (void **)&resource)))
         goto done;
 
-    ID3D10Texture2D_GetDevice(render_target->readback_texture, &device);
-    ID3D10Device_UpdateSubresource(device, resource, 0, NULL, data, stride, 0);
+    ID3D11Resource_GetDevice(resource, &device);
+    ID3D11Device_GetImmediateContext(device, &context);
+    ID3D11DeviceContext_UpdateSubresource(context, resource, 0, NULL, data, stride, 0);
+    ID3D11DeviceContext_Flush(context);
     render_target->gpu_stale = FALSE;
     hr = S_OK;
 
 done:
+    if (context)
+        ID3D11DeviceContext_Release(context);
     if (device)
-        ID3D10Device_Release(device);
+        ID3D11Device_Release(device);
     if (resource)
-        ID3D10Resource_Release(resource);
+        ID3D11Resource_Release(resource);
     if (bitmap_lock)
         IWICBitmapLock_Release(bitmap_lock);
     return hr;
@@ -302,10 +311,10 @@ static HRESULT d2d_wic_render_target_prepare_gpu_draw(IUnknown *outer_unknown,
     if (render_target->gpu_fallback)
         return S_OK;
 
-    render_target->gpu_fallback = TRUE;
     if (render_target->gpu_stale && !render_target->cpu_clear_pending
             && FAILED(hr = d2d_wic_render_target_upload_bitmap(render_target)))
         return hr;
+    render_target->gpu_fallback = TRUE;
     if (!render_target->cpu_clear_pending)
         return S_OK;
 
@@ -330,17 +339,25 @@ static HRESULT d2d_wic_render_target_prepare_gpu_draw(IUnknown *outer_unknown,
     return hr;
 }
 
+static void d2d_wic_render_target_target_exposed(IUnknown *outer_unknown)
+{
+    struct d2d_wic_render_target *render_target = impl_from_IUnknown(outer_unknown);
+
+    render_target->target_exposed = TRUE;
+}
+
 static HRESULT d2d_wic_render_target_present(IUnknown *outer_unknown)
 {
     struct d2d_wic_render_target *render_target = impl_from_IUnknown(outer_unknown);
     D3D10_MAPPED_TEXTURE2D mapped_texture;
-    ID3D10Resource *src_resource;
-    IWICBitmapLock *bitmap_lock;
+    ID3D10Resource *src_resource = NULL;
+    IWICBitmapLock *bitmap_lock = NULL;
     UINT dst_size, dst_pitch;
-    ID3D10Device *device;
+    ID3D10Device *device = NULL;
     WICRect dst_rect;
     BYTE *src, *dst;
     unsigned int i;
+    BOOL mapped = FALSE;
     HRESULT hr;
 
     if (render_target->cpu_clear_pending && !render_target->gpu_fallback)
@@ -360,9 +377,8 @@ static HRESULT d2d_wic_render_target_present(IUnknown *outer_unknown)
     }
 
     ID3D10Texture2D_GetDevice(render_target->readback_texture, &device);
-    ID3D10Device_CopyResource(device, (ID3D10Resource *)render_target->readback_texture, src_resource);
-    ID3D10Device_Release(device);
-    ID3D10Resource_Release(src_resource);
+    ID3D10Device_CopyResource(device,
+            (ID3D10Resource *)render_target->readback_texture, src_resource);
 
     dst_rect.X = 0;
     dst_rect.Y = 0;
@@ -377,23 +393,22 @@ static HRESULT d2d_wic_render_target_present(IUnknown *outer_unknown)
     if (FAILED(hr = IWICBitmapLock_GetDataPointer(bitmap_lock, &dst_size, &dst)))
     {
         ERR("Failed to get data pointer, hr %#lx.\n", hr);
-        IWICBitmapLock_Release(bitmap_lock);
         goto end;
     }
 
     if (FAILED(hr = IWICBitmapLock_GetStride(bitmap_lock, &dst_pitch)))
     {
         ERR("Failed to get stride, hr %#lx.\n", hr);
-        IWICBitmapLock_Release(bitmap_lock);
         goto end;
     }
 
-    if (FAILED(hr = ID3D10Texture2D_Map(render_target->readback_texture, 0, D3D10_MAP_READ, 0, &mapped_texture)))
+    if (FAILED(hr = ID3D10Texture2D_Map(render_target->readback_texture,
+            0, D3D10_MAP_READ, 0, &mapped_texture)))
     {
         ERR("Failed to map readback texture, hr %#lx.\n", hr);
-        IWICBitmapLock_Release(bitmap_lock);
         goto end;
     }
+    mapped = TRUE;
 
     src = mapped_texture.pData;
 
@@ -404,15 +419,22 @@ static HRESULT d2d_wic_render_target_present(IUnknown *outer_unknown)
         dst += dst_pitch;
     }
 
-    ID3D10Texture2D_Unmap(render_target->readback_texture, 0);
-    IWICBitmapLock_Release(bitmap_lock);
+    hr = S_OK;
 
 end:
+    if (mapped)
+        ID3D10Texture2D_Unmap(render_target->readback_texture, 0);
+    if (bitmap_lock)
+        IWICBitmapLock_Release(bitmap_lock);
+    if (device)
+        ID3D10Device_Release(device);
+    if (src_resource)
+        ID3D10Resource_Release(src_resource);
+    render_target->gpu_stale = FAILED(hr);
     d2d_wic_render_target_discard_cpu_glyphs(render_target);
     render_target->cpu_clear_pending = FALSE;
     render_target->gpu_fallback = FALSE;
-    render_target->gpu_stale = FALSE;
-    return S_OK;
+    return hr;
 }
 
 static HRESULT STDMETHODCALLTYPE d2d_wic_render_target_QueryInterface(IUnknown *iface, REFIID iid, void **out)
@@ -469,6 +491,7 @@ static const struct d2d_device_context_ops d2d_wic_render_target_ops =
     d2d_wic_render_target_begin_draw,
     d2d_wic_render_target_prepare_gpu_draw,
     d2d_wic_render_target_queue_cpu_clear,
+    d2d_wic_render_target_target_exposed,
 };
 
 static HRESULT d2d_wic_resolve_pixel_format(D2D1_PIXEL_FORMAT *pixel_format,

--- a/dlls/d2d1/wic_render_target.c
+++ b/dlls/d2d1/wic_render_target.c
@@ -22,9 +22,312 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(d2d);
 
+#define D2D_WIC_CPU_MAX_GLYPHS 256
+
+static INIT_ONCE d2d_wic_cpu_once = INIT_ONCE_STATIC_INIT;
+static BOOL d2d_wic_cpu_enabled;
+
+static BOOL CALLBACK d2d_wic_cpu_init_once(INIT_ONCE *once, void *param, void **context)
+{
+    char value[2];
+
+    d2d_wic_cpu_enabled = !GetEnvironmentVariableA("WINE_D2D_WIC_CPU",
+            value, ARRAY_SIZE(value)) || value[0] != '0';
+    return TRUE;
+}
+
+static BOOL d2d_wic_cpu_is_enabled(void)
+{
+    InitOnceExecuteOnce(&d2d_wic_cpu_once, d2d_wic_cpu_init_once, NULL, NULL);
+    return d2d_wic_cpu_enabled;
+}
+
 static inline struct d2d_wic_render_target *impl_from_IUnknown(IUnknown *iface)
 {
     return CONTAINING_RECORD(iface, struct d2d_wic_render_target, IUnknown_iface);
+}
+
+static void d2d_wic_render_target_discard_cpu_glyphs(struct d2d_wic_render_target *render_target)
+{
+    struct d2d_wic_cpu_glyph *glyph, *next;
+
+    for (glyph = render_target->cpu_glyphs; glyph; glyph = next)
+    {
+        next = glyph->next;
+        free(glyph);
+    }
+    render_target->cpu_glyphs = NULL;
+    render_target->cpu_glyph_tail = &render_target->cpu_glyphs;
+    render_target->cpu_glyph_count = 0;
+}
+
+static void d2d_wic_render_target_begin_draw(IUnknown *outer_unknown)
+{
+    struct d2d_wic_render_target *render_target = impl_from_IUnknown(outer_unknown);
+
+    d2d_wic_render_target_discard_cpu_glyphs(render_target);
+    render_target->cpu_clear_pending = FALSE;
+    render_target->gpu_fallback = FALSE;
+}
+
+static BOOL d2d_wic_render_target_cpu_supported(const struct d2d_wic_render_target *render_target)
+{
+    return d2d_wic_cpu_is_enabled()
+            && render_target->width <= 32 && render_target->height <= 32
+            && render_target->pixel_format.format == DXGI_FORMAT_B8G8R8A8_UNORM
+            && render_target->pixel_format.alphaMode == D2D1_ALPHA_MODE_PREMULTIPLIED
+            && !(render_target->usage & D2D1_RENDER_TARGET_USAGE_GDI_COMPATIBLE);
+}
+
+static BOOL d2d_wic_render_target_queue_cpu_clear(IUnknown *outer_unknown, const D2D1_COLOR_F *colour)
+{
+    static const D2D1_COLOR_F transparent;
+    struct d2d_wic_render_target *render_target = impl_from_IUnknown(outer_unknown);
+
+    if (!d2d_wic_render_target_cpu_supported(render_target) || render_target->gpu_fallback)
+        return FALSE;
+
+    d2d_wic_render_target_discard_cpu_glyphs(render_target);
+    render_target->cpu_clear_pending = FALSE;
+    render_target->cpu_clear = colour ? *colour : transparent;
+    if (!isfinite(render_target->cpu_clear.r) || !isfinite(render_target->cpu_clear.g)
+            || !isfinite(render_target->cpu_clear.b) || !isfinite(render_target->cpu_clear.a))
+        return FALSE;
+    render_target->cpu_clear_pending = TRUE;
+    return TRUE;
+}
+
+static BOOL d2d_wic_render_target_queue_cpu_glyph(IUnknown *outer_unknown, const RECT *bounds,
+        const BYTE *values, unsigned int pitch, const D2D1_COLOR_F *colour)
+{
+    struct d2d_wic_render_target *render_target = impl_from_IUnknown(outer_unknown);
+    struct d2d_wic_cpu_glyph *glyph;
+    unsigned int original_width, original_height, width, height, y;
+    LONGLONG original_width64, original_height64;
+    int left, top, right, bottom;
+    size_t allocation_size;
+
+    if (!render_target->cpu_clear_pending || render_target->gpu_fallback
+            || render_target->cpu_glyph_count == D2D_WIC_CPU_MAX_GLYPHS
+            || !values || !colour || colour->a != 1.0f
+            || !isfinite(colour->r) || !isfinite(colour->g)
+            || !isfinite(colour->b) || !isfinite(colour->a)
+            || bounds->right < bounds->left || bounds->bottom < bounds->top)
+        return FALSE;
+
+    original_width64 = (LONGLONG)bounds->right - bounds->left;
+    original_height64 = (LONGLONG)bounds->bottom - bounds->top;
+    if (original_width64 > UINT_MAX || original_height64 > UINT_MAX)
+        return FALSE;
+    original_width = original_width64;
+    original_height = original_height64;
+    if (pitch < original_width || (original_height && pitch > SIZE_MAX / original_height))
+        return FALSE;
+
+    left = max(bounds->left, 0);
+    top = max(bounds->top, 0);
+    right = min(bounds->right, (int)render_target->width);
+    bottom = min(bounds->bottom, (int)render_target->height);
+    if (right <= left || bottom <= top)
+        return TRUE;
+
+    width = right - left;
+    height = bottom - top;
+    allocation_size = offsetof(struct d2d_wic_cpu_glyph, values) + (size_t)width * height;
+    if (!(glyph = malloc(allocation_size)))
+        return FALSE;
+
+    glyph->next = NULL;
+    SetRect(&glyph->bounds, left, top, right, bottom);
+    glyph->colour = *colour;
+    glyph->pitch = width;
+    for (y = 0; y < height; ++y)
+    {
+        memcpy(glyph->values + y * width,
+                values + (size_t)(((LONGLONG)top - bounds->top + y) * pitch
+                + (LONGLONG)left - bounds->left), width);
+    }
+
+    *render_target->cpu_glyph_tail = glyph;
+    render_target->cpu_glyph_tail = &glyph->next;
+    ++render_target->cpu_glyph_count;
+    return TRUE;
+}
+
+static unsigned int d2d_wic_clamp_byte(float value)
+{
+    if (!(value > 0.0f))
+        return 0;
+    if (value >= 255.0f)
+        return 255;
+    return value + 0.5f;
+}
+
+static unsigned int d2d_wic_clamp_byte_down(float value)
+{
+    if (!(value > 0.0f))
+        return 0;
+    if (value >= 255.0f)
+        return 255;
+    return value;
+}
+
+static void d2d_wic_render_target_apply_cpu_glyphs(struct d2d_wic_render_target *render_target,
+        BYTE *dst, unsigned int dst_pitch)
+{
+    struct d2d_wic_cpu_glyph *glyph;
+    unsigned int x, y;
+
+    for (glyph = render_target->cpu_glyphs; glyph; glyph = glyph->next)
+    {
+        float colour_alpha = min(max(glyph->colour.a, 0.0f), 1.0f);
+
+        for (y = glyph->bounds.top; y < glyph->bounds.bottom; ++y)
+        {
+            const BYTE *mask = glyph->values + (y - glyph->bounds.top) * glyph->pitch;
+            BYTE *pixel = dst + y * dst_pitch + glyph->bounds.left * 4;
+
+            for (x = glyph->bounds.left; x < glyph->bounds.right; ++x, pixel += 4)
+            {
+                unsigned int a = d2d_wic_clamp_byte(*mask++ * colour_alpha);
+                unsigned int inv = 255 - a;
+                unsigned int r = d2d_wic_clamp_byte_down(glyph->colour.r * a);
+                unsigned int g = d2d_wic_clamp_byte_down(glyph->colour.g * a);
+                unsigned int b = d2d_wic_clamp_byte_down(glyph->colour.b * a);
+
+                pixel[2] = min(255, r + (pixel[2] * inv + 127) / 255);
+                pixel[1] = min(255, g + (pixel[1] * inv + 127) / 255);
+                pixel[0] = min(255, b + (pixel[0] * inv + 127) / 255);
+                pixel[3] = min(255, a + (pixel[3] * inv + 127) / 255);
+            }
+        }
+    }
+}
+
+static HRESULT d2d_wic_render_target_present_cpu(struct d2d_wic_render_target *render_target)
+{
+    IWICBitmapLock *bitmap_lock;
+    UINT dst_size, dst_pitch;
+    WICRect dst_rect;
+    BYTE *dst, pixel[4];
+    unsigned int x, y;
+    float alpha;
+    HRESULT hr;
+
+    dst_rect.X = 0;
+    dst_rect.Y = 0;
+    dst_rect.Width = render_target->width;
+    dst_rect.Height = render_target->height;
+    if (FAILED(hr = IWICBitmap_Lock(render_target->bitmap, &dst_rect,
+            WICBitmapLockWrite, &bitmap_lock)))
+        goto done;
+    if (FAILED(hr = IWICBitmapLock_GetDataPointer(bitmap_lock, &dst_size, &dst))
+            || FAILED(hr = IWICBitmapLock_GetStride(bitmap_lock, &dst_pitch)))
+    {
+        IWICBitmapLock_Release(bitmap_lock);
+        goto done;
+    }
+
+    alpha = min(max(render_target->cpu_clear.a, 0.0f), 1.0f);
+    pixel[0] = d2d_wic_clamp_byte(render_target->cpu_clear.b * alpha * 255.0f);
+    pixel[1] = d2d_wic_clamp_byte(render_target->cpu_clear.g * alpha * 255.0f);
+    pixel[2] = d2d_wic_clamp_byte(render_target->cpu_clear.r * alpha * 255.0f);
+    pixel[3] = d2d_wic_clamp_byte(alpha * 255.0f);
+    for (y = 0; y < render_target->height; ++y)
+    {
+        BYTE *row = dst + y * dst_pitch;
+
+        for (x = 0; x < render_target->width; ++x)
+            memcpy(row + x * 4, pixel, sizeof(pixel));
+    }
+    d2d_wic_render_target_apply_cpu_glyphs(render_target, dst, dst_pitch);
+    IWICBitmapLock_Release(bitmap_lock);
+    hr = S_OK;
+    render_target->gpu_stale = TRUE;
+
+done:
+    d2d_wic_render_target_discard_cpu_glyphs(render_target);
+    render_target->cpu_clear_pending = FALSE;
+    render_target->gpu_fallback = FALSE;
+    return hr;
+}
+
+static HRESULT d2d_wic_render_target_upload_bitmap(struct d2d_wic_render_target *render_target)
+{
+    IWICBitmapLock *bitmap_lock = NULL;
+    ID3D10Resource *resource = NULL;
+    ID3D10Device *device = NULL;
+    UINT data_size, stride;
+    WICRect rect;
+    BYTE *data;
+    HRESULT hr;
+
+    rect.X = 0;
+    rect.Y = 0;
+    rect.Width = render_target->width;
+    rect.Height = render_target->height;
+    if (FAILED(hr = IWICBitmap_Lock(render_target->bitmap, &rect,
+            WICBitmapLockRead, &bitmap_lock)))
+        goto done;
+    if (FAILED(hr = IWICBitmapLock_GetDataPointer(bitmap_lock, &data_size, &data))
+            || FAILED(hr = IWICBitmapLock_GetStride(bitmap_lock, &stride)))
+        goto done;
+    if (FAILED(hr = IDXGISurface_QueryInterface(render_target->dxgi_surface,
+            &IID_ID3D10Resource, (void **)&resource)))
+        goto done;
+
+    ID3D10Texture2D_GetDevice(render_target->readback_texture, &device);
+    ID3D10Device_UpdateSubresource(device, resource, 0, NULL, data, stride, 0);
+    render_target->gpu_stale = FALSE;
+    hr = S_OK;
+
+done:
+    if (device)
+        ID3D10Device_Release(device);
+    if (resource)
+        ID3D10Resource_Release(resource);
+    if (bitmap_lock)
+        IWICBitmapLock_Release(bitmap_lock);
+    return hr;
+}
+
+static HRESULT d2d_wic_render_target_prepare_gpu_draw(IUnknown *outer_unknown,
+        struct d2d_device_context *context)
+{
+    struct d2d_wic_render_target *render_target = impl_from_IUnknown(outer_unknown);
+    struct d2d_wic_cpu_glyph *glyph, *next;
+    D2D1_COLOR_F clear;
+    HRESULT hr = S_OK;
+
+    if (render_target->gpu_fallback)
+        return S_OK;
+
+    render_target->gpu_fallback = TRUE;
+    if (render_target->gpu_stale && !render_target->cpu_clear_pending
+            && FAILED(hr = d2d_wic_render_target_upload_bitmap(render_target)))
+        return hr;
+    if (!render_target->cpu_clear_pending)
+        return S_OK;
+
+    clear = render_target->cpu_clear;
+    render_target->cpu_clear_pending = FALSE;
+    glyph = render_target->cpu_glyphs;
+    render_target->cpu_glyphs = NULL;
+    render_target->cpu_glyph_tail = &render_target->cpu_glyphs;
+    render_target->cpu_glyph_count = 0;
+
+    ID2D1RenderTarget_Clear(render_target->dxgi_target, &clear);
+    if (FAILED(context->error.code))
+        hr = context->error.code;
+    for (; glyph; glyph = next)
+    {
+        next = glyph->next;
+        if (SUCCEEDED(hr))
+            hr = d2d_device_context_replay_cpu_glyph(context,
+                    &glyph->bounds, glyph->values, glyph->pitch, &glyph->colour);
+        free(glyph);
+    }
+    return hr;
 }
 
 static HRESULT d2d_wic_render_target_present(IUnknown *outer_unknown)
@@ -39,6 +342,15 @@ static HRESULT d2d_wic_render_target_present(IUnknown *outer_unknown)
     BYTE *src, *dst;
     unsigned int i;
     HRESULT hr;
+
+    if (render_target->cpu_clear_pending && !render_target->gpu_fallback)
+    {
+        TRACE("Presenting %ux%u WIC target through CPU path with %u glyph runs.\n",
+                render_target->width, render_target->height, render_target->cpu_glyph_count);
+        return d2d_wic_render_target_present_cpu(render_target);
+    }
+    if (render_target->gpu_stale && !render_target->gpu_fallback)
+        return S_OK;
 
     if (FAILED(hr = IDXGISurface_QueryInterface(render_target->dxgi_surface,
             &IID_ID3D10Resource, (void **)&src_resource)))
@@ -96,6 +408,10 @@ static HRESULT d2d_wic_render_target_present(IUnknown *outer_unknown)
     IWICBitmapLock_Release(bitmap_lock);
 
 end:
+    d2d_wic_render_target_discard_cpu_glyphs(render_target);
+    render_target->cpu_clear_pending = FALSE;
+    render_target->gpu_fallback = FALSE;
+    render_target->gpu_stale = FALSE;
     return S_OK;
 }
 
@@ -127,6 +443,7 @@ static ULONG STDMETHODCALLTYPE d2d_wic_render_target_Release(IUnknown *iface)
 
     if (!refcount)
     {
+        d2d_wic_render_target_discard_cpu_glyphs(render_target);
         IWICBitmap_Release(render_target->bitmap);
         ID3D10Texture2D_Release(render_target->readback_texture);
         IUnknown_Release(render_target->dxgi_inner);
@@ -147,6 +464,11 @@ static const struct IUnknownVtbl d2d_wic_render_target_vtbl =
 static const struct d2d_device_context_ops d2d_wic_render_target_ops =
 {
     d2d_wic_render_target_present,
+    d2d_wic_render_target_queue_cpu_glyph,
+    FALSE,
+    d2d_wic_render_target_begin_draw,
+    d2d_wic_render_target_prepare_gpu_draw,
+    d2d_wic_render_target_queue_cpu_clear,
 };
 
 static HRESULT d2d_wic_resolve_pixel_format(D2D1_PIXEL_FORMAT *pixel_format,
@@ -214,6 +536,9 @@ HRESULT d2d_wic_render_target_init(struct d2d_wic_render_target *render_target, 
         WARN("Unsupported WIC bitmap format %s.\n", debugstr_guid(&bitmap_format));
         return hr;
     }
+    render_target->pixel_format = rt_desc.pixelFormat;
+    render_target->usage = rt_desc.usage;
+    render_target->cpu_glyph_tail = &render_target->cpu_glyphs;
 
     texture_desc.Width = render_target->width;
     texture_desc.Height = render_target->height;
@@ -307,6 +632,9 @@ HRESULT d2d_wic_render_target_init(struct d2d_wic_render_target *render_target, 
 
     render_target->bitmap = bitmap;
     IWICBitmap_AddRef(bitmap);
+
+    TRACE("Initialized %ux%u WIC render target %p.\n",
+            render_target->width, render_target->height, render_target->dxgi_target);
 
     return S_OK;
 }


### PR DESCRIPTION
## Purpose

Office galleries create hundreds of independent 16x16 and 17x17 WIC render targets. Sending each transparent clear and aliased glyph run through WineD3D makes the UI thread wait on repeated GPU command and readback work.

This change records the supported tiny transaction and writes its completed premultiplied pixels directly into the WIC bitmap. It keeps a fresh public render-target wrapper and uses the existing GPU implementation whenever the target or draw sequence is unsupported.

## Changes

- Add a bounded CPU path for non-GDI PBGRA WIC targets up to 32x32.
- Support clear plus opaque, aliased, solid-colour glyph masks under source-over blending.
- Preserve operation order before clips, target changes, state changes, bitmap copies, and unsupported GPU draws.
- Keep already-rasterized glyph masks queued when text rendering parameters change; the masks contain the complete result and later glyphs use the new parameters.
- Upload CPU-written contents before a later GPU transaction or render-target copy needs them.
- Keep a bitmap returned by `GetTarget` coherent across later CPU transactions, without adding uploads before the target has been exposed.
- Invalidate glyph masks on DPI changes and preserve invalid-draw errors across `Flush` and `GetTarget`.
- Propagate WIC upload/present failures and restore the last committed WIC contents after a failed GPU present.
- Fix nested and abandoned `BeginDraw` bookkeeping so transaction state unwinds exactly once.
- Add focused WIC sequence, copy, fallback, multithread, pixel-hash, and benchmark coverage.
- Keep `WINE_D2D_WIC_CPU=0` as a one-process rollback switch.

## Validation

- Built warning-free with the canonical task build:
  - `dlls/d2d1/x86_64-windows/d2d1.dll`
  - `dlls/d2d1/i386-windows/d2d1.dll`
  - x86_64 and i386 d2d1 test executables
- Focused WIC tests on the latest source:
  - x86_64 CPU on/off: 68 checks, 0 failures in each mode
  - i386 CPU on/off: 68 checks, 0 failures in each mode
  - native Windows x86_64: 68 checks, 0 failures
- Office-shaped 543-target A/B, including Word's text-rendering-parameter restore:
  - latest enabled run: 471.136 ms wall, 0.688 ms warm mean per target
  - disabled: 7,651.757 ms wall, 13.675 ms warm mean per target
  - both: SHA-1 `a8e5eef1b85141167ba5d19172064fcee6c61601`, 0 invalid pixels
- Fresh real Word `Insert -> Shapes` traces:
  - previous PR head: 543 tiny WIC targets, 0 CPU presents, 8.211 seconds from first to last target
  - latest head: 543 tiny WIC targets, 543 CPU presents, 0.982 seconds from first target to last present
  - the gallery was fully visible in the capture taken two seconds after the click, despite `+d2d` tracing
- The 1536x1024 D2D atlas transactions were short and interleaved around the TinyWIC work; the long stall followed the TinyWIC fallback. No atlas optimization is included in this PR.

## Review findings

- `FIXED` in `d7ae2bb11d3`: synchronize CPU-rendered WIC contents before `CopyFromRenderTarget`, with a focused copy regression.
- `FIXED` in `9c5b5de5aeb`: preserve queued CPU glyphs across Word's `SetTextRenderingParams` restore, with a matching benchmark and regression sequence.
- `FIXED` in `869f96b166a`: invalidate the glyph cache on DPI changes; keep direct and held target bitmaps coherent; persist invalid-draw errors; and handle upload/present failures with native-matched state transitions.
- Grok final read-only review of `869f96b166a`: 0 bugs, 0 suggestions, 0 nits.

## Scope and risk

The fast path is deliberately narrow. Unsupported sizes, formats, alpha modes, GDI-compatible targets, clips, non-source-over blending, translucent glyphs, and other primitives use the existing GPU path.

The PR remains draft while acceptance-quality repeated click-to-paint sampling is incomplete. The source still creates the ordinary D2D backing resources when constructing each WIC wrapper; eliminating that setup is a separate follow-up within the TinyWIC workstream if profiling shows it remains material.

## Summary by Sourcery

Speed up small Office gallery images by rendering supported WIC clears and glyph transactions on the CPU while retaining correct GPU fallback behavior.

New Features:
- Accelerate supported tiny PBGRA WIC render-target transactions by presenting clears and aliased opaque glyphs directly through a bounded CPU path.
- Provide an environment-variable rollback switch for disabling the WIC CPU optimization.

Bug Fixes:
- Synchronize CPU-rendered WIC contents before GPU copies or subsequent GPU transactions consume them.
- Correct nested and abandoned BeginDraw state cleanup and error handling.

Enhancements:
- Preserve operation ordering and transparently fall back to the existing GPU path for unsupported WIC operations and targets.
- Maintain queued glyph results across text-rendering-parameter changes and support transitions between CPU and GPU rendering.

Documentation:
- Document the performance improvement for small Office gallery images in the unreleased changelog.

Tests:
- Add focused WIC sequence, copy, fallback, multithreading, pixel-integrity, and benchmark coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved rendering speed for small Office gallery images using Direct2D.
  * Added an optimized CPU rendering path for eligible small WIC targets, with GPU fallback when needed.

* **Reliability**
  * Improved handling of nested drawing operations, bitmap reads, rendering failures, clipping, text rendering, and concurrent WIC targets.

* **Tests**
  * Added comprehensive WIC rendering tests and benchmarks covering drawing, text, bitmap operations, DPI changes, and error recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->