### PR TITLE
ntdll: Avoid recursive App-V VFS overlays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Reduce Office startup file-system work by avoiding recursive App-V VFS lookups.
 - Speed up small Office gallery images rendered through Direct2D.
 - Reduce memory use and latency when drawing complex antialiased Direct2D geometry.
 - Reduce Word CPU use by coalescing Office timers that allow delayed delivery.

--- a/dlls/ntdll/tests/file.c
+++ b/dlls/ntdll/tests/file.c
@@ -7420,6 +7420,7 @@ static void test_appv_vfs_overlay(void)
 {
     static const char payload[] = "App-V VFS resource";
     char temp[MAX_PATH], base[MAX_PATH], path[MAX_PATH], source[MAX_PATH], requested[MAX_PATH];
+    char nested_source[MAX_PATH], prefix_source[MAX_PATH];
     DWORD written, read, attributes;
     HANDLE file;
     BOOL ret;
@@ -7447,6 +7448,8 @@ static void test_appv_vfs_overlay(void)
     CREATE_SUBDIR( "\\AppVPackage\\root\\vfs" );
     CREATE_SUBDIR( "\\AppVPackage\\root\\vfs\\ProgramFilesCommonX64" );
     CREATE_SUBDIR( "\\AppVPackage\\root\\vfs\\ProgramFilesCommonX64\\Microsoft Shared" );
+    CREATE_SUBDIR( "\\AppVPackage\\root\\vfs\\ProgramFilesCommonX64\\Microsoft Shared\\vfs" );
+    CREATE_SUBDIR( "\\AppVPackage\\root\\vfs\\ProgramFilesCommonX64\\Microsoft Shared\\vfsfoo" );
     CREATE_SUBDIR( "\\AppVPackage\\root\\vfs\\ProgramFilesCommonX64\\Microsoft Shared\\Product42" );
     CREATE_SUBDIR( "\\AppVPackage\\root\\vfs\\ProgramFilesCommonX64\\Microsoft Shared\\Product42\\1033" );
 #undef CREATE_SUBDIR
@@ -7461,6 +7464,33 @@ static void test_appv_vfs_overlay(void)
     ret = WriteFile( file, payload, sizeof(payload), &written, NULL );
     ok( ret && written == sizeof(payload), "Failed to write VFS source, error %lu.\n", GetLastError() );
     CloseHandle( file );
+
+    snprintf( nested_source, ARRAY_SIZE(nested_source),
+              "%s\\AppVPackage\\root\\vfs\\ProgramFilesCommonX64\\Microsoft Shared\\vfs\\sentinel.bin",
+              base );
+    file = CreateFileA( nested_source, GENERIC_WRITE, 0, NULL, CREATE_NEW, 0, NULL );
+    ok( file != INVALID_HANDLE_VALUE, "Failed to create nested VFS source, error %lu.\n", GetLastError() );
+    CloseHandle( file );
+
+    snprintf( path, ARRAY_SIZE(path), "%s\\AppVPackage\\root\\VfS\\sentinel.bin", base );
+    attributes = GetFileAttributesA( path );
+    ok( attributes == INVALID_FILE_ATTRIBUTES,
+        "Backing-store path unexpectedly received another VFS overlay.\n" );
+    file = CreateFileA( path, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, 0, NULL );
+    ok( file == INVALID_HANDLE_VALUE, "Open unexpectedly received another VFS overlay.\n" );
+    if (file != INVALID_HANDLE_VALUE) CloseHandle( file );
+    ok( GetFileAttributesA( nested_source ) != INVALID_FILE_ATTRIBUTES,
+        "Nested VFS source is not directly accessible.\n" );
+
+    snprintf( prefix_source, ARRAY_SIZE(prefix_source),
+              "%s\\AppVPackage\\root\\vfs\\ProgramFilesCommonX64\\Microsoft Shared\\vfsfoo\\sentinel.bin",
+              base );
+    file = CreateFileA( prefix_source, GENERIC_WRITE, 0, NULL, CREATE_NEW, 0, NULL );
+    ok( file != INVALID_HANDLE_VALUE, "Failed to create VFS-prefix source, error %lu.\n", GetLastError() );
+    CloseHandle( file );
+    snprintf( path, ARRAY_SIZE(path), "%s\\AppVPackage\\root\\vfsfoo\\sentinel.bin", base );
+    ok( GetFileAttributesA( path ) != INVALID_FILE_ATTRIBUTES,
+        "Non-component VFS prefix was not overlaid, error %lu.\n", GetLastError() );
 
     attributes = GetFileAttributesA( requested );
     ok( attributes != INVALID_FILE_ATTRIBUTES, "VFS attributes failed, error %lu.\n", GetLastError() );
@@ -7479,9 +7509,13 @@ static void test_appv_vfs_overlay(void)
     ok( !ret, "Delete unexpectedly reached the immutable VFS source.\n" );
     ok( GetFileAttributesA( source ) != INVALID_FILE_ATTRIBUTES, "VFS source was removed.\n" );
 
+    DeleteFileA( prefix_source );
+    DeleteFileA( nested_source );
     DeleteFileA( source );
     snprintf( path, ARRAY_SIZE(path), "%s\\AppVPackage\\root\\vfs\\ProgramFilesCommonX64\\Microsoft Shared\\Product42\\1033", base ); RemoveDirectoryA( path );
     snprintf( path, ARRAY_SIZE(path), "%s\\AppVPackage\\root\\vfs\\ProgramFilesCommonX64\\Microsoft Shared\\Product42", base ); RemoveDirectoryA( path );
+    snprintf( path, ARRAY_SIZE(path), "%s\\AppVPackage\\root\\vfs\\ProgramFilesCommonX64\\Microsoft Shared\\vfsfoo", base ); RemoveDirectoryA( path );
+    snprintf( path, ARRAY_SIZE(path), "%s\\AppVPackage\\root\\vfs\\ProgramFilesCommonX64\\Microsoft Shared\\vfs", base ); RemoveDirectoryA( path );
     snprintf( path, ARRAY_SIZE(path), "%s\\AppVPackage\\root\\vfs\\ProgramFilesCommonX64\\Microsoft Shared", base ); RemoveDirectoryA( path );
     snprintf( path, ARRAY_SIZE(path), "%s\\AppVPackage\\root\\vfs\\ProgramFilesCommonX64", base ); RemoveDirectoryA( path );
     snprintf( path, ARRAY_SIZE(path), "%s\\AppVPackage\\root\\vfs", base ); RemoveDirectoryA( path );

--- a/dlls/ntdll/unix/file.c
+++ b/dlls/ntdll/unix/file.c
@@ -4422,6 +4422,13 @@ static NTSTATUS get_appv_vfs_unix_name( const OBJECT_ATTRIBUTES *attr, const UNI
         prefix_len = match - name->Buffer;
         search = match + 1;
         suffix_len = name->Length / sizeof(WCHAR) - prefix_len - strlen(marker);
+        remainder.Buffer = (WCHAR *)(match + strlen(marker));
+        remainder.Length = suffix_len * sizeof(WCHAR);
+        remainder.MaximumLength = remainder.Length;
+        /* root/vfs is already the package backing store; do not overlay it again. */
+        if (find_ascii_substring_i( &remainder, "vfs" ) == remainder.Buffer &&
+            (suffix_len == 3 || remainder.Buffer[3] == '\\'))
+            continue;
 
         for (i = 0; i < ARRAY_SIZE(replacements); i++)
         {


### PR DESCRIPTION
## Summary

- stop the App-V fallback from treating `root\\vfs` as another logical package root
- keep the normal `root\\Product` to VFS overlay and component-prefix behavior intact
- add public API regression coverage for mixed-case `VfS`, direct backing-store access, and `vfsfoo`

## Root cause

The App-V retry runs after a normal file lookup fails. It matched every `\\root\\` segment, including paths already inside the package VFS backing store, and generated another pair of architecture-specific VFS paths. Those recursive candidates cannot resolve in the Office package and trigger repeated case-insensitive directory scans.

## Validation

- focused dry run: 7 compile/link commands
- rebuilt `dlls/ntdll/ntdll.so`
- rebuilt x86-64 and i386 `ntdll_test.exe`
- negative control without the fix: the two new double-overlay assertions failed
- final x86-64 and i386 runs: neither new assertion failed; the existing headless test environment still reports the same 54 unrelated `ntdll:file` failures in each architecture
- `git diff --check`

Matched Excel C2 startup traces used the same prefix snapshot, document, and 17-second trace window:

| syscall / behavior | baseline | patched | delta |
| --- | ---: | ---: | ---: |
| recursive VFS candidates | 2,699 | 0 | -2,699 |
| `newfstatat` | 47,704 | 41,375 | -6,329 |
| `openat` | 19,642 | 16,478 | -3,164 |
| `getdents64` | 9,313 | 6,000 | -3,313 |
| valid overlay successes | 395 | 394 | -1 |

The one-success difference is normal run-to-run variation; successful redirects remain exclusively under `Office16` in both runs.

## Evidence

- baseline trace: `/home/ttv20/wine365vm-agents/plan14-c2r-20260830/artifacts/appv-vfs-double-overlay-20260830/baseline-c2-002.strace`
- patched trace: `/home/ttv20/wine365vm-agents/plan14-c2r-20260830/artifacts/appv-vfs-double-overlay-20260830/patched-c2-001.strace`
- patched Office environment: `wine365-plan14-appv-research-20260830`

## Summary by Sourcery

Avoid recursive App-V VFS lookups while preserving valid package overlays and reducing unnecessary filesystem activity.

Bug Fixes:
- Prevent App-V VFS resolution from recursively overlaying paths that are already inside the package backing store.

Enhancements:
- Preserve normal package-to-VFS overlays while reducing redundant Office startup filesystem work.

Tests:
- Add regression coverage for mixed-case VFS paths, direct backing-store access, and similarly prefixed directories.