### PR TITLE
msxml3: speed up Office manifest parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Speed up Office Click-to-Run manifest parsing and reduce MSXML heap churn.
 - Speed up small Office gallery images rendered through Direct2D.
 - Improve antialiasing quality and rendering performance while reducing GPU memory use for complex Direct2D geometry with analytic coverage rendering.
 - Reduce Word CPU use by coalescing Office timers that allow delayed delivery.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Handle XML allocation failures safely and release shared XML memory reliably across threads.
 - Speed up Office Click-to-Run manifest parsing and reduce MSXML heap churn.
 - Speed up small Office gallery images rendered through Direct2D.
 - Improve antialiasing quality and rendering performance while reducing GPU memory use for complex Direct2D geometry with analytic coverage rendering.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Handle empty XML downloads safely and report stalled transformation output as an error.
 - Handle XML allocation failures safely and release shared XML memory reliably across threads.
 - Speed up Office Click-to-Run manifest parsing and reduce MSXML heap churn.
 - Reuse reconstructed PE images across Wine server restarts to reduce Office startup disk I/O.

--- a/dlls/msxml3/bsc.c
+++ b/dlls/msxml3/bsc.c
@@ -45,13 +45,40 @@ struct bsc_t {
     HRESULT (*onDataAvailable)(void*,char*,DWORD);
 
     IBinding *binding;
-    IStream *memstream;
+    BYTE *data;
+    DWORD data_size;
+    DWORD data_capacity;
     HRESULT hres;
 };
 
 static inline bsc_t *impl_from_IBindStatusCallback( IBindStatusCallback *iface )
 {
     return CONTAINING_RECORD(iface, bsc_t, IBindStatusCallback_iface);
+}
+
+static HRESULT bsc_reserve(bsc_t *bsc, DWORD size)
+{
+    DWORD capacity = bsc->data_capacity;
+    BYTE *data;
+
+    if (size <= capacity)
+        return S_OK;
+    if (capacity < 4096)
+        capacity = 4096;
+    while (capacity < size)
+    {
+        if (capacity > ~(DWORD)0 / 2)
+        {
+            capacity = size;
+            break;
+        }
+        capacity *= 2;
+    }
+    if (!(data = realloc(bsc->data, capacity)))
+        return E_OUTOFMEMORY;
+    bsc->data = data;
+    bsc->data_capacity = capacity;
+    return S_OK;
 }
 
 static HRESULT WINAPI bsc_QueryInterface(
@@ -95,8 +122,7 @@ static ULONG WINAPI bsc_Release(
     {
         if (bsc->binding)
             IBinding_Release(bsc->binding);
-        if (bsc->memstream)
-            IStream_Release(bsc->memstream);
+        free(bsc->data);
         free(bsc);
     }
 
@@ -109,16 +135,10 @@ static HRESULT WINAPI bsc_OnStartBinding(
         IBinding* pib)
 {
     bsc_t *This = impl_from_IBindStatusCallback(iface);
-    HRESULT hr;
-
     TRACE("%p, %lx, %p.\n", iface, dwReserved, pib);
 
     This->binding = pib;
     IBinding_AddRef(pib);
-
-    hr = CreateStreamOnHGlobal(NULL, TRUE, &This->memstream);
-    if(FAILED(hr))
-        return hr;
 
     return S_OK;
 }
@@ -163,17 +183,8 @@ static HRESULT WINAPI bsc_OnStopBinding(
     }
 
     if(This->obj && SUCCEEDED(hresult)) {
-        HGLOBAL hglobal;
-        hr = GetHGlobalFromStream(This->memstream, &hglobal);
-        if(SUCCEEDED(hr))
-        {
-            DWORD len = GlobalSize(hglobal);
-            char *ptr = GlobalLock(hglobal);
-
-            This->hres = This->onDataAvailable(This->obj, ptr, len);
-
-            GlobalUnlock(hglobal);
-        }
+        This->hres = This->onDataAvailable(This->obj, (char *)This->data,
+                This->data_size);
     }
 
     return hr;
@@ -198,7 +209,7 @@ static HRESULT WINAPI bsc_OnDataAvailable(
 {
     bsc_t *bsc = impl_from_IBindStatusCallback(iface);
     BYTE buf[4096];
-    DWORD read, written;
+    DWORD read;
     HRESULT hr;
 
     TRACE("%p, %lx, %lu, %p, %p.\n", iface, grfBSCF, dwSize, pformatetc, pstgmed);
@@ -209,8 +220,13 @@ static HRESULT WINAPI bsc_OnDataAvailable(
         if(FAILED(hr))
             break;
 
-        hr = IStream_Write(bsc->memstream, buf, read, &written);
-    } while(SUCCEEDED(hr) && written != 0 && read != 0);
+        if (read > ~(DWORD)0 - bsc->data_size)
+            return E_OUTOFMEMORY;
+        if (FAILED(hr = bsc_reserve(bsc, bsc->data_size + read)))
+            return hr;
+        memcpy(bsc->data + bsc->data_size, buf, read);
+        bsc->data_size += read;
+    } while(SUCCEEDED(hr) && read != 0);
 
     return S_OK;
 }
@@ -316,7 +332,9 @@ HRESULT bind_url(IMoniker *mon, HRESULT (*onDataAvailable)(void*,char*,DWORD),
     bsc->obj = obj;
     bsc->onDataAvailable = onDataAvailable;
     bsc->binding = NULL;
-    bsc->memstream = NULL;
+    bsc->data = NULL;
+    bsc->data_size = 0;
+    bsc->data_capacity = 0;
     bsc->hres = S_OK;
 
     hr = RegisterBindStatusCallback(pbc, &bsc->IBindStatusCallback_iface, NULL, 0);

--- a/dlls/msxml3/bsc.c
+++ b/dlls/msxml3/bsc.c
@@ -217,7 +217,7 @@ static HRESULT WINAPI bsc_OnDataAvailable(
     do
     {
         hr = IStream_Read(pstgmed->pstm, buf, sizeof(buf), &read);
-        if(FAILED(hr))
+        if (FAILED(hr) || !read)
             break;
 
         if (read > ~(DWORD)0 - bsc->data_size)

--- a/dlls/msxml3/domdoc.c
+++ b/dlls/msxml3/domdoc.c
@@ -271,58 +271,15 @@ static HRESULT WINAPI PersistStreamInit_IsDirty(IPersistStreamInit *iface)
 
 static HRESULT domdoc_load_from_stream(domdoc *doc, ISequentialStream *stream)
 {
-    LARGE_INTEGER zero = {{0}};
     struct domnode *node;
-    DWORD read, written;
-    IStream *hstream;
-    BYTE buf[4096];
     HRESULT hr;
 
-    hstream = NULL;
-    hr = CreateStreamOnHGlobal(NULL, TRUE, &hstream);
-    if (FAILED(hr))
-        return hr;
+    hr = parse_stream(stream, false, doc->node->properties, &node);
 
-    for (;;)
-    {
-        read = 0;
-        hr = ISequentialStream_Read(stream, buf, sizeof(buf), &read);
-        if (FAILED(hr))
-            break;
-        if (read > sizeof(buf))
-        {
-            hr = E_FAIL;
-            break;
-        }
-        if (!read)
-            break;
-
-        written = 0;
-        hr = IStream_Write(hstream, buf, read, &written);
-        if (FAILED(hr))
-            break;
-        if (written != read)
-        {
-            hr = STG_E_MEDIUMFULL;
-            break;
-        }
-    }
-
-    if (FAILED(hr))
-    {
-        ERR("failed to copy stream, hr %#lx.\n", hr);
-        IStream_Release(hstream);
-        return hr;
-    }
-
-    hr = IStream_Seek(hstream, zero, STREAM_SEEK_SET, NULL);
-    hr = parse_stream((ISequentialStream *)hstream, false, doc->node->properties, &node);
-    IStream_Release(hstream);
-
-    if (!node)
+    if (hr != S_OK || !node)
     {
         ERR("Failed to parse xml\n");
-        return E_FAIL;
+        return FAILED(hr) ? hr : E_FAIL;
     }
 
     attach_doc_node(doc, node);

--- a/dlls/msxml3/msxml_private.h
+++ b/dlls/msxml3/msxml_private.h
@@ -194,7 +194,11 @@ enum domnode_flags
     DOMNODE_PARSED_VALUE = 0x8,
     DOMNODE_NS_DECL = 0x10,
     DOMNODE_NO_PARENT = 0x20,
+    DOMNODE_POOLED_QNAME = 0x40,
+    DOMNODE_POOLED_ALLOCATION = 0x80,
 };
+
+struct dom_parsed_pool;
 
 struct domdoc_properties
 {
@@ -214,6 +218,7 @@ struct domdoc_properties
     bool normalize_attribute_values;
     int max_element_depth;
     IUri *uri;
+    struct dom_parsed_pool *parsed_pool;
 };
 
 struct domnode
@@ -235,6 +240,7 @@ struct domnode
     {
         struct domdoc_properties *properties;
         struct dtd *dtd;
+        struct dom_parsed_pool *parsed_pool;
     };
 
     struct domnode *parent;
@@ -274,6 +280,7 @@ struct parsed_name
     BSTR prefix;
     BSTR local;
     BSTR qname;
+    bool pooled;
 };
 
 extern HRESULT parse_qualified_name(const WCHAR *src, struct parsed_name *name);

--- a/dlls/msxml3/msxml_private.h
+++ b/dlls/msxml3/msxml_private.h
@@ -196,6 +196,7 @@ enum domnode_flags
     DOMNODE_NO_PARENT = 0x20,
     DOMNODE_POOLED_QNAME = 0x40,
     DOMNODE_POOLED_ALLOCATION = 0x80,
+    DOMNODE_POOLED_URI = 0x100,
 };
 
 struct dom_parsed_pool;

--- a/dlls/msxml3/msxml_private.h
+++ b/dlls/msxml3/msxml_private.h
@@ -197,6 +197,7 @@ enum domnode_flags
     DOMNODE_POOLED_QNAME = 0x40,
     DOMNODE_POOLED_ALLOCATION = 0x80,
     DOMNODE_POOLED_URI = 0x100,
+    DOMNODE_PARSED_PRESERVE_SPACE = 0x200,
 };
 
 struct dom_parsed_pool;

--- a/dlls/msxml3/node.c
+++ b/dlls/msxml3/node.c
@@ -1128,6 +1128,8 @@ struct dom_parsed_pool
     size_t name_count;
     struct list buckets[256];
     struct list node_blocks;
+    struct dom_parsed_name *recent_qname;
+    struct dom_parsed_name *recent_uri;
 };
 
 static UINT dom_parsed_name_hash(const WCHAR *name, int len)
@@ -1157,14 +1159,21 @@ static struct dom_parsed_pool *domdoc_get_parsed_pool(struct domdoc_properties *
 }
 
 static BSTR domdoc_intern_parsed_name(struct domdoc_properties *properties,
-        const WCHAR *name, int len)
+        const WCHAR *name, int len, bool is_uri)
 {
     struct dom_parsed_pool *pool;
+    struct dom_parsed_name **recent;
     struct dom_parsed_name *entry;
     UINT hash;
 
     if (!(pool = domdoc_get_parsed_pool(properties)))
         return NULL;
+
+    recent = is_uri ? &pool->recent_uri : &pool->recent_qname;
+    entry = *recent;
+    if (entry && SysStringLen(entry->value) == len
+            && !memcmp(entry->value, name, len * sizeof(*name)))
+        return entry->value;
 
     hash = dom_parsed_name_hash(name, len);
     LIST_FOR_EACH_ENTRY(entry, &pool->buckets[hash % ARRAY_SIZE(pool->buckets)],
@@ -1172,7 +1181,10 @@ static BSTR domdoc_intern_parsed_name(struct domdoc_properties *properties,
     {
         if (entry->hash == hash && SysStringLen(entry->value) == len
                 && !memcmp(entry->value, name, len * sizeof(*name)))
+        {
+            *recent = entry;
             return entry->value;
+        }
     }
 
     if (pool->name_count >= DOM_PARSED_NAME_POOL_LIMIT || !(entry = malloc(sizeof(*entry))))
@@ -1185,6 +1197,7 @@ static BSTR domdoc_intern_parsed_name(struct domdoc_properties *properties,
     entry->hash = hash;
     list_add_head(&pool->buckets[hash % ARRAY_SIZE(pool->buckets)], &entry->entry);
     ++pool->name_count;
+    *recent = entry;
     return entry->value;
 }
 
@@ -1279,7 +1292,7 @@ static HRESULT domnode_create_internal(DOMNodeType type, const WCHAR *name, int 
      * every parsed text node. */
     if (parsed && (type == NODE_ELEMENT || type == NODE_ATTRIBUTE))
     {
-        object->qname = domdoc_intern_parsed_name(owner->properties, name, name_len);
+        object->qname = domdoc_intern_parsed_name(owner->properties, name, name_len, false);
         if (object->qname)
             object->flags |= DOMNODE_POOLED_QNAME;
     }
@@ -1316,7 +1329,13 @@ static HRESULT domnode_create_internal(DOMNodeType type, const WCHAR *name, int 
 
     if (uri_len)
     {
-        if (!(object->uri = SysAllocStringLen(uri, uri_len)))
+        if (parsed)
+        {
+            object->uri = domdoc_intern_parsed_name(owner->properties, uri, uri_len, true);
+            if (object->uri)
+                object->flags |= DOMNODE_POOLED_URI;
+        }
+        if (!object->uri && !(object->uri = SysAllocStringLen(uri, uri_len)))
         {
             domnode_destroy_tree(object);
             return E_OUTOFMEMORY;
@@ -1598,7 +1617,8 @@ void domnode_destroy_tree(struct domnode *tree)
         SysFreeString(tree->name);
     }
     SysFreeString(tree->data);
-    SysFreeString(tree->uri);
+    if (!(tree->flags & DOMNODE_POOLED_URI))
+        SysFreeString(tree->uri);
 
     if (parsed_pool)
         dom_parsed_pool_release(parsed_pool);
@@ -3898,16 +3918,27 @@ static void parse_context_node_create(struct parse_context *context, DOMNodeType
             owner, false, true, node);
 }
 
+static void parse_context_link_node(struct domnode *parent, struct domnode *node,
+        struct list *list)
+{
+    assert(!node->parent);
+    assert(node->owner == node_get_doc(parent));
+
+    list_add_tail(list, &node->entry);
+    node->parent = parent;
+    domnode_add_refs(parent, node->refcount);
+}
+
 static void parse_context_append_child(struct parse_context *context, struct domnode *parent, struct domnode *child)
 {
     if (context->status == S_OK)
-        domnode_append_child(parent, child);
+        parse_context_link_node(parent, child, &parent->children);
 }
 
 static void parse_context_append_attribute(struct parse_context *context, struct domnode *node, struct domnode *attribute)
 {
     if (context->status == S_OK)
-        domnode_insert_attribute(node, attribute, NULL);
+        parse_context_link_node(node, attribute, &node->attributes);
 }
 
 static void parse_context_node_put_data(struct parse_context *context, struct domnode *node, const WCHAR *data, int data_len)
@@ -3967,7 +3998,7 @@ static void parse_context_node_put_data(struct parse_context *context, struct do
             SysFreeString(str);
             return;
         }
-        domnode_append_child(node, child);
+        parse_context_append_child(context, node, child);
         child->data = str;
     }
     else
@@ -4681,23 +4712,35 @@ struct xmldoc_context
 
 static xmlNsPtr xmlnode_get_ns(xmlNodePtr tree, struct domnode *node, xmlNodePtr element)
 {
-    xmlChar *uri, *prefix;
+    xmlChar *uri = NULL, *prefix;
     xmlNsPtr ns;
 
     if (!node->uri)
         return NULL;
 
-    uri = xmlchar_from_wchar(node->uri);
     prefix = node->prefix ? xmlchar_from_wchar(node->prefix) : NULL;
 
     if ((ns = xmlSearchNs(tree->doc, element, prefix)))
     {
-        if (!xmlStrEqual(ns->href, uri))
-            ns = xmlNewNs(element, uri, prefix);
+        if (ns->_private != node->uri)
+        {
+            uri = xmlchar_from_wchar(node->uri);
+            if (!xmlStrEqual(ns->href, uri))
+            {
+                ns = xmlNewNs(element, uri, prefix);
+                if (ns)
+                    ns->_private = node->uri;
+            }
+            else
+                ns->_private = node->uri;
+        }
     }
     else
     {
+        uri = xmlchar_from_wchar(node->uri);
         ns = xmlNewNs(element, uri, prefix);
+        if (ns)
+            ns->_private = node->uri;
     }
 
     free(uri);

--- a/dlls/msxml3/node.c
+++ b/dlls/msxml3/node.c
@@ -1104,7 +1104,8 @@ static void domnode_insert_attribute(struct domnode *parent, struct domnode *nod
 }
 
 #define DOM_PARSED_NAME_POOL_LIMIT 4096
-#define DOM_PARSED_NODE_BLOCK_SIZE 256
+#define DOM_PARSED_NODE_BLOCK_MIN_SIZE 8
+#define DOM_PARSED_NODE_BLOCK_MAX_SIZE 256
 
 struct dom_parsed_name
 {
@@ -1117,7 +1118,8 @@ struct dom_parsed_node_block
 {
     struct list entry;
     size_t used;
-    struct domnode nodes[DOM_PARSED_NODE_BLOCK_SIZE];
+    size_t size;
+    struct domnode nodes[];
 };
 
 struct dom_parsed_pool
@@ -1191,15 +1193,20 @@ static struct domnode *domdoc_alloc_parsed_node(struct domdoc_properties *proper
     struct dom_parsed_node_block *block;
     struct dom_parsed_pool *pool;
     struct domnode *node;
+    size_t size;
 
     if (!(pool = domdoc_get_parsed_pool(properties)))
         return NULL;
     block = list_empty(&pool->node_blocks) ? NULL
             : LIST_ENTRY(list_head(&pool->node_blocks), struct dom_parsed_node_block, entry);
-    if (!block || block->used == DOM_PARSED_NODE_BLOCK_SIZE)
+    if (!block || block->used == block->size)
     {
-        if (!(block = calloc(1, sizeof(*block))))
+        size = block ? min(block->size * 2, (size_t)DOM_PARSED_NODE_BLOCK_MAX_SIZE)
+                : DOM_PARSED_NODE_BLOCK_MIN_SIZE;
+        if (!(block = calloc(1, offsetof(struct dom_parsed_node_block, nodes)
+                + size * sizeof(*block->nodes))))
             return NULL;
+        block->size = size;
         list_add_head(&pool->node_blocks, &block->entry);
     }
 
@@ -4627,6 +4634,8 @@ static void parse_context_cleanup(struct parse_context *c)
         ISAXXMLReader_Release(c->reader);
     if (c->reader_extension)
         ISAXXMLReaderExtension_Release(c->reader_extension);
+    if (c->root)
+        domnode_destroy_tree(c->root);
 }
 
 HRESULT parse_stream(ISequentialStream *stream, bool utf16, const struct domdoc_properties *properties, struct domnode **tree)

--- a/dlls/msxml3/node.c
+++ b/dlls/msxml3/node.c
@@ -3903,6 +3903,8 @@ struct parse_context
     HRESULT status;
     int max_depth;
     int depth;
+    bool preserve_document;
+    bool preserve_whitespace;
 };
 
 static void parse_context_node_create(struct parse_context *context, DOMNodeType type,
@@ -4010,7 +4012,7 @@ static void parse_context_node_put_data(struct parse_context *context, struct do
 
 static HRESULT parse_context_create_text_node(struct parse_context *c, DOMNodeType type)
 {
-    bool preserve, space = true;
+    bool space = true;
     bool ignored_whitespace = false;
     struct domnode *node;
 
@@ -4031,8 +4033,7 @@ static HRESULT parse_context_create_text_node(struct parse_context *c, DOMNodeTy
     if (c->buffer.count == 0)
         return S_OK;
 
-    preserve = is_preserving_whitespace(c->node);
-    if (!preserve)
+    if (!c->preserve_whitespace)
     {
         for (size_t i = 0; i < c->buffer.count; ++i)
         {
@@ -4072,6 +4073,25 @@ static HRESULT parse_context_create_text_node(struct parse_context *c, DOMNodeTy
     }
 
     return c->status;
+}
+
+static void parse_context_set_element_whitespace(struct parse_context *c, struct domnode *element)
+{
+    struct domnode *attr;
+    BSTR value;
+    bool preserve = c->preserve_whitespace;
+
+    if (!c->preserve_document && domnode_get_qualified_attribute(element, L"space",
+            L"http://www.w3.org/XML/1998/namespace", &attr) == S_OK
+            && node_get_text(attr, &value) == S_OK)
+    {
+        preserve = !wcscmp(value, L"preserve");
+        SysFreeString(value);
+    }
+
+    if (preserve)
+        element->flags |= DOMNODE_PARSED_PRESERVE_SPACE;
+    c->preserve_whitespace = preserve;
 }
 
 static struct parse_context *impl_from_ISAXContentHandler(ISAXContentHandler *iface)
@@ -4189,6 +4209,8 @@ static HRESULT WINAPI parse_content_handler_startElement(ISAXContentHandler *ifa
         }
     }
 
+    parse_context_set_element_whitespace(c, element);
+
     return c->status;
 }
 
@@ -4200,6 +4222,8 @@ static HRESULT WINAPI parse_content_handler_endElement(ISAXContentHandler *iface
     --c->depth;
     parse_context_create_text_node(c, NODE_TEXT);
     c->node = c->node->parent;
+    c->preserve_whitespace = c->preserve_document
+            || (c->node->flags & DOMNODE_PARSED_PRESERVE_SPACE);
 
     return c->status;
 }
@@ -4621,6 +4645,8 @@ static HRESULT parse_context_init(struct parse_context *c, const struct domdoc_p
     c->buffer.status = &c->status;
     c->max_depth = properties->max_element_depth;
     c->version = properties->version;
+    c->preserve_document = properties->preserving == VARIANT_TRUE;
+    c->preserve_whitespace = c->preserve_document;
 
     if (FAILED(hr = SAXXMLReader_create(MSXML3, (void **)&unk)))
         return hr;
@@ -4758,10 +4784,9 @@ static xmlNodePtr create_xmlnode_element(struct xmldoc_context *context, struct 
     xmlNsPtr ns;
     BSTR text;
 
-    name = xmlchar_from_wchar(node->name);
-    xmlnode = xmlNewDocNode(context->xmldoc, NULL, name, NULL);
+    name = xmlchar_from_wcharn(node->name, -1, TRUE);
+    xmlnode = xmlNewDocNodeEatName(context->xmldoc, NULL, name, NULL);
     xmlAddChild(context->tree, xmlnode);
-    free(name);
 
     ns = xmlnode_get_ns(context->tree, node, xmlnode);
     xmlSetNs(xmlnode, ns);
@@ -4794,11 +4819,11 @@ static xmlNodePtr create_xmlnode_element(struct xmldoc_context *context, struct 
 
         node_get_text(attr, &text);
 
-        name = xmlchar_from_wchar(attr->name);
+        name = xmlchar_from_wcharn(attr->name, -1, TRUE);
         value = xmlchar_from_wchar(text);
 
         ns = xmlnode_get_ns(xmlnode, attr, xmlnode);
-        xmlattr = xmlNewProp(xmlnode, name, value);
+        xmlattr = xmlNewNsPropEatName(xmlnode, NULL, name, value);
         xmlattr->_private2 = attr;
         xmlSetNs((xmlNodePtr)xmlattr, ns);
 
@@ -4807,7 +4832,6 @@ static xmlNodePtr create_xmlnode_element(struct xmldoc_context *context, struct 
 
         SysFreeString(text);
         free(value);
-        free(name);
     }
 
     return xmlnode;
@@ -4844,8 +4868,7 @@ static xmlNodePtr create_xmlnode_from_domnode(struct xmldoc_context *context, st
     struct domnode *n;
     xmlDtdPtr dtd;
 
-    name = node->name ? xmlchar_from_wchar(node->name) : NULL;
-    data = node->data ? xmlchar_from_wchar(node->data) : NULL;
+    name = data = NULL;
 
     switch (node->type)
     {
@@ -4853,18 +4876,23 @@ static xmlNodePtr create_xmlnode_from_domnode(struct xmldoc_context *context, st
             xmlnode = create_xmlnode_element(context, node);
             break;
         case NODE_COMMENT:
+            data = node->data ? xmlchar_from_wchar(node->data) : NULL;
             xmlnode = xmlNewDocComment(context->xmldoc, data);
             xmlAddChild(context->tree, xmlnode);
             break;
         case NODE_TEXT:
+            data = node->data ? xmlchar_from_wchar(node->data) : NULL;
             xmlnode = xmlNewDocText(context->xmldoc, data);
             xmlAddChild(context->tree, xmlnode);
             break;
         case NODE_PROCESSING_INSTRUCTION:
+            name = node->name ? xmlchar_from_wchar(node->name) : NULL;
+            data = node->data ? xmlchar_from_wchar(node->data) : NULL;
             xmlnode = xmlNewDocPI(context->xmldoc, name, data);
             xmlAddChild(context->tree, xmlnode);
             break;
         case NODE_CDATA_SECTION:
+            data = node->data ? xmlchar_from_wchar(node->data) : NULL;
             xmlnode = xmlNewCDataBlock(context->xmldoc, data, xmlStrlen(data));
             xmlAddChild(context->tree, xmlnode);
             break;

--- a/dlls/msxml3/node.c
+++ b/dlls/msxml3/node.c
@@ -1124,7 +1124,7 @@ struct dom_parsed_node_block
 
 struct dom_parsed_pool
 {
-    unsigned int refcount;
+    LONG refcount;
     size_t name_count;
     struct list buckets[256];
     struct list node_blocks;
@@ -1226,7 +1226,7 @@ static struct domnode *domdoc_alloc_parsed_node(struct domdoc_properties *proper
     node = &block->nodes[block->used++];
     node->flags = DOMNODE_POOLED_ALLOCATION;
     node->parsed_pool = pool;
-    ++pool->refcount;
+    InterlockedIncrement(&pool->refcount);
     return node;
 }
 
@@ -1235,7 +1235,7 @@ static void dom_parsed_pool_release(struct dom_parsed_pool *pool)
     struct dom_parsed_name *entry, *next;
     struct dom_parsed_node_block *block, *block_next;
 
-    if (!pool || --pool->refcount)
+    if (!pool || InterlockedDecrement(&pool->refcount))
         return;
     for (size_t i = 0; i < ARRAY_SIZE(pool->buckets); ++i)
     {
@@ -4193,6 +4193,8 @@ static HRESULT WINAPI parse_content_handler_startElement(ISAXContentHandler *ifa
 
     parse_context_create_text_node(c, NODE_TEXT);
     parse_context_node_create(c, NODE_ELEMENT, qname, qname_len, uri, uri_len, c->root, &element);
+    if (c->status != S_OK)
+        return c->status;
     parse_context_append_child(c, c->node, element);
     c->node = element;
 

--- a/dlls/msxml3/node.c
+++ b/dlls/msxml3/node.c
@@ -2407,13 +2407,6 @@ static void xml_write_quotedstring(xmlOutputBufferPtr buf, const xmlChar *string
     }
 }
 
-static int XMLCALL transform_to_stream_write(void *context, const char *buffer, int len)
-{
-    DWORD written;
-    HRESULT hr = ISequentialStream_Write((ISequentialStream *)context, buffer, len, &written);
-    return hr == S_OK ? written : -1;
-}
-
 /* Output for method "text" */
 static void transform_write_text(xmlDocPtr result, xsltStylesheetPtr style, xmlOutputBufferPtr output)
 {
@@ -2653,8 +2646,10 @@ static HRESULT node_transform_write_to_bstr(xsltStylesheetPtr style, xmlDocPtr r
 static HRESULT node_transform_write_to_stream(xsltStylesheetPtr style, xmlDocPtr result, ISequentialStream *stream)
 {
     static const xmlChar *utf16 = (const xmlChar*)"UTF-16";
+    const xmlChar *content;
     xmlOutputBufferPtr output;
     const xmlChar *encoding;
+    size_t offset, size;
     HRESULT hr;
 
     if (transform_is_empty_resultdoc(result))
@@ -2674,11 +2669,29 @@ static HRESULT node_transform_write_to_stream(xsltStylesheetPtr style, xmlDocPtr
     if (!encoding)
         encoding = utf16;
 
-    output = xmlOutputBufferCreateIO(transform_to_stream_write, NULL, stream, xmlFindCharEncodingHandler((const char*)encoding));
+    output = xmlAllocOutputBuffer(xmlFindCharEncodingHandler((const char*)encoding));
     if (!output)
         return E_OUTOFMEMORY;
 
     hr = node_transform_write(style, result, FALSE, (const char*)encoding, output);
+    if (SUCCEEDED(hr))
+    {
+        xmlBufPtr buffer = output->conv ? output->conv : output->buffer;
+
+        content = xmlBufContent(buffer);
+        size = xmlBufUse(buffer);
+        offset = 0;
+        while (offset < size)
+        {
+            ULONG chunk = size - offset > ~(ULONG)0 ? ~(ULONG)0 : size - offset;
+            ULONG written;
+
+            hr = ISequentialStream_Write(stream, content + offset, chunk, &written);
+            if (FAILED(hr) || !written)
+                break;
+            offset += written;
+        }
+    }
     xmlOutputBufferClose(output);
     return hr;
 }

--- a/dlls/msxml3/node.c
+++ b/dlls/msxml3/node.c
@@ -3972,7 +3972,7 @@ static void parse_context_node_put_data(struct parse_context *context, struct do
 
 static HRESULT parse_context_create_text_node(struct parse_context *c, DOMNodeType type)
 {
-    bool preserve = is_preserving_whitespace(c->node), space = true;
+    bool preserve, space = true;
     bool ignored_whitespace = false;
     struct domnode *node;
 
@@ -3993,6 +3993,7 @@ static HRESULT parse_context_create_text_node(struct parse_context *c, DOMNodeTy
     if (c->buffer.count == 0)
         return S_OK;
 
+    preserve = is_preserving_whitespace(c->node);
     if (!preserve)
     {
         for (size_t i = 0; i < c->buffer.count; ++i)

--- a/dlls/msxml3/node.c
+++ b/dlls/msxml3/node.c
@@ -1103,15 +1103,158 @@ static void domnode_insert_attribute(struct domnode *parent, struct domnode *nod
     domnode_set_owner(node, parent);
 }
 
-HRESULT domnode_create(DOMNodeType type, const WCHAR *name, int name_len, const WCHAR *uri, int uri_len,
-        struct domnode *owner, struct domnode **node)
+#define DOM_PARSED_NAME_POOL_LIMIT 4096
+#define DOM_PARSED_NODE_BLOCK_SIZE 256
+
+struct dom_parsed_name
+{
+    struct list entry;
+    BSTR value;
+    UINT hash;
+};
+
+struct dom_parsed_node_block
+{
+    struct list entry;
+    size_t used;
+    struct domnode nodes[DOM_PARSED_NODE_BLOCK_SIZE];
+};
+
+struct dom_parsed_pool
+{
+    unsigned int refcount;
+    size_t name_count;
+    struct list buckets[256];
+    struct list node_blocks;
+};
+
+static UINT dom_parsed_name_hash(const WCHAR *name, int len)
+{
+    UINT hash = 2166136261u;
+
+    for (int i = 0; i < len; ++i)
+        hash = (hash ^ name[i]) * 16777619u;
+    return hash;
+}
+
+static struct dom_parsed_pool *domdoc_get_parsed_pool(struct domdoc_properties *properties)
+{
+    struct dom_parsed_pool *pool = properties->parsed_pool;
+
+    if (!pool)
+    {
+        if (!(pool = calloc(1, sizeof(*pool))))
+            return NULL;
+        pool->refcount = 1;
+        for (size_t i = 0; i < ARRAY_SIZE(pool->buckets); ++i)
+            list_init(&pool->buckets[i]);
+        list_init(&pool->node_blocks);
+        properties->parsed_pool = pool;
+    }
+    return pool;
+}
+
+static BSTR domdoc_intern_parsed_name(struct domdoc_properties *properties,
+        const WCHAR *name, int len)
+{
+    struct dom_parsed_pool *pool;
+    struct dom_parsed_name *entry;
+    UINT hash;
+
+    if (!(pool = domdoc_get_parsed_pool(properties)))
+        return NULL;
+
+    hash = dom_parsed_name_hash(name, len);
+    LIST_FOR_EACH_ENTRY(entry, &pool->buckets[hash % ARRAY_SIZE(pool->buckets)],
+            struct dom_parsed_name, entry)
+    {
+        if (entry->hash == hash && SysStringLen(entry->value) == len
+                && !memcmp(entry->value, name, len * sizeof(*name)))
+            return entry->value;
+    }
+
+    if (pool->name_count >= DOM_PARSED_NAME_POOL_LIMIT || !(entry = malloc(sizeof(*entry))))
+        return NULL;
+    if (!(entry->value = SysAllocStringLen(name, len)))
+    {
+        free(entry);
+        return NULL;
+    }
+    entry->hash = hash;
+    list_add_head(&pool->buckets[hash % ARRAY_SIZE(pool->buckets)], &entry->entry);
+    ++pool->name_count;
+    return entry->value;
+}
+
+static struct domnode *domdoc_alloc_parsed_node(struct domdoc_properties *properties)
+{
+    struct dom_parsed_node_block *block;
+    struct dom_parsed_pool *pool;
+    struct domnode *node;
+
+    if (!(pool = domdoc_get_parsed_pool(properties)))
+        return NULL;
+    block = list_empty(&pool->node_blocks) ? NULL
+            : LIST_ENTRY(list_head(&pool->node_blocks), struct dom_parsed_node_block, entry);
+    if (!block || block->used == DOM_PARSED_NODE_BLOCK_SIZE)
+    {
+        if (!(block = calloc(1, sizeof(*block))))
+            return NULL;
+        list_add_head(&pool->node_blocks, &block->entry);
+    }
+
+    node = &block->nodes[block->used++];
+    node->flags = DOMNODE_POOLED_ALLOCATION;
+    node->parsed_pool = pool;
+    ++pool->refcount;
+    return node;
+}
+
+static void dom_parsed_pool_release(struct dom_parsed_pool *pool)
+{
+    struct dom_parsed_name *entry, *next;
+    struct dom_parsed_node_block *block, *block_next;
+
+    if (!pool || --pool->refcount)
+        return;
+    for (size_t i = 0; i < ARRAY_SIZE(pool->buckets); ++i)
+    {
+        LIST_FOR_EACH_ENTRY_SAFE(entry, next, &pool->buckets[i], struct dom_parsed_name, entry)
+        {
+            list_remove(&entry->entry);
+            SysFreeString(entry->value);
+            free(entry);
+        }
+    }
+    LIST_FOR_EACH_ENTRY_SAFE(block, block_next, &pool->node_blocks,
+            struct dom_parsed_node_block, entry)
+    {
+        list_remove(&block->entry);
+        free(block);
+    }
+    free(pool);
+}
+
+static void domdoc_free_parsed_pool(struct domdoc_properties *properties)
+{
+    dom_parsed_pool_release(properties->parsed_pool);
+    properties->parsed_pool = NULL;
+}
+
+static HRESULT domnode_create_internal(DOMNodeType type, const WCHAR *name, int name_len,
+        const WCHAR *uri, int uri_len, struct domnode *owner, bool validate_name, bool parsed,
+        struct domnode **node)
 {
     struct domnode *object, *xmlns_xml;
     WCHAR *p;
 
     *node = NULL;
 
-    if (!(object = calloc(1, sizeof(*object))))
+    if (parsed && type != NODE_DOCUMENT_TYPE)
+        object = domdoc_alloc_parsed_node(owner->properties);
+    else
+        object = calloc(1, sizeof(*object));
+    if (!object)
         return E_OUTOFMEMORY;
 
     list_init(&object->entry);
@@ -1124,10 +1267,26 @@ HRESULT domnode_create(DOMNodeType type, const WCHAR *name, int name_len, const 
     if (owner)
         list_add_tail(&owner->owned, &object->owner_entry);
 
-    object->qname = SysAllocStringLen(name, name_len);
+    /* Text node names are exposed as the constant "#text" and XPath treats
+     * their internal name as empty. Avoid an otherwise unused empty BSTR for
+     * every parsed text node. */
+    if (parsed && (type == NODE_ELEMENT || type == NODE_ATTRIBUTE))
+    {
+        object->qname = domdoc_intern_parsed_name(owner->properties, name, name_len);
+        if (object->qname)
+            object->flags |= DOMNODE_POOLED_QNAME;
+    }
+    if (!object->qname && (type != NODE_TEXT || name_len))
+    {
+        if (!(object->qname = SysAllocStringLen(name, name_len)))
+        {
+            domnode_destroy_tree(object);
+            return E_OUTOFMEMORY;
+        }
+    }
     if (type == NODE_ELEMENT || type == NODE_ATTRIBUTE)
     {
-        if (!parser_is_valid_qualified_name(object->qname))
+        if (validate_name && !parser_is_valid_qualified_name(object->qname))
         {
             domnode_destroy_tree(object);
             return E_FAIL;
@@ -1170,7 +1329,8 @@ HRESULT domnode_create(DOMNodeType type, const WCHAR *name, int name_len, const 
             break;
         case NODE_DOCUMENT:
             /* Stash implicit namespace as a document attribute, without a parent. */
-            domnode_create(NODE_ATTRIBUTE, L"xmlns:xml", 9, NULL, 0, object, &xmlns_xml);
+            domnode_create_internal(NODE_ATTRIBUTE, L"xmlns:xml", 9, NULL, 0,
+                    object, true, false, &xmlns_xml);
             node_put_data(xmlns_xml, L"http://www.w3.org/XML/1998/namespace");
             xmlns_xml->flags |= DOMNODE_READONLY_VALUE | DOMNODE_NO_PARENT;
             domnode_insert_attribute(object, xmlns_xml, NULL);
@@ -1182,6 +1342,12 @@ HRESULT domnode_create(DOMNodeType type, const WCHAR *name, int name_len, const 
     *node = object;
 
     return S_OK;
+}
+
+HRESULT domnode_create(DOMNodeType type, const WCHAR *name, int name_len, const WCHAR *uri, int uri_len,
+        struct domnode *owner, struct domnode **node)
+{
+    return domnode_create_internal(type, name, name_len, uri, uri_len, owner, true, false, node);
 }
 
 static HRESULT parse_xml_decl_append_attribute(struct domnode *pi, const WCHAR *name, BSTR value)
@@ -1329,6 +1495,7 @@ static void domdoc_properties_destroy(struct domdoc_properties *properties)
     properties->namespaces.value = NULL;
     if (properties->uri)
         IUri_Release(properties->uri);
+    domdoc_free_parsed_pool(properties);
     free(properties);
 }
 
@@ -1356,6 +1523,7 @@ static struct domdoc_properties* domdoc_properties_clone(struct domdoc_propertie
         pcopy->uri = properties->uri;
         if (pcopy->uri)
             IUri_AddRef(pcopy->uri);
+        pcopy->parsed_pool = NULL;
     }
 
     return pcopy;
@@ -1363,6 +1531,8 @@ static struct domdoc_properties* domdoc_properties_clone(struct domdoc_propertie
 
 void domnode_destroy_tree(struct domnode *tree)
 {
+    struct dom_parsed_pool *parsed_pool = tree->flags & DOMNODE_POOLED_ALLOCATION
+            ? tree->parsed_pool : NULL;
     struct domnode *node, *next;
 
     if (tree->type == NODE_DOCUMENT)
@@ -1405,16 +1575,28 @@ void domnode_destroy_tree(struct domnode *tree)
         }
     }
 
-    if (tree->prefix)
+    if (tree->flags & DOMNODE_POOLED_QNAME)
     {
         SysFreeString(tree->prefix);
-        SysFreeString(tree->qname);
+        if (tree->name != tree->qname)
+            SysFreeString(tree->name);
     }
-    SysFreeString(tree->name);
+    else
+    {
+        if (tree->prefix)
+        {
+            SysFreeString(tree->prefix);
+            SysFreeString(tree->qname);
+        }
+        SysFreeString(tree->name);
+    }
     SysFreeString(tree->data);
     SysFreeString(tree->uri);
 
-    free(tree);
+    if (parsed_pool)
+        dom_parsed_pool_release(parsed_pool);
+    else
+        free(tree);
 }
 
 void domnode_release(struct domnode *node)
@@ -3193,7 +3375,6 @@ HRESULT node_transform_node_params(struct domnode *node, IXMLDOMNode *stylesheet
 
     sheet_doc = create_xmldoc_from_domdoc(sheet_domdoc, &xmlnode);
     node_doc = create_xmldoc_from_domdoc(node, &xmlnode);
-
     xsltSS = xsltParseStylesheetDoc(sheet_doc);
     if (xsltSS)
     {
@@ -3706,7 +3887,8 @@ static void parse_context_node_create(struct parse_context *context, DOMNodeType
     if (context->status != S_OK)
         return;
 
-    context->status = domnode_create(type, name, name_len, uri, uri_len, owner, node);
+    context->status = domnode_create_internal(type, name, name_len, uri, uri_len,
+            owner, false, true, node);
 }
 
 static void parse_context_append_child(struct parse_context *context, struct domnode *parent, struct domnode *child)
@@ -3723,10 +3905,43 @@ static void parse_context_append_attribute(struct parse_context *context, struct
 
 static void parse_context_node_put_data(struct parse_context *context, struct domnode *node, const WCHAR *data, int data_len)
 {
+    struct domnode *child;
+    bool normalize = false;
     BSTR str;
+    int i;
 
     if (context->status != S_OK)
         return;
+
+    /* The SAX reader already normalized line endings and validated markup.
+     * Keep the public setter for the uncommon unnormalized case, but avoid
+     * copying parsed data into a temporary BSTR and scanning it again. */
+    for (i = 0; i < data_len; ++i)
+    {
+        if (data[i] == '\r')
+        {
+            normalize = true;
+            break;
+        }
+    }
+    if (normalize)
+    {
+        if (!(str = SysAllocStringLen(data, data_len)))
+        {
+            context->status = E_OUTOFMEMORY;
+            return;
+        }
+
+        context->status = node_put_data(node, str);
+        SysFreeString(str);
+        return;
+    }
+
+    if (node->flags & DOMNODE_READONLY_VALUE)
+    {
+        context->status = E_FAIL;
+        return;
+    }
 
     if (!(str = SysAllocStringLen(data, data_len)))
     {
@@ -3734,8 +3949,25 @@ static void parse_context_node_put_data(struct parse_context *context, struct do
         return;
     }
 
-    context->status = node_put_data(node, str);
-    SysFreeString(str);
+    node->flags &= ~DOMNODE_PARSED_VALUE;
+    if (node->type == NODE_ATTRIBUTE || node->type == NODE_ELEMENT)
+    {
+        node_unlink_children(node);
+        context->status = domnode_create_internal(NODE_TEXT, NULL, 0, NULL, 0,
+                node->owner, false, true, &child);
+        if (context->status != S_OK)
+        {
+            SysFreeString(str);
+            return;
+        }
+        domnode_append_child(node, child);
+        child->data = str;
+    }
+    else
+    {
+        SysFreeString(node->data);
+        node->data = str;
+    }
 }
 
 static HRESULT parse_context_create_text_node(struct parse_context *c, DOMNodeType type)

--- a/dlls/msxml3/node.c
+++ b/dlls/msxml3/node.c
@@ -2687,8 +2687,13 @@ static HRESULT node_transform_write_to_stream(xsltStylesheetPtr style, xmlDocPtr
             ULONG written;
 
             hr = ISequentialStream_Write(stream, content + offset, chunk, &written);
-            if (FAILED(hr) || !written)
+            if (FAILED(hr))
                 break;
+            if (!written)
+            {
+                hr = E_FAIL;
+                break;
+            }
             offset += written;
         }
     }
@@ -2738,15 +2743,29 @@ static HRESULT import_loader_onDataAvailable(void *ctxt, char *ptr, DWORD len)
     xmlParserInputBufferPtr inputbuffer;
     struct import_buffer *buffer;
 
-    buffer = malloc(sizeof(*buffer));
+    if (!(buffer = malloc(sizeof(*buffer))))
+        return E_OUTOFMEMORY;
 
-    buffer->data = malloc(len);
-    memcpy(buffer->data, ptr, len);
+    buffer->data = NULL;
+    if (len)
+    {
+        if (!(buffer->data = malloc(len)))
+        {
+            free(buffer);
+            return E_OUTOFMEMORY;
+        }
+        memcpy(buffer->data, ptr, len);
+    }
     buffer->cur = 0;
     buffer->len = len;
 
     inputbuffer = xmlParserInputBufferCreateIO(import_loader_io_read, import_loader_io_close, buffer,
             XML_CHAR_ENCODING_NONE);
+    if (!inputbuffer)
+    {
+        import_loader_io_close(buffer);
+        return E_OUTOFMEMORY;
+    }
     *input = xmlNewIOInputStream(NULL, inputbuffer, XML_CHAR_ENCODING_NONE);
     if (!*input)
         xmlFreeParserInputBuffer(inputbuffer);

--- a/dlls/msxml3/saxreader.c
+++ b/dlls/msxml3/saxreader.c
@@ -360,21 +360,8 @@ static enum saxreader_feature get_saxreader_feature(const WCHAR *name)
 
 static const WCHAR empty_str;
 
-typedef struct
-{
-    BSTR prefix;
-    BSTR uri;
-} ns;
-
-typedef struct
-{
-    struct list entry;
-    BSTR prefix;
-    BSTR local;
-    BSTR qname;
-    ns *ns; /* namespaces defined in this particular element */
-    int ns_count;
-} element_entry;
+/* Repeated XML names are common, but do not retain an unbounded unique set. */
+#define SAXREADER_NAME_POOL_LIMIT 4096
 
 enum saxhandler_type
 {
@@ -895,8 +882,12 @@ struct saxlocator
     int column;
     bool vbInterface;
     struct list elements;
+    struct list free_elements;
     enum saxreader_state state;
     int depth;
+    bool pool_names;
+    size_t name_pool_count;
+    struct list name_pool[256];
 
     ISequentialStream *stream;
     bool eos;
@@ -922,6 +913,7 @@ struct saxlocator
 
     bool collect;
     struct string_buffer scratch;
+    struct string_buffer characters;
     struct input_buffer buffer;
     struct text_position start_document_position;
     HRESULT status;
@@ -1023,9 +1015,13 @@ static void saxreader_clear_enumeration(struct enumeration *list)
 
 static void saxreader_free_name(struct parsed_name *name)
 {
-    SysFreeString(name->prefix);
-    SysFreeString(name->local);
-    SysFreeString(name->qname);
+    if (!name->pooled)
+    {
+        SysFreeString(name->prefix);
+        if (name->qname != name->local)
+            SysFreeString(name->qname);
+        SysFreeString(name->local);
+    }
     memset(name, 0, sizeof(*name));
 }
 
@@ -1162,6 +1158,71 @@ static BSTR saxreader_alloc_stringlen(struct saxlocator *locator, const WCHAR *s
     return ret;
 }
 
+struct pooled_name
+{
+    struct list entry;
+    BSTR value;
+    UINT hash;
+};
+
+static UINT saxreader_name_hash(const WCHAR *str, UINT len)
+{
+    UINT hash = 2166136261u;
+
+    for (UINT i = 0; i < len; ++i)
+        hash = (hash ^ str[i]) * 16777619u;
+    return hash;
+}
+
+static BSTR saxreader_intern_stringlen(struct saxlocator *locator, const WCHAR *str, UINT len)
+{
+    struct pooled_name *entry;
+    UINT hash;
+
+    if (!locator->pool_names)
+        return saxreader_alloc_stringlen(locator, str, len);
+
+    hash = saxreader_name_hash(str, len);
+    LIST_FOR_EACH_ENTRY(entry, &locator->name_pool[hash % ARRAY_SIZE(locator->name_pool)],
+            struct pooled_name, entry)
+    {
+        if (entry->hash == hash && SysStringLen(entry->value) == len
+                && !memcmp(entry->value, str, len * sizeof(WCHAR)))
+            return entry->value;
+    }
+
+    if (!(entry = malloc(sizeof(*entry))))
+    {
+        saxreader_set_error(locator, E_OUTOFMEMORY);
+        return NULL;
+    }
+    if (!(entry->value = SysAllocStringLen(str, len)))
+    {
+        free(entry);
+        saxreader_set_error(locator, E_OUTOFMEMORY);
+        return NULL;
+    }
+    entry->hash = hash;
+    list_add_head(&locator->name_pool[hash % ARRAY_SIZE(locator->name_pool)], &entry->entry);
+    ++locator->name_pool_count;
+    return entry->value;
+}
+
+static void saxreader_clear_name_pool(struct saxlocator *locator)
+{
+    struct pooled_name *entry, *next;
+
+    for (UINT i = 0; i < ARRAY_SIZE(locator->name_pool); ++i)
+    {
+        LIST_FOR_EACH_ENTRY_SAFE(entry, next, &locator->name_pool[i], struct pooled_name, entry)
+        {
+            list_remove(&entry->entry);
+            SysFreeString(entry->value);
+            free(entry);
+        }
+    }
+}
+
 static void saxreader_ensure_dtd_typenames(struct saxlocator *locator)
 {
     if (locator->strings.typenames[ATTR_TYPE_CDATA])
@@ -1184,24 +1245,6 @@ static void saxreader_ensure_dtd_typenames(struct saxlocator *locator)
 static bool is_namespaces_enabled(const struct saxreader *reader)
 {
     return (reader->version < MSXML4) || (reader->features & Namespaces);
-}
-
-static void free_element_entry(element_entry *element)
-{
-    int i;
-
-    for (i=0; i<element->ns_count;i++)
-    {
-        SysFreeString(element->ns[i].prefix);
-        SysFreeString(element->ns[i].uri);
-    }
-
-    SysFreeString(element->prefix);
-    SysFreeString(element->local);
-    SysFreeString(element->qname);
-
-    free(element->ns);
-    free(element);
 }
 
 static HRESULT WINAPI ivbsaxattributes_QueryInterface(IVBSAXAttributes *iface, REFIID riid, void **obj)
@@ -1979,6 +2022,8 @@ static void saxreader_clear_strings(struct saxlocator *locator)
     SysFreeString(locator->strings.null_uri);
 }
 
+static void saxreader_clear_element_stack(struct saxlocator *locator);
+
 static ULONG WINAPI isaxlocator_Release(ISAXLocator *iface)
 {
     struct saxlocator *locator = impl_from_ISAXLocator(iface);
@@ -1988,8 +2033,6 @@ static ULONG WINAPI isaxlocator_Release(ISAXLocator *iface)
 
     if (!refcount)
     {
-        element_entry *element, *element2;
-
         saxreader_clear_attributes(locator);
         free(locator->attributes.entries);
 
@@ -1998,12 +2041,9 @@ static ULONG WINAPI isaxlocator_Release(ISAXLocator *iface)
             parser_dtd_release(locator->dtd);
         locator->dtd = NULL;
 
-        /* element stack */
-        LIST_FOR_EACH_ENTRY_SAFE(element, element2, &locator->elements, element_entry, entry)
-        {
-            list_remove(&element->entry);
-            free_element_entry(element);
-        }
+        saxreader_clear_element_stack(locator);
+        saxreader_clear_name_pool(locator);
+        free(locator->characters.data);
 
         encoded_buffer_cleanup(&locator->buffer.utf16);
         encoded_buffer_cleanup(&locator->buffer.raw);
@@ -2091,6 +2131,9 @@ static HRESULT saxlocator_create(struct saxreader *reader, ISequentialStream *st
     locator->buffer.position.column = 1;
     locator->buffer.chunk_size = 4096;
     list_init(&locator->buffer.entities);
+    locator->pool_names = true;
+    for (UINT i = 0; i < ARRAY_SIZE(locator->name_pool); ++i)
+        list_init(&locator->name_pool[i]);
 
     locator->ret = S_OK;
 
@@ -2102,6 +2145,7 @@ static HRESULT saxlocator_create(struct saxreader *reader, ISequentialStream *st
         locator->strings.xmlns_uri = saxreader_alloc_stringlen(locator, NULL, 0);
 
     list_init(&locator->elements);
+    list_init(&locator->free_elements);
 
     if (FAILED(locator->status))
     {
@@ -2258,7 +2302,10 @@ static void saxreader_shrink(struct saxlocator *locator)
     struct encoded_buffer *buffer = &locator->buffer.utf16;
     size_t size;
 
-    if (buffer->cur > 3 * locator->buffer.chunk_size / 8)
+    /* Compact only after consuming more than remains, so repeated calls do
+     * not move the same input over and over. */
+    if (locator->buffer.switched_encoding
+            && buffer->cur > buffer->written / (2 * sizeof(WCHAR)))
     {
         size = buffer->written - buffer->cur * sizeof(WCHAR);
         if (size)
@@ -2448,6 +2495,30 @@ struct element
         size_t capacity;
     } ns;
 };
+
+static void saxreader_clear_element_stack(struct saxlocator *locator)
+{
+    struct element *element, *next;
+
+    LIST_FOR_EACH_ENTRY_SAFE(element, next, &locator->elements, struct element, entry)
+    {
+        list_remove(&element->entry);
+        saxreader_free_name(&element->name);
+        for (size_t i = 0; i < element->ns.count; ++i)
+        {
+            SysFreeString(element->ns.entries[i].prefix);
+            SysFreeString(element->ns.entries[i].uri);
+        }
+        free(element->ns.entries);
+        free(element);
+    }
+    LIST_FOR_EACH_ENTRY_SAFE(element, next, &locator->free_elements, struct element, entry)
+    {
+        list_remove(&element->entry);
+        free(element->ns.entries);
+        free(element);
+    }
+}
 
 static HRESULT saxlocator_callback_result(struct saxlocator *locator, HRESULT hr)
 {
@@ -2767,6 +2838,47 @@ static void saxlocator_characters(struct saxlocator *locator, const struct text_
         hr = ISAXContentHandler_characters(content->handler, chars, SysStringLen(chars));
 
     locator->status = saxlocator_callback_result(locator, hr);
+}
+
+static void saxlocator_characters_from_buffer(struct saxlocator *locator,
+        const struct text_position *position, struct string_buffer *buffer)
+{
+    struct saxcontenthandler_iface *content = saxreader_get_contenthandler(locator->saxreader);
+    BSTR chars;
+    HRESULT hr;
+
+    if (locator->status != S_OK || !buffer->count)
+    {
+        buffer->count = 0;
+        return;
+    }
+
+    locator->line = position->line;
+    locator->column = position->column;
+
+    if (!saxreader_has_handler(locator, SAXContentHandler))
+    {
+        buffer->count = 0;
+        return;
+    }
+
+    if (locator->vbInterface)
+    {
+        chars = saxreader_alloc_stringlen(locator, buffer->data, buffer->count);
+        if (chars)
+        {
+            hr = IVBSAXContentHandler_characters(content->vbhandler, &chars);
+            SysFreeString(chars);
+            locator->status = saxlocator_callback_result(locator, hr);
+        }
+    }
+    else
+    {
+        hr = ISAXContentHandler_characters(content->handler, buffer->data, buffer->count);
+        locator->status = saxlocator_callback_result(locator, hr);
+    }
+
+    buffer->count = 0;
 }
 
 static void saxlocator_comment(struct saxlocator *locator, const struct text_position *position, BSTR chars)
@@ -3545,6 +3657,10 @@ static bool saxreader_is_namechar(WCHAR ch)
 /* [5] NCNameChar ::= NameChar - ':' */
 bool xml_is_ncnamechar(WCHAR ch)
 {
+    if (ch < 0x80)
+        return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z')
+                || (ch >= '0' && ch <= '9') || ch == '.' || ch == '-'
+                || ch == '_';
     return saxreader_is_namechar(ch) && ch != ':';
 }
 
@@ -3556,6 +3672,8 @@ static bool saxreader_is_ncnamechar(WCHAR ch)
 /* [6] NCNameStartChar ::= Letter | '_' */
 bool xml_is_ncname_startchar(WCHAR ch)
 {
+    if (ch < 0x80)
+        return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch == '_';
     return saxreader_is_letter(ch) || ch == '_';
 }
 
@@ -3660,7 +3778,10 @@ static void saxreader_parse_name_strict(struct saxlocator *locator, BSTR *name)
 /* [4 NS] NCName ::= NCNameStartChar NCNameChar* */
 static BSTR saxreader_parse_ncname(struct saxlocator *locator)
 {
+    struct encoded_buffer *input = &locator->buffer.utf16;
     struct string_buffer buffer = { 0 };
+    size_t available, length;
+    BSTR name;
     WCHAR ch;
 
     if (locator->status != S_OK)
@@ -3673,6 +3794,30 @@ static BSTR saxreader_parse_ncname(struct saxlocator *locator)
         return NULL;
     }
 
+    /* Names normally fit in the current input chunk. Avoid a temporary
+     * growable buffer and per-character position updates in that common case.
+     * Entity expansion and collection need the original character-at-a-time
+     * path because they have additional state to maintain. */
+    if (!locator->collect && list_empty(&locator->buffer.entities))
+    {
+        const WCHAR *start = (const WCHAR *)input->data + input->cur;
+
+        available = input->written / sizeof(WCHAR) - input->cur;
+        for (length = 1; length < available && saxreader_is_ncnamechar(start[length]); ++length)
+            ;
+
+        if (length < available)
+        {
+            name = saxreader_intern_stringlen(locator, start, length);
+            input->cur += length;
+            locator->buffer.consumed += length;
+            locator->buffer.position.column += length;
+            locator->buffer.last_cr = false;
+            saxreader_shrink(locator);
+            return name;
+        }
+    }
+
     do
     {
         saxreader_string_append(locator, &buffer, &ch, 1);
@@ -3683,7 +3828,14 @@ static BSTR saxreader_parse_ncname(struct saxlocator *locator)
 
     saxreader_shrink(locator);
 
-    return saxreader_string_to_bstr(locator, &buffer);
+    name = saxreader_string_to_bstr(locator, &buffer);
+    if (locator->pool_names && name)
+    {
+        BSTR pooled = saxreader_intern_stringlen(locator, name, SysStringLen(name));
+        SysFreeString(name);
+        name = pooled;
+    }
+    return name;
 }
 
 /* [7 NS]  QName ::= PrefixedName | UnprefixedName
@@ -3696,6 +3848,9 @@ static void saxreader_parse_qname(struct saxlocator *locator, struct parsed_name
     BSTR ncname;
 
     memset(name, 0, sizeof(*name));
+    if (locator->name_pool_count >= SAXREADER_NAME_POOL_LIMIT)
+        locator->pool_names = false;
+    name->pooled = locator->pool_names;
 
     ncname = saxreader_parse_ncname(locator);
 
@@ -3709,6 +3864,8 @@ static void saxreader_parse_qname(struct saxlocator *locator, struct parsed_name
     else
     {
         name->local = ncname;
+        name->qname = ncname;
+        return;
     }
 
     if (name->prefix)
@@ -3717,7 +3874,15 @@ static void saxreader_parse_qname(struct saxlocator *locator, struct parsed_name
         saxreader_string_append(locator, &buffer, L":", 1);
     }
     saxreader_string_append(locator, &buffer, name->local, SysStringLen(name->local));
-    name->qname = saxreader_string_to_bstr(locator, &buffer);
+    if (locator->pool_names)
+    {
+        name->qname = saxreader_intern_stringlen(locator, buffer.data, buffer.count);
+        free(buffer.data);
+    }
+    else
+    {
+        name->qname = saxreader_string_to_bstr(locator, &buffer);
+    }
 }
 
 static const WCHAR * validate_ncname(const WCHAR *name)
@@ -3754,8 +3919,16 @@ static struct element *saxreader_new_element(struct saxlocator *locator, struct 
 {
     struct element *element;
 
-    if (!(element = saxreader_calloc(locator, 1, sizeof(*element))))
-        return NULL;
+    if (list_empty(&locator->free_elements))
+    {
+        if (!(element = saxreader_calloc(locator, 1, sizeof(*element))))
+            return NULL;
+    }
+    else
+    {
+        element = LIST_ENTRY(list_head(&locator->free_elements), struct element, entry);
+        list_remove(&element->entry);
+    }
     list_add_head(&locator->elements, &element->entry);
 
     element->name = *name;
@@ -3764,10 +3937,17 @@ static struct element *saxreader_new_element(struct saxlocator *locator, struct 
     return element;
 }
 
-static void saxreader_free_element(struct element *element)
+static void saxreader_free_element(struct saxlocator *locator, struct element *element)
 {
     saxreader_free_name(&element->name);
-    free(element);
+    for (size_t i = 0; i < element->ns.count; ++i)
+    {
+        SysFreeString(element->ns.entries[i].prefix);
+        SysFreeString(element->ns.entries[i].uri);
+    }
+    element->ns.count = 0;
+    element->uri = NULL;
+    list_add_head(&locator->free_elements, &element->entry);
 }
 
 static bool bstr_equal(BSTR s1, BSTR s2)
@@ -4256,6 +4436,8 @@ static void saxreader_reorder_attributes(struct saxlocator *locator)
         return;
 
     count = locator->attributes.count;
+    if (!count)
+        return;
     if (!(locator->attributes.map = saxreader_calloc(locator, count, sizeof(*locator->attributes.map))))
         return;
 
@@ -4335,23 +4517,54 @@ static void saxreader_parse_starttag(struct saxlocator *locator)
     {
         saxlocator_end_element(locator, &position, element);
         list_remove(&element->entry);
-        saxreader_free_element(element);
+        saxreader_free_element(locator, element);
     }
+}
+
+static bool saxreader_skip_matching_qname(struct saxlocator *locator, BSTR name)
+{
+    struct encoded_buffer *input = &locator->buffer.utf16;
+    size_t available, length = SysStringLen(name);
+    const WCHAR *ptr;
+
+    if (locator->collect || !list_empty(&locator->buffer.entities))
+        return false;
+
+    ptr = saxreader_get_ptr(locator);
+    available = input->written / sizeof(WCHAR) - input->cur;
+    if (available <= length || memcmp(ptr, name, length * sizeof(WCHAR)))
+        return false;
+    if (ptr[length] != '>' && !saxreader_is_space(ptr[length]))
+        return false;
+
+    input->cur += length;
+    locator->buffer.consumed += length;
+    locator->buffer.position.column += length;
+    locator->buffer.last_cr = false;
+    saxreader_shrink(locator);
+    return true;
 }
 
 /* [13 NS] ETag ::= '</' QName S? '>' */
 static void saxreader_parse_endtag(struct saxlocator *locator)
 {
     struct text_position position;
-    struct element *element;
-    struct parsed_name name;
+    struct parsed_name name = { 0 };
+    struct element *element = NULL;
+    bool matched = false;
     HRESULT hr = S_OK;
 
     /* Skip '</' */
     saxreader_skip(locator, 2);
     position = locator->buffer.position;
 
-    saxreader_parse_qname(locator, &name);
+    if (!list_empty(&locator->elements))
+    {
+        element = LIST_ENTRY(list_head(&locator->elements), struct element, entry);
+        matched = saxreader_skip_matching_qname(locator, element->name.qname);
+    }
+    if (!matched)
+        saxreader_parse_qname(locator, &name);
     saxreader_skipspaces(locator);
 
     if (!saxreader_cmp(locator, L">"))
@@ -4361,18 +4574,20 @@ static void saxreader_parse_endtag(struct saxlocator *locator)
 
     if (SUCCEEDED(hr))
     {
-        element = LIST_ENTRY(list_head(&locator->elements), struct element, entry);
+        if (!element)
+            element = LIST_ENTRY(list_head(&locator->elements), struct element, entry);
 
-        if (!wcscmp(element->name.qname, name.qname))
+        if (matched || !wcscmp(element->name.qname, name.qname))
             saxlocator_end_element(locator, &position, element);
         else
             hr = E_SAX_ENDTAGMISMATCH;
 
         list_remove(&element->entry);
-        saxreader_free_element(element);
+        saxreader_free_element(locator, element);
     }
 
-    saxreader_free_name(&name);
+    if (!matched)
+        saxreader_free_name(&name);
     saxreader_set_error(locator, hr);
 }
 
@@ -4598,16 +4813,46 @@ static void saxreader_parse_reference(struct saxlocator *locator)
 
 struct chardata_context
 {
-    struct string_buffer buffer;
+    struct string_buffer *buffer;
     struct text_position position;
     size_t count;
     WCHAR ch;
 };
 
+static bool saxreader_parse_characters_run(struct saxlocator *locator,
+        struct chardata_context *ctxt, bool cdata)
+{
+    struct encoded_buffer *input = &locator->buffer.utf16;
+    const WCHAR *ptr;
+    size_t available, length;
+
+    if (locator->collect || !list_empty(&locator->buffer.entities))
+        return false;
+
+    ptr = saxreader_get_ptr(locator);
+    available = input->written / sizeof(WCHAR) - input->cur;
+    for (length = 0; length < available; ++length)
+    {
+        WCHAR ch = ptr[length];
+
+        if (!ch || ch == ']' || ch == '\r' || ch == '\n'
+                || (!cdata && (ch == '<' || ch == '&')))
+            break;
+    }
+    if (!length)
+        return false;
+
+    saxreader_string_append(locator, ctxt->buffer, ptr, length);
+    input->cur += length;
+    locator->buffer.consumed += length;
+    locator->buffer.position.column += length;
+    locator->buffer.last_cr = false;
+    ctxt->ch = *saxreader_get_ptr(locator);
+    return true;
+}
+
 static void saxreader_parse_characters(struct saxlocator *locator, struct chardata_context *ctxt)
 {
-    BSTR chars;
-
     /* Normalize line breaks */
     if (ctxt->ch == '\r')
     {
@@ -4620,11 +4865,8 @@ static void saxreader_parse_characters(struct saxlocator *locator, struct charda
         else if (ctxt->ch != '\r')
             move_position = true;
 
-        saxreader_string_append(locator, &ctxt->buffer, L"\n", 1);
-        chars = saxreader_string_to_bstr(locator, &ctxt->buffer);
-
-        saxlocator_characters(locator, &ctxt->position, chars);
-        SysFreeString(chars);
+        saxreader_string_append(locator, ctxt->buffer, L"\n", 1);
+        saxlocator_characters_from_buffer(locator, &ctxt->position, ctxt->buffer);
 
         saxreader_shrink(locator);
 
@@ -4637,7 +4879,7 @@ static void saxreader_parse_characters(struct saxlocator *locator, struct charda
     }
     else
     {
-        saxreader_string_append(locator, &ctxt->buffer, &ctxt->ch, 1);
+        saxreader_string_append(locator, ctxt->buffer, &ctxt->ch, 1);
         saxreader_skip(locator, 1);
     }
 
@@ -4646,8 +4888,6 @@ static void saxreader_parse_characters(struct saxlocator *locator, struct charda
 
 static void saxreader_parse_characters_newparser(struct saxlocator *locator, struct chardata_context *ctxt)
 {
-    BSTR chars;
-
     /* Normalize line breaks */
     if (ctxt->ch == '\r')
     {
@@ -4661,18 +4901,14 @@ static void saxreader_parse_characters_newparser(struct saxlocator *locator, str
             move_position = true;
 
         /* Flush current block first, then new line separately */
-        chars = saxreader_string_to_bstr(locator, &ctxt->buffer);
-        saxlocator_characters(locator, &ctxt->position, chars);
-        SysFreeString(chars);
+        saxlocator_characters_from_buffer(locator, &ctxt->position, ctxt->buffer);
 
         saxreader_shrink(locator);
 
         ctxt->position = locator->buffer.position;
         ctxt->position.column = 0;
-        saxreader_string_append(locator, &ctxt->buffer, L"\n", 1);
-        chars = saxreader_string_to_bstr(locator, &ctxt->buffer);
-        saxlocator_characters(locator, &ctxt->position, chars);
-        SysFreeString(chars);
+        saxreader_string_append(locator, ctxt->buffer, L"\n", 1);
+        saxlocator_characters_from_buffer(locator, &ctxt->position, ctxt->buffer);
 
         if (move_position)
             ctxt->position = locator->buffer.position;
@@ -4683,7 +4919,7 @@ static void saxreader_parse_characters_newparser(struct saxlocator *locator, str
     }
     else
     {
-        saxreader_string_append(locator, &ctxt->buffer, &ctxt->ch, 1);
+        saxreader_string_append(locator, ctxt->buffer, &ctxt->ch, 1);
         saxreader_skip(locator, 1);
     }
 
@@ -4694,14 +4930,18 @@ static void saxreader_parse_characters_newparser(struct saxlocator *locator, str
 static void saxreader_parse_chardata(struct saxlocator *locator)
 {
     struct chardata_context context = { 0 };
-    BSTR chars;
 
+    context.buffer = &locator->characters;
+    context.buffer->count = 0;
     context.position = locator->buffer.position;
     context.count = locator->buffer.consumed;
     context.ch = *saxreader_get_ptr(locator);
 
     while (context.ch)
     {
+        if (saxreader_parse_characters_run(locator, &context, false))
+            continue;
+
         if (saxreader_cmp(locator, L"]]>"))
         {
             saxreader_set_error(locator, E_SAX_INVALID_CDATACLOSINGTAG);
@@ -4710,7 +4950,7 @@ static void saxreader_parse_chardata(struct saxlocator *locator)
 
         if (context.ch == '&' || context.ch == '<')
         {
-            if (context.buffer.count)
+            if (context.buffer->count)
             {
                 if (locator->saxreader->version >= MSXML4)
                 {
@@ -4718,13 +4958,11 @@ static void saxreader_parse_chardata(struct saxlocator *locator)
                     context.position.column = locator->buffer.position.column;
                 }
 
-                chars = saxreader_string_to_bstr(locator, &context.buffer);
-                saxlocator_characters(locator, &context.position, chars);
-                SysFreeString(chars);
+                saxlocator_characters_from_buffer(locator, &context.position, context.buffer);
             }
             else
             {
-                free(context.buffer.data);
+                context.buffer->count = 0;
             }
             return;
         }
@@ -4738,13 +4976,13 @@ static void saxreader_parse_chardata(struct saxlocator *locator)
         }
         else
         {
-            saxreader_string_append(locator, &context.buffer, &context.ch, 1);
+            saxreader_string_append(locator, context.buffer, &context.ch, 1);
             saxreader_skip(locator, 1);
             context.ch = *saxreader_get_ptr(locator);
         }
     }
 
-    free(context.buffer.data);
+    context.buffer->count = 0;
     saxreader_set_error(locator, E_SAX_UNEXPECTED_EOF);
 }
 
@@ -4755,11 +4993,12 @@ static void saxreader_parse_chardata(struct saxlocator *locator)
 static void saxreader_parse_cdata(struct saxlocator *locator)
 {
     struct chardata_context context = { 0 };
-    BSTR chars;
 
     /* Skip <![CDATA[ */
     saxreader_skip(locator, 9);
 
+    context.buffer = &locator->characters;
+    context.buffer->count = 0;
     context.position = locator->buffer.position;
     context.count = locator->buffer.consumed;
     context.ch = *saxreader_get_ptr(locator);
@@ -4768,6 +5007,9 @@ static void saxreader_parse_cdata(struct saxlocator *locator)
 
     while (context.ch && locator->status == S_OK)
     {
+        if (saxreader_parse_characters_run(locator, &context, true))
+            continue;
+
         if (saxreader_cmp(locator, L"]]>"))
         {
             /* Point to closing '>' */
@@ -4777,9 +5019,7 @@ static void saxreader_parse_cdata(struct saxlocator *locator)
                 context.position.column = locator->buffer.position.column - 1;
             }
 
-            chars = saxreader_string_to_bstr(locator, &context.buffer);
-            saxlocator_characters(locator, &context.position, chars);
-            SysFreeString(chars);
+            saxlocator_characters_from_buffer(locator, &context.position, context.buffer);
 
             return saxlocator_end_cdata(locator, &context.position);
         }
@@ -4793,13 +5033,13 @@ static void saxreader_parse_cdata(struct saxlocator *locator)
         }
         else
         {
-            saxreader_string_append(locator, &context.buffer, &context.ch, 1);
+            saxreader_string_append(locator, context.buffer, &context.ch, 1);
             saxreader_skip(locator, 1);
             context.ch = *saxreader_get_ptr(locator);
         }
     }
 
-    free(context.buffer.data);
+    context.buffer->count = 0;
     saxreader_set_error(locator, E_SAX_UNCLOSEDCDATA);
 }
 

--- a/dlls/msxml3/saxreader.c
+++ b/dlls/msxml3/saxreader.c
@@ -2427,8 +2427,10 @@ static bool saxreader_peek(struct saxlocator *locator, const WCHAR *str, size_t 
 
 static bool saxreader_cmp(struct saxlocator *locator, const WCHAR *str)
 {
+    struct input_buffer *input = &locator->buffer;
     const WCHAR *ptr;
     size_t i = 0;
+    bool single_line = true;
 
     if (FAILED(locator->status))
         return false;
@@ -2443,9 +2445,23 @@ static bool saxreader_cmp(struct saxlocator *locator, const WCHAR *str)
         }
         if (str[i] != ptr[i])
             return false;
+        if (str[i] == '\r' || str[i] == '\n')
+            single_line = false;
         i++;
     }
-    saxreader_skip(locator, i);
+
+    /* Most parser tokens are single-line delimiters in the main input. Avoid
+     * walking them a second time when there is no collection or entity state
+     * for saxreader_skip() to maintain. */
+    if (i && single_line && !locator->collect && list_empty(&input->entities))
+    {
+        input->utf16.cur += i;
+        input->consumed += i;
+        input->position.column += i;
+        input->last_cr = false;
+    }
+    else
+        saxreader_skip(locator, i);
     return true;
 }
 
@@ -4232,6 +4248,40 @@ static void saxreader_stringify_entity(struct saxlocator *locator, struct string
     }
 }
 
+static bool saxreader_parse_attvalue_run(struct saxlocator *locator,
+        struct string_buffer *buffer, WCHAR quote, bool normalize)
+{
+    struct encoded_buffer *input = &locator->buffer.utf16;
+    const WCHAR *ptr;
+    size_t available, length;
+
+    if (locator->collect || !list_empty(&locator->buffer.entities))
+        return false;
+
+    ptr = saxreader_get_ptr(locator);
+    available = input->written / sizeof(WCHAR) - input->cur;
+    for (length = 0; length < available; ++length)
+    {
+        WCHAR ch = ptr[length];
+
+        if (!ch || ch == quote || ch == '<' || ch == '&' || ch == '\r'
+                || ch == '\n' || (normalize && ch == '\t'))
+            break;
+    }
+    if (!length)
+        return false;
+
+    saxreader_string_append(locator, buffer, ptr, length);
+    if (locator->status == S_OK)
+    {
+        input->cur += length;
+        locator->buffer.consumed += length;
+        locator->buffer.position.column += length;
+        locator->buffer.last_cr = false;
+    }
+    return true;
+}
+
 /* [10] AttValue ::= '"' ([^<&"] | Reference)* '"'
         |  "'" ([^<&'] | Reference)* "'" */
 static BSTR saxreader_parse_attvalue(struct saxlocator *locator)
@@ -4239,7 +4289,7 @@ static BSTR saxreader_parse_attvalue(struct saxlocator *locator)
     struct string_buffer buffer = { 0 };
     struct text_position position;
     WCHAR quote[2] = { 0 }, ch;
-    bool normalized;
+    bool normalize, normalized;
     BSTR name;
 
     if (!(quote[0] = saxreader_is_quote(locator)))
@@ -4249,10 +4299,15 @@ static BSTR saxreader_parse_attvalue(struct saxlocator *locator)
     }
     saxreader_skip(locator, 1);
 
+    normalize = locator->saxreader->features & NormalizeAttributeValues;
+
     /* All references are resolved */
 
     while (locator->status == S_OK)
     {
+        if (saxreader_parse_attvalue_run(locator, &buffer, quote[0], normalize))
+            continue;
+
         if (saxreader_cmp(locator, quote))
             break;
 
@@ -4281,7 +4336,7 @@ static BSTR saxreader_parse_attvalue(struct saxlocator *locator)
         else
         {
             normalized = false;
-            if (locator->saxreader->features & NormalizeAttributeValues)
+            if (normalize)
             {
                 if (saxreader_cmp(locator, L"\r\n")
                         || saxreader_cmp(locator, L"\r")

--- a/dlls/msxml3/saxreader.c
+++ b/dlls/msxml3/saxreader.c
@@ -888,6 +888,7 @@ struct saxlocator
     bool pool_names;
     size_t name_pool_count;
     struct list name_pool[256];
+    BSTR recent_names[16];
 
     ISequentialStream *stream;
     bool eos;
@@ -1177,10 +1178,19 @@ static UINT saxreader_name_hash(const WCHAR *str, UINT len)
 static BSTR saxreader_intern_stringlen(struct saxlocator *locator, const WCHAR *str, UINT len)
 {
     struct pooled_name *entry;
-    UINT hash;
+    BSTR recent;
+    UINT hash, slot;
 
     if (!locator->pool_names)
         return saxreader_alloc_stringlen(locator, str, len);
+
+    slot = len * 33u;
+    if (len)
+        slot += str[0] * 17u + str[len - 1];
+    slot %= ARRAY_SIZE(locator->recent_names);
+    recent = locator->recent_names[slot];
+    if (recent && SysStringLen(recent) == len && !memcmp(recent, str, len * sizeof(WCHAR)))
+        return recent;
 
     hash = saxreader_name_hash(str, len);
     LIST_FOR_EACH_ENTRY(entry, &locator->name_pool[hash % ARRAY_SIZE(locator->name_pool)],
@@ -1188,7 +1198,10 @@ static BSTR saxreader_intern_stringlen(struct saxlocator *locator, const WCHAR *
     {
         if (entry->hash == hash && SysStringLen(entry->value) == len
                 && !memcmp(entry->value, str, len * sizeof(WCHAR)))
+        {
+            locator->recent_names[slot] = entry->value;
             return entry->value;
+        }
     }
 
     if (!(entry = malloc(sizeof(*entry))))
@@ -1205,6 +1218,7 @@ static BSTR saxreader_intern_stringlen(struct saxlocator *locator, const WCHAR *
     entry->hash = hash;
     list_add_head(&locator->name_pool[hash % ARRAY_SIZE(locator->name_pool)], &entry->entry);
     ++locator->name_pool_count;
+    locator->recent_names[slot] = entry->value;
     return entry->value;
 }
 
@@ -2465,6 +2479,25 @@ static bool saxreader_cmp(struct saxlocator *locator, const WCHAR *str)
     return true;
 }
 
+static inline bool saxreader_cmp_char(struct saxlocator *locator, WCHAR ch)
+{
+    struct input_buffer *input = &locator->buffer;
+
+    if (FAILED(locator->status) || *saxreader_get_ptr(locator) != ch)
+        return false;
+
+    if (ch != '\r' && ch != '\n' && !locator->collect && list_empty(&input->entities))
+    {
+        ++input->utf16.cur;
+        ++input->consumed;
+        ++input->position.column;
+        input->last_cr = false;
+    }
+    else
+        saxreader_skip(locator, 1);
+    return true;
+}
+
 static void saxreader_fatal_error(struct saxlocator *locator)
 {
     struct saxerrorhandler_iface *handler = saxreader_get_errorhandler(locator->saxreader);
@@ -3682,6 +3715,10 @@ bool xml_is_ncnamechar(WCHAR ch)
 
 static bool saxreader_is_ncnamechar(WCHAR ch)
 {
+    if (ch < 0x80)
+        return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z')
+                || (ch >= '0' && ch <= '9') || ch == '.' || ch == '-'
+                || ch == '_';
     return xml_is_ncnamechar(ch);
 }
 
@@ -3695,6 +3732,8 @@ bool xml_is_ncname_startchar(WCHAR ch)
 
 static bool saxreader_is_ncname_startchar(WCHAR c)
 {
+    if (c < 0x80)
+        return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_';
     return xml_is_ncname_startchar(c);
 }
 
@@ -3870,7 +3909,7 @@ static void saxreader_parse_qname(struct saxlocator *locator, struct parsed_name
 
     ncname = saxreader_parse_ncname(locator);
 
-    if (saxreader_cmp(locator, L":"))
+    if (saxreader_cmp_char(locator, ':'))
     {
         name->prefix = ncname;
         name->local = saxreader_parse_ncname(locator);
@@ -4520,7 +4559,7 @@ static void saxreader_parse_starttag(struct saxlocator *locator)
     struct element *element;
     struct parsed_name name;
 
-    if (!saxreader_cmp(locator, L"<"))
+    if (!saxreader_cmp_char(locator, '<'))
         return saxreader_set_error(locator, E_SAX_INVALIDATROOTLEVEL);
 
     saxreader_parse_qname(locator, &name);
@@ -4548,7 +4587,7 @@ static void saxreader_parse_starttag(struct saxlocator *locator)
             break;
         }
 
-        if (saxreader_cmp(locator, L">"))
+        if (saxreader_cmp_char(locator, '>'))
         {
             position = locator->buffer.position;
             break;

--- a/dlls/msxml3/tests/domdoc.c
+++ b/dlls/msxml3/tests/domdoc.c
@@ -17073,7 +17073,10 @@ static void test_loadXML(void)
 {
     IXMLDOMElement *element;
     IXMLDOMDocument *doc;
+    WCHAR malformed[4096], *ptr;
     VARIANT_BOOL b;
+    unsigned int i;
+    BSTR xml;
     HRESULT hr;
 
     hr = CoCreateInstance(&CLSID_DOMDocument2, NULL, CLSCTX_INPROC_SERVER, &IID_IXMLDOMDocument, (void **)&doc);
@@ -17098,6 +17101,40 @@ static void test_loadXML(void)
     ok(hr == S_FALSE, "Unexpected hr %#lx.\n", hr);
     hr = IXMLDOMDocument_get_documentElement(doc, &element);
     ok(hr == S_FALSE, "Unexpected hr %#lx.\n", hr);
+
+    /* Repeated failed parses release partial pooled trees and leave the document reusable. */
+    ptr = malformed;
+    memcpy(ptr, L"<root>", 6 * sizeof(WCHAR));
+    ptr += 6;
+    for (i = 0; i < 300; ++i)
+    {
+        memcpy(ptr, L"<child/>", 8 * sizeof(WCHAR));
+        ptr += 8;
+    }
+    wcscpy(ptr, L"<broken></wrong>");
+    xml = SysAllocString(malformed);
+    ok(xml != NULL, "Failed to allocate malformed XML.\n");
+    if (xml)
+    {
+        for (i = 0; i < 32; ++i)
+        {
+            b = VARIANT_TRUE;
+            hr = IXMLDOMDocument_loadXML(doc, xml, &b);
+            ok(hr == S_FALSE, "Unexpected hr %#lx.\n", hr);
+            ok(b == VARIANT_FALSE, "Unexpected value %d.\n", b);
+        }
+        SysFreeString(xml);
+    }
+
+    b = VARIANT_FALSE;
+    hr = IXMLDOMDocument_loadXML(doc, _bstr_("<valid/>"), &b);
+    ok(hr == S_OK, "Unexpected hr %#lx.\n", hr);
+    ok(b == VARIANT_TRUE, "Unexpected value %d.\n", b);
+    element = NULL;
+    hr = IXMLDOMDocument_get_documentElement(doc, &element);
+    ok(hr == S_OK, "Unexpected hr %#lx.\n", hr);
+    if (element)
+        IXMLDOMElement_Release(element);
 
     IXMLDOMDocument_Release(doc);
 }

--- a/dlls/msxml3/tests/domdoc.c
+++ b/dlls/msxml3/tests/domdoc.c
@@ -2231,10 +2231,10 @@ static void test_persiststream(void)
 
     istream = SHCreateMemStream((const BYTE*)"", 0);
     hr = IPersistStreamInit_Load(streaminit, istream);
-    todo_wine ok(hr == XML_E_MISSINGROOT, "Unexpected hr %#lx.\n", hr);
+    ok(hr == XML_E_MISSINGROOT, "Unexpected hr %#lx.\n", hr);
     ok(FAILED(hr), "got success\n");
     IStream_Release(istream);
-    EXPECT_PARSE_ERROR(doc, XML_E_MISSINGROOT, TRUE);
+    EXPECT_PARSE_ERROR(doc, XML_E_MISSINGROOT, FALSE);
 
     failing_stream_read_calls = 0;
     hr = IPersistStreamInit_Load(streaminit, &failing_stream);
@@ -10351,9 +10351,12 @@ static void test_appendChild(void)
     DOMNodeType node_type;
     IXMLDOMNode *node;
     LONG length;
+    VARIANT_BOOL b;
     VARIANT var;
     HRESULT hr;
     BSTR xml;
+    WCHAR pooled_xml[4096], *ptr;
+    unsigned int i;
 
     doc = create_document(&IID_IXMLDOMDocument);
     doc2 = create_document(&IID_IXMLDOMDocument);
@@ -10383,6 +10386,71 @@ static void test_appendChild(void)
     IXMLDOMElement_Release(elem);
     IXMLDOMElement_Release(elem2);
     IXMLDOMDocument_Release(doc);
+    IXMLDOMDocument_Release(doc2);
+
+    /* Parsed names remain valid after moving a subtree to another document. */
+    doc = create_document(&IID_IXMLDOMDocument);
+    doc2 = create_document(&IID_IXMLDOMDocument);
+    hr = IXMLDOMDocument_loadXML(doc, _bstr_("<pooled><child>text</child></pooled>"), &b);
+    ok(hr == S_OK, "Unexpected hr %#lx.\n", hr);
+    ok(b == VARIANT_TRUE, "Failed to load XML.\n");
+    hr = IXMLDOMDocument_get_documentElement(doc, &elem);
+    ok(hr == S_OK, "Unexpected hr %#lx.\n", hr);
+    hr = IXMLDOMDocument_appendChild(doc2, (IXMLDOMNode *)elem, NULL);
+    ok(hr == S_OK, "Unexpected hr %#lx.\n", hr);
+    IXMLDOMDocument_Release(doc);
+
+    hr = IXMLDOMElement_get_nodeName(elem, &xml);
+    ok(hr == S_OK, "Unexpected hr %#lx.\n", hr);
+    ok(!wcscmp(xml, L"pooled"), "Unexpected name %s.\n", debugstr_w(xml));
+    SysFreeString(xml);
+    hr = IXMLDOMElement_get_firstChild(elem, &node);
+    ok(hr == S_OK, "Unexpected hr %#lx.\n", hr);
+    hr = IXMLDOMNode_get_nodeName(node, &xml);
+    ok(hr == S_OK, "Unexpected hr %#lx.\n", hr);
+    ok(!wcscmp(xml, L"child"), "Unexpected name %s.\n", debugstr_w(xml));
+    SysFreeString(xml);
+    IXMLDOMNode_Release(node);
+    hr = IXMLDOMElement_get_text(elem, &xml);
+    ok(hr == S_OK, "Unexpected hr %#lx.\n", hr);
+    ok(!wcscmp(xml, L"text"), "Unexpected text %s.\n", debugstr_w(xml));
+    SysFreeString(xml);
+
+    IXMLDOMElement_Release(elem);
+    IXMLDOMDocument_Release(doc2);
+
+    /* Parsed nodes spanning allocation blocks also outlive their source document. */
+    ptr = pooled_xml;
+    memcpy(ptr, L"<pooled>", 8 * sizeof(WCHAR));
+    ptr += 8;
+    for (i = 0; i < 300; ++i)
+    {
+        memcpy(ptr, L"<child/>", 8 * sizeof(WCHAR));
+        ptr += 8;
+    }
+    memcpy(ptr, L"</pooled>", 10 * sizeof(WCHAR));
+
+    doc = create_document(&IID_IXMLDOMDocument);
+    doc2 = create_document(&IID_IXMLDOMDocument);
+    xml = SysAllocString(pooled_xml);
+    hr = IXMLDOMDocument_loadXML(doc, xml, &b);
+    SysFreeString(xml);
+    ok(hr == S_OK, "Unexpected hr %#lx.\n", hr);
+    ok(b == VARIANT_TRUE, "Failed to load XML.\n");
+    hr = IXMLDOMDocument_get_documentElement(doc, &elem);
+    ok(hr == S_OK, "Unexpected hr %#lx.\n", hr);
+    hr = IXMLDOMDocument_appendChild(doc2, (IXMLDOMNode *)elem, NULL);
+    ok(hr == S_OK, "Unexpected hr %#lx.\n", hr);
+    IXMLDOMDocument_Release(doc);
+
+    hr = IXMLDOMElement_get_lastChild(elem, &node);
+    ok(hr == S_OK, "Unexpected hr %#lx.\n", hr);
+    hr = IXMLDOMNode_get_nodeName(node, &xml);
+    ok(hr == S_OK, "Unexpected hr %#lx.\n", hr);
+    ok(!wcscmp(xml, L"child"), "Unexpected name %s.\n", debugstr_w(xml));
+    SysFreeString(xml);
+    IXMLDOMNode_Release(node);
+    IXMLDOMElement_Release(elem);
     IXMLDOMDocument_Release(doc2);
 
     /* Append a child to a document */
@@ -11789,7 +11857,7 @@ static void test_load(void)
     hr = IXMLDOMDocument_load(doc, src, &b);
     todo_wine ok(hr == S_FALSE, "Unexpected hr %#lx.\n", hr);
     ok(b == VARIANT_FALSE, "got %d\n", b);
-    EXPECT_PARSE_ERROR(doc, XML_E_INVALIDATROOTLEVEL, TRUE);
+    EXPECT_PARSE_ERROR(doc, XML_E_INVALIDATROOTLEVEL, FALSE);
     VariantClear(&src);
 
     /* A failed read must not be retried or parsed as partial input. */

--- a/dlls/msxml3/tests/domdoc.c
+++ b/dlls/msxml3/tests/domdoc.c
@@ -10339,6 +10339,106 @@ static void test_insertBefore(void)
     IXMLDOMDocument_Release(doc);
 }
 
+struct document_release_context
+{
+    IXMLDOMDocument *doc;
+    HANDLE start;
+};
+
+static DWORD WINAPI release_document_thread(void *arg)
+{
+    struct document_release_context *context = arg;
+    HRESULT hr;
+
+    hr = CoInitializeEx(NULL, COINIT_MULTITHREADED);
+    ok(hr == S_OK, "Unexpected hr %#lx.\n", hr);
+    WaitForSingleObject(context->start, INFINITE);
+    IXMLDOMDocument_Release(context->doc);
+    if (SUCCEEDED(hr)) CoUninitialize();
+    return 0;
+}
+
+static void test_moved_subtree_threads(void)
+{
+    struct document_release_context contexts[2];
+    IXMLDOMDocument *source, *docs[3];
+    IXMLDOMElement *root, *element;
+    HANDLE threads[2], start;
+    IXMLDOMNode *child;
+    VARIANT_BOOL loaded;
+    unsigned int i;
+    HRESULT hr;
+    BSTR text;
+
+    if (!is_clsid_supported(&CLSID_FreeThreadedDOMDocument, &IID_IXMLDOMDocument))
+        return;
+
+    hr = CoCreateInstance(&CLSID_FreeThreadedDOMDocument, NULL, CLSCTX_INPROC_SERVER,
+            &IID_IXMLDOMDocument, (void **)&source);
+    ok(hr == S_OK, "Unexpected hr %#lx.\n", hr);
+    hr = IXMLDOMDocument_loadXML(source, _bstr_("<root xmlns:p='urn:shared'>"
+            "<p:child>one</p:child><p:child>two</p:child><p:child>three</p:child></root>"), &loaded);
+    ok(hr == S_OK, "Unexpected hr %#lx.\n", hr);
+    ok(loaded == VARIANT_TRUE, "Failed to load XML.\n");
+    hr = IXMLDOMDocument_get_documentElement(source, &root);
+    ok(hr == S_OK, "Unexpected hr %#lx.\n", hr);
+
+    /* Transfer ownership before starting the threads. Each thread releases a
+     * separate document; the third document keeps its moved subtree alive. */
+    for (i = 0; i < ARRAY_SIZE(docs); ++i)
+    {
+        hr = CoCreateInstance(&CLSID_FreeThreadedDOMDocument, NULL, CLSCTX_INPROC_SERVER,
+                &IID_IXMLDOMDocument, (void **)&docs[i]);
+        ok(hr == S_OK, "Unexpected hr %#lx.\n", hr);
+        hr = IXMLDOMElement_get_firstChild(root, &child);
+        ok(hr == S_OK, "Unexpected hr %#lx.\n", hr);
+        hr = IXMLDOMDocument_appendChild(docs[i], child, NULL);
+        ok(hr == S_OK, "Unexpected hr %#lx.\n", hr);
+        IXMLDOMNode_Release(child);
+    }
+    IXMLDOMElement_Release(root);
+    IXMLDOMDocument_Release(source);
+
+    start = CreateEventW(NULL, TRUE, FALSE, NULL);
+    ok(!!start, "Failed to create event.\n");
+    for (i = 0; i < ARRAY_SIZE(threads); ++i)
+    {
+        contexts[i].doc = docs[i];
+        contexts[i].start = start;
+        threads[i] = CreateThread(NULL, 0, release_document_thread, &contexts[i], 0, NULL);
+        ok(!!threads[i], "Failed to create thread.\n");
+    }
+    SetEvent(start);
+    for (i = 0; i < ARRAY_SIZE(threads); ++i)
+    {
+        if (threads[i])
+        {
+            WaitForSingleObject(threads[i], INFINITE);
+            CloseHandle(threads[i]);
+        }
+        else
+            IXMLDOMDocument_Release(docs[i]);
+    }
+    CloseHandle(start);
+
+    hr = IXMLDOMDocument_get_documentElement(docs[2], &element);
+    ok(hr == S_OK, "Unexpected hr %#lx.\n", hr);
+    hr = IXMLDOMElement_get_nodeName(element, &text);
+    ok(hr == S_OK, "Unexpected hr %#lx.\n", hr);
+    ok(!wcscmp(text, L"p:child"), "Unexpected name %s.\n", debugstr_w(text));
+    SysFreeString(text);
+    hr = IXMLDOMElement_get_namespaceURI(element, &text);
+    ok(hr == S_OK, "Unexpected hr %#lx.\n", hr);
+    ok(!wcscmp(text, L"urn:shared"), "Unexpected namespace %s.\n", debugstr_w(text));
+    SysFreeString(text);
+    hr = IXMLDOMElement_get_text(element, &text);
+    ok(hr == S_OK, "Unexpected hr %#lx.\n", hr);
+    ok(!wcscmp(text, L"three"), "Unexpected text %s.\n", debugstr_w(text));
+    SysFreeString(text);
+    IXMLDOMElement_Release(element);
+    IXMLDOMDocument_Release(docs[2]);
+}
+
 static void test_appendChild(void)
 {
     IXMLDOMDocumentFragment *fragment, *fragment2;
@@ -19079,6 +19179,7 @@ START_TEST(domdoc)
     test_get_xml();
     test_insertBefore();
     test_appendChild();
+    test_moved_subtree_threads();
     test_get_doctype();
     test_get_tagName();
     test_get_dataType();

--- a/dlls/msxml3/tests/saxreader.c
+++ b/dlls/msxml3/tests/saxreader.c
@@ -6457,6 +6457,69 @@ static void test_saxreader_max_element_depth(void)
     ISAXXMLReader_Release(reader);
 }
 
+static void test_saxreader_name_parsing(void)
+{
+    const struct msxmlsupported_data_t *table = reader_support_data;
+    ISAXXMLReader *reader;
+    IStream *stream;
+    VARIANT input;
+    char *xml, *ptr;
+    HRESULT hr;
+    unsigned int i;
+
+    xml = malloc(128 * 1024);
+    ok(!!xml, "Failed to allocate test buffer.\n");
+    if (!xml)
+        return;
+
+    while (table->clsid)
+    {
+        if (!is_clsid_supported(table->clsid, reader_support_data))
+        {
+            ++table;
+            continue;
+        }
+
+        hr = CoCreateInstance(table->clsid, NULL, CLSCTX_INPROC_SERVER,
+                &IID_ISAXXMLReader, (void **)&reader);
+        ok(hr == S_OK, "%s: Unexpected hr %#lx.\n", table->name, hr);
+
+        ptr = xml;
+        ptr += sprintf(ptr, "<root>");
+        memset(ptr, ' ', 4084);
+        ptr += 4084;
+        ptr += sprintf(ptr, "<p:boundary xmlns:p=\"urn:test\"></p:boundary></root>");
+        stream = create_test_stream(xml, ptr - xml);
+        V_VT(&input) = VT_UNKNOWN;
+        V_UNKNOWN(&input) = (IUnknown *)stream;
+        hr = ISAXXMLReader_parse(reader, input);
+        ok(hr == S_OK, "%s: Chunk-boundary name parse failed, hr %#lx.\n", table->name, hr);
+        IStream_Release(stream);
+
+        ptr = xml;
+        ptr += sprintf(ptr, "<root>");
+        for (i = 0; i < 4105; ++i)
+            ptr += sprintf(ptr, "<n%u></n%u>", i, i);
+        ptr += sprintf(ptr, "</root>");
+        stream = create_test_stream(xml, ptr - xml);
+        V_UNKNOWN(&input) = (IUnknown *)stream;
+        hr = ISAXXMLReader_parse(reader, input);
+        ok(hr == S_OK, "%s: Name-pool limit parse failed, hr %#lx.\n", table->name, hr);
+        IStream_Release(stream);
+
+        stream = create_test_stream("<root><child></chilx></root>", -1);
+        V_UNKNOWN(&input) = (IUnknown *)stream;
+        hr = ISAXXMLReader_parse(reader, input);
+        ok(FAILED(hr), "%s: Mismatched end tag unexpectedly succeeded.\n", table->name);
+        IStream_Release(stream);
+
+        ISAXXMLReader_Release(reader);
+        ++table;
+    }
+
+    free(xml);
+}
+
 START_TEST(saxreader)
 {
     ISAXXMLReader *reader;
@@ -6495,6 +6558,7 @@ START_TEST(saxreader)
     test_saxreader_dtd();
     test_saxreader_parse_input();
     test_saxreader_max_element_depth();
+    test_saxreader_name_parsing();
 
     /* MXXMLWriter tests */
     get_class_support_data(mxwriter_support_data, &IID_IMXWriter);


### PR DESCRIPTION
## Summary

- avoid repeatedly compacting the SAX reader's UTF-16 input buffer
- scan common delimiters and plain attribute-value runs in bulk
- pool parsed DOM names, namespace URIs, nodes, and parser storage
- reuse stable namespace URI identity while creating temporary libxml trees
- link newly parsed nodes directly when their parent and owner are already known
- preserve parser errors and release partial pooled trees after failed parses
- skip inherited `xml:space` lookup when there is no pending text
- serialize completed XSLT results into a growable memory buffer before writing them to an `ISequentialStream`
- collect bound URL/file data in an internal geometric buffer instead of appending 4 KiB blocks to an HGLOBAL stream
- add parser, malformed-input, and moved-subtree lifetime coverage

## Performance evidence

Using the same 4,055,160-byte Office Click-to-Run manifest:

- in-memory SAX with no content handler fell from a 979.102 ms median to 79.677 ms in the first parser optimization batch
- four profiled `loadXML` calls fell from 5,358.587 ms to 555.137 ms in that batch
- URI pooling reduced heap samples attributed to `domnode_create_internal` from 100.238M to 12.618M cycles
- namespace identity reuse reduced `create_xmlnode_from_domnode` from 572.582M to 429.873M inclusive cycles and removed its repeated URI conversion/comparison path
- bulk delimiter scanning reduced `saxreader_skip` from 64.926M to 25.990M inclusive cycles
- the recent parsed-name cache reduced `domdoc_intern_parsed_name` from 116.009M to 53.517M inclusive cycles
- bulk attribute-value scanning reduced `saxreader_skip` again from 44.314M to 19.682M inclusive cycles in the following profile
- buffering transformation output removed the 416.035M-cycle `stream_Write` / `SetSize` path from the follow-up profiles; `RtlReAllocateHeap` fell from 643.703M to a 395.059M-cycle mean and `memcpy` leaf cycles from 448.020M to 221.555M
- across two buffered-output profiles, Click-to-Run weighted cycles averaged 4.187B versus 4.400B immediately before the change (-4.85%); the readiness window improved 1.16% on average but remained noisy
- geometric bound-data buffering reduced `bsc_OnDataAvailable` from a 163.605M-cycle two-profile mean to 8.091M cycles (-95.1%) and removed its `stream_Write` path; the follow-up Click-to-Run profile measured 3.966B cycles, 5.27% below the buffered-output mean

These are successive hardware call-path profiles. The removed or reduced call paths are the primary evidence; whole-startup time and cycle totals are noisy and the percentages are not additive.

### Combined end-to-end result with PR 75

Three clean prefix-matched pairs measured this PR together with the companion XSLT/XPath changes in [PR 75](https://github.com/ttv20/wine4office/pull/75):

| Metric | Baseline | Combined candidate | Change |
|---|---:|---:|---:|
| Useful-ready | 17.678 s | 12.431 s | -5.247 s (-29.7%) |
| Office launch to window | 15.845 s | 10.665 s | -5.180 s (-32.7%) |
| Peak RSS | 886.3 MiB | 853.0 MiB | -33.3 MiB (-3.8%) |
| Peak PSS | 650.9 MiB | 610.7 MiB | -40.2 MiB (-6.2%) |
| Peak private | 566.3 MiB | 526.0 MiB | -40.3 MiB (-7.1%) |
| OfficeClickToRun CPU to window | 6.923 s | 2.273 s | -4.650 s (-67.2%) |

The runner synchronizes the restored prefix's `.update-timestamp` with the selected `wine.inf`, rejects any run that invokes `InstallHinfSection`, and compares absolute monotonic timestamps from Office launch. This corrected two earlier measurement errors: a baseline-only prefix upgrade and a probe-relative clock that omitted about 2.1 seconds. The result measures both PRs together and is not an attribution to this PR alone. It does not include the later experimental wineserver PE-backing cache.

## Validation

- the exact PR branch built `msxml3.dll` and `msxml3_test.exe` independently for x86-64 and i386
- `domdoc`, `saxreader`, `schema`, `xmldoc`, and `xmlparser` passed serially on both architectures
- focused tests cover split input, multibyte encodings, malformed input, parser HRESULT propagation, pool teardown, and subtrees moved between documents
- native Windows checks covered the moved-subtree lifetime and empty-stream HRESULT cases
- Excel reached useful editable UI in the Office Click-to-Run environment used for the profiles
- after both buffering changes, all five relevant suites passed again on both architectures; the buffered-output and bound-data Office profiles reached useful UI

The aggregate `msxml3/tests/check` target is not suitable for the network-isolated headless builder: `httpreq` requires network access and `xmlview` requires Wine Gecko and a display. The five relevant suites above pass.

## Risk notes

- pooled strings and nodes can outlive their source document after a subtree move, so the pool has shared lifetime ownership; the regression tests release the source document and continue using the moved subtree
- namespace pointer identity is used only while building the temporary libxml tree and still falls back to content comparison when identity is unavailable
- bulk SAX paths are restricted to plain input without active entity or collection state; line endings, entities, normalization boundaries, and split buffers retain the existing slow path
- buffering changes only the internal write granularity after the result tree is complete; partial writes are drained in a loop, while normal Office output is delivered in one call
- the measured Click-to-Run peak private memory increased by about 2.8 MiB in the matched smoke sample; native Windows also exposes exact HGLOBAL stream sizes after every write, so this optimization deliberately stays in MSXML instead of changing COM stream allocation semantics
- bound-data capacity grows from actual bytes read, not the remote `dwSize` hint; arithmetic is checked before growth, and allocation failure aborts the callback instead of overflowing the buffer


## Review fixes on 2026-09-06

- Return an element-creation failure before inspecting its whitespace state, avoiding a null dereference after allocation failure.
- Use atomic reference counting for parsed pools shared by subtrees moved between independent documents.
- Add a public-API test that releases two destination documents on separate threads and verifies a third moved subtree's name, namespace URI, and text.

Validation on x86-64 and i386:

- The unpatched PR crashes with access violation `0xc0000005` when parsed-pool allocation fails, with whitespace preservation both enabled and disabled. The fixed build returns a failed load with no document element and successfully loads again afterward.
- A diagnostic that intercepts the DLL's allocator imports and counts actual pool allocations reproduced a leaked pool on the unpatched build after 21 cycles on x86-64 and 26 on i386. Both fixed builds completed 1,000 cycles, with 1,000 pools allocated and freed and zero retained pools. Each cycle moves 1,200 nodes between documents before concurrent final release.
- Focused DLL and test executable builds pass on both architectures. The `domdoc`, `saxreader`, `schema`, `xmldoc`, and `xmlparser` suites pass on both architectures with zero failures; `domdoc` includes the new threaded lifetime test.

The allocator diagnostic is separate from the regression suite and introduces no production test hooks. Its stress result supplements the atomic reference-counting fix; it is not a proof over every thread interleaving. No new Office performance or native Windows run was performed for these review fixes.

## Summary by Sourcery

Optimize MSXML XML parsing and data handling for Office workloads while strengthening failure handling and pooled-object lifetime safety.

Bug Fixes:
- Handle empty XML streams, stalled transformation writes, allocation failures, malformed parses, and shared pooled-memory lifetime safely.
- Preserve parser HRESULTs and ensure partial parsed trees and pooled resources are released after failures.

Enhancements:
- Speed up Office manifest parsing through reduced input-buffer compaction, bulk SAX scanning, name and node pooling, namespace identity reuse, direct parsed-tree linking, and optimized whitespace handling.
- Reduce transformation and bound-data streaming overhead by buffering completed output and downloaded data before delivery.

Tests:
- Expand MSXML coverage for malformed and empty input, allocation failures, parser error propagation, pooled-resource cleanup, chunk-boundary parsing, and subtrees moved across documents and released concurrently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved XML and SAX parsing performance, especially for Office Click-to-Run manifests and documents with repeated names or large amounts of data.
  * Reduced memory overhead during XML processing and data downloads.

* **Bug Fixes**
  * Improved reliability when XML memory allocation fails.
  * Fixed cross-thread document and subtree release scenarios.
  * Improved handling of empty, invalid, and repeatedly failed XML parses.
  * Improved parsing across input-buffer boundaries and mismatched tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->