### PR TITLE
user32/tests: extend message wait coverage

### DIFF
--- a/dlls/user32/tests/msg.c
+++ b/dlls/user32/tests/msg.c
@@ -5506,9 +5506,33 @@ static void CALLBACK apc_test_proc(ULONG_PTR param)
     /* nothing */
 }
 
+struct msg_wait_post_params
+{
+    HWND hwnd;
+    DWORD thread_id;
+    UINT message;
+};
+
+static DWORD CALLBACK msg_wait_post_thread(void *arg)
+{
+    struct msg_wait_post_params *params = arg;
+    DWORD ret = 0;
+
+    SendMessageA( params->hwnd, WM_NULL, 0, 0 );
+    if (!PostThreadMessageA( params->thread_id, params->message, 0, 0 )) ret = GetLastError();
+    HeapFree( GetProcessHeap(), 0, params );
+    return ret;
+}
+
+static void wait_for_thread( HANDLE thread );
+
 static void test_MsgWaitForMultipleObjects(HWND hwnd)
 {
-    DWORD ret;
+    struct msg_wait_post_params *params;
+    HANDLE event, thread;
+    DWORD ret, exit_code;
+    BOOL got_message = FALSE;
+    unsigned int i;
     MSG msg;
 
     ret = MsgWaitForMultipleObjects(0, NULL, FALSE, 0, QS_POSTMESSAGE);
@@ -5592,6 +5616,87 @@ static void test_MsgWaitForMultipleObjects(HWND hwnd)
     /* the APC call is still queued */
     ret = MsgWaitForMultipleObjectsEx( 0, NULL, 0, QS_POSTMESSAGE, MWMO_ALERTABLE );
     ok(ret == WAIT_IO_COMPLETION, "MsgWaitForMultipleObjectsEx returned %lx\n", ret);
+
+    event = CreateEventW( NULL, TRUE, FALSE, NULL );
+    ok(!!event, "CreateEvent failed, error %lu\n", GetLastError());
+    if (!event) return;
+
+    ret = SetEvent( event );
+    ok(ret, "SetEvent failed, error %lu\n", GetLastError());
+    ret = MsgWaitForMultipleObjectsEx( 1, &event, 0, QS_POSTMESSAGE, 0 );
+    ok(ret == WAIT_OBJECT_0, "signaled event wait returned %lx\n", ret);
+
+    ret = ResetEvent( event );
+    ok(ret, "ResetEvent failed, error %lu\n", GetLastError());
+    ret = PostThreadMessageA( GetCurrentThreadId(), WM_APP + 1, 0, 0 );
+    ok(ret, "PostThreadMessage failed, error %lu\n", GetLastError());
+    ret = MsgWaitForMultipleObjectsEx( 1, &event, 0, QS_POSTMESSAGE, MWMO_INPUTAVAILABLE );
+    ok(ret == WAIT_OBJECT_0 + 1, "pending message wait returned %lx\n", ret);
+    ok(PeekMessageA( &msg, 0, WM_APP + 1, WM_APP + 1, PM_REMOVE ),
+       "PeekMessage should remove the pending message\n");
+
+    ret = SetEvent( event );
+    ok(ret, "SetEvent failed, error %lu\n", GetLastError());
+    ret = PostThreadMessageA( GetCurrentThreadId(), WM_APP + 2, 0, 0 );
+    ok(ret, "PostThreadMessage failed, error %lu\n", GetLastError());
+    ret = MsgWaitForMultipleObjectsEx( 1, &event, 1000, QS_POSTMESSAGE,
+                                       MWMO_WAITALL | MWMO_INPUTAVAILABLE );
+    ok(ret == WAIT_OBJECT_0, "wait-all returned %lx\n", ret);
+    ok(PeekMessageA( &msg, 0, WM_APP + 2, WM_APP + 2, PM_REMOVE ),
+       "PeekMessage should remove the wait-all message\n");
+
+    ret = ResetEvent( event );
+    ok(ret, "ResetEvent failed, error %lu\n", GetLastError());
+    ret = PostThreadMessageA( GetCurrentThreadId(), WM_APP + 3, 0, 0 );
+    ok(ret, "PostThreadMessage failed, error %lu\n", GetLastError());
+    ret = MsgWaitForMultipleObjectsEx( 1, &event, 0, QS_POSTMESSAGE,
+                                       MWMO_WAITALL | MWMO_INPUTAVAILABLE );
+    ok(ret == WAIT_TIMEOUT, "unsignaled wait-all returned %lx\n", ret);
+    ok(PeekMessageA( &msg, 0, WM_APP + 3, WM_APP + 3, PM_REMOVE ),
+       "PeekMessage should remove the wait-all timeout message\n");
+
+    ret = MsgWaitForMultipleObjectsEx( 0, NULL, 20, QS_POSTMESSAGE, 0 );
+    ok(ret == WAIT_TIMEOUT, "finite message wait returned %lx\n", ret);
+
+    params = HeapAlloc( GetProcessHeap(), 0, sizeof(*params) );
+    ok(!!params, "failed to allocate post parameters\n");
+    if (!params)
+    {
+        CloseHandle( event );
+        return;
+    }
+    params->hwnd = hwnd;
+    params->thread_id = GetCurrentThreadId();
+    params->message = WM_APP + 4;
+    thread = CreateThread( NULL, 0, msg_wait_post_thread, params, 0, NULL );
+    ok(!!thread, "failed to create post thread, error %lu\n", GetLastError());
+    if (!thread)
+    {
+        HeapFree( GetProcessHeap(), 0, params );
+        CloseHandle( event );
+        return;
+    }
+    /* the sent message may wake the wait before the helper posts its thread message */
+    for (i = 0; i < 3 && !got_message; ++i)
+    {
+        ret = MsgWaitForMultipleObjectsEx( 0, NULL, 10000, QS_POSTMESSAGE | QS_SENDMESSAGE, 0 );
+        ok(ret == WAIT_OBJECT_0, "helper-thread message wait returned %lx\n", ret);
+        if (ret != WAIT_OBJECT_0) break;
+        got_message = PeekMessageA( &msg, 0, WM_APP + 4, WM_APP + 4, PM_REMOVE );
+    }
+    ok(got_message, "PeekMessage should remove the helper-thread message\n");
+    wait_for_thread( thread );
+    exit_code = STILL_ACTIVE;
+    ret = GetExitCodeThread( thread, &exit_code );
+    ok(ret, "GetExitCodeThread failed, error %lu\n", GetLastError());
+    if (ret) ok(!exit_code, "post thread failed, error %lu\n", exit_code);
+    CloseHandle( thread );
+
+    CloseHandle( event );
+    SetLastError( 0xdeadbeef );
+    ret = MsgWaitForMultipleObjectsEx( 1, &event, 0, QS_POSTMESSAGE, 0 );
+    ok(ret == WAIT_FAILED, "closed handle wait returned %lx\n", ret);
+    ok(GetLastError() == ERROR_INVALID_HANDLE, "expected ERROR_INVALID_HANDLE, got %lu\n", GetLastError());
 }
 
 static void test_WM_DEVICECHANGE(HWND hwnd)


### PR DESCRIPTION
## Summary

- extend `MsgWaitForMultipleObjectsEx()` coverage for event-versus-queue WaitAny behavior
- cover pending input, successful and timed-out `MWMO_WAITALL`, and finite timeouts
- exercise sent-message processing followed by a helper-thread post
- verify closed handles fail with `ERROR_INVALID_HANDLE`
- keep helper-thread parameters alive safely if a test resource or wait fails

This PR contains tests only. The experimental atomic message-wait implementation from Plan 11 is intentionally excluded.

## Validation

- canonical focused WoW64 build rebuilt and linked `user32_test.exe` for i386 and x86_64 in four commands
- i386 executable SHA-256: `7e57699d82b3c2b113e67a74e487e3534a2eb98871d89b036e0baca52af3ef06`
- x86_64 executable SHA-256: `1f7b3974d44810d80e4072113dabb0f75a8a049fd0166225e689f6a7fddb736c`
- the normal-path test block previously passed on baseline Wine in x86_64 and i386
- equivalent WaitAll and helper-post oracles passed on native Windows x64, with the helper-post oracle also passing on native Windows x86
- `git diff --check` passes

The current helper-lifetime hardening changes only failure-path storage and cleanup. The pull-request CI run is the authoritative current runtime gate.

## Risk

Test-only change; no production Wine behavior or server protocol is modified. `CHANGELOG.md` is intentionally unchanged because this adds regression coverage without a user-facing behavior change.

## Summary by Sourcery

Extend user32 message-wait tests to cover event-versus-queue semantics and failure-path handling without changing production behavior.

Enhancements:
- Expand user32 message-wait regression coverage for event and message-queue interactions, wait-all behavior, timeouts, helper-thread posts, and invalid handles.

Tests:
- Add coverage for pending input, successful and timed-out MWMO_WAITALL waits, finite timeouts, sent-message processing followed by helper-thread posts, and closed-handle errors.
- Harden helper-thread test resource lifetime and cleanup on allocation or thread-creation failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded message-waiting test coverage for signaled events, posted messages, wait-all behavior, finite timeouts, helper-thread message posting, and invalid handles.
  * Added validation for synchronization, cleanup, callback behavior, and expected wait results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->