### PR TITLE
xslt: reduce repeated XPath work during Office startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Speed up small Office gallery images rendered through Direct2D.
 - Improve antialiasing quality and rendering performance while reducing GPU memory use for complex Direct2D geometry with analytic coverage rendering.
 - Reduce Word CPU use by coalescing Office timers that allow delayed delivery.
+- Speed up repeated XSLT and XPath evaluation during Office startup.
 - Reduce message-loop server calls after retrieving queued messages.
 - Respect Direct2D stroke join styles while keeping sharp WordArt corners bounded.
 - Keep Word responsive while Microsoft 365 tokens are checked or refreshed in the background.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Report failed XML transformation checks without crashing the test suite.
 - Reuse reconstructed PE images across Wine server restarts to reduce Office startup disk I/O.
 - Fix Excel startup crashes caused by certificate-store registry handling.
 - Prevent Office startup crashes when certificate chains are built concurrently.

--- a/dlls/msxml3/tests/domdoc.c
+++ b/dlls/msxml3/tests/domdoc.c
@@ -14160,6 +14160,50 @@ static const char dynamic_name_doc[] =
 "    <beta value=\"two\"/>"
 "</items>";
 
+static const char invalid_dynamic_name_xsl[] =
+"<?xml version=\"1.0\"?>"
+"<xsl:stylesheet version=\"1.0\" xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\">"
+"<xsl:output method=\"text\"/>"
+"<xsl:template match=\"/\">"
+"    <xsl:for-each select=\"/items/item\">"
+"        <xsl:element name=\"{@name}\">ok</xsl:element>"
+"    </xsl:for-each>"
+"</xsl:template>"
+"</xsl:stylesheet>";
+
+static const char invalid_dynamic_name_doc[] =
+"<items>"
+"    <item name=\"valid\"/>"
+"    <item name=\"bad:name\"/>"
+"</items>";
+
+static const char xpath_cache_xsl[] =
+"<?xml version=\"1.0\"?>"
+"<xsl:stylesheet version=\"1.0\" xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\">"
+"<xsl:output method=\"text\"/>"
+"<xsl:variable name=\"label\" select=\"'global'\"/>"
+"<xsl:variable name=\"offset\" select=\"7\"/>"
+"<xsl:variable name=\"enabled\" select=\"true()\"/>"
+"<xsl:variable name=\"nodes\" select=\"/items/item\"/>"
+"<xsl:template match=\"/\">"
+"    <xsl:for-each select=\"$nodes\">"
+"        <xsl:sort select=\"concat(@group, substring(@name, 1, 2), @rank)\"/>"
+"        <xsl:variable name=\"label\" select=\"concat(../@prefix, @name)\"/>"
+"        <xsl:if test=\"$enabled and position() &lt;= count($nodes)\">"
+"            <xsl:value-of select=\"concat($label, ':', $offset + position(), ';')\"/>"
+"        </xsl:if>"
+"    </xsl:for-each>"
+"    <xsl:value-of select=\"concat('|', $label, '|', count($nodes), '|', not($enabled))\"/>"
+"</xsl:template>"
+"</xsl:stylesheet>";
+
+static const char xpath_cache_doc[] =
+"<items prefix=\"p-\">"
+"    <item group=\"b\" name=\"beta\" rank=\"2\"/>"
+"    <item group=\"a\" name=\"alpha\" rank=\"3\"/>"
+"    <item group=\"a\" name=\"aardvark\" rank=\"1\"/>"
+"</items>";
+
 static void check_dynamic_name_result(BSTR result)
 {
     static const char *const names[] = {"alpha", "beta"};
@@ -14233,6 +14277,7 @@ static void test_xsltext(void)
 {
     IXMLDOMDocument *doc, *doc2;
     VARIANT_BOOL b;
+    unsigned int i;
     HRESULT hr;
     BSTR ret;
 
@@ -14273,6 +14318,38 @@ static void test_xsltext(void)
     ok(hr == S_OK, "Unexpected hr %#lx.\n", hr);
     check_dynamic_name_result(ret);
     SysFreeString(ret);
+
+    /* AVT evaluation failure after a successful dynamic name */
+    hr = IXMLDOMDocument_loadXML(doc, _bstr_(invalid_dynamic_name_xsl), &b);
+    ok(hr == S_OK, "Unexpected hr %#lx.\n", hr);
+    ok(b == VARIANT_TRUE, "Failed to load stylesheet.\n");
+    hr = IXMLDOMDocument_loadXML(doc2, _bstr_(invalid_dynamic_name_doc), &b);
+    ok(hr == S_OK, "Unexpected hr %#lx.\n", hr);
+    ok(b == VARIANT_TRUE, "Failed to load source document.\n");
+
+    ret = NULL;
+    hr = IXMLDOMDocument_transformNode(doc2, (IXMLDOMNode *)doc, &ret);
+    todo_wine ok(hr == E_FAIL, "Unexpected hr %#lx.\n", hr);
+    if (hr == S_OK)
+        ok(ret && !*ret, "Unexpected partial transform result %s.\n", wine_dbgstr_w(ret));
+    SysFreeString(ret);
+
+    /* repeated XPath contexts, cached variable values, nested functions, and sort keys */
+    hr = IXMLDOMDocument_loadXML(doc, _bstr_(xpath_cache_xsl), &b);
+    ok(hr == S_OK, "Unexpected hr %#lx.\n", hr);
+    ok(b == VARIANT_TRUE, "Failed to load stylesheet.\n");
+    hr = IXMLDOMDocument_loadXML(doc2, _bstr_(xpath_cache_doc), &b);
+    ok(hr == S_OK, "Unexpected hr %#lx.\n", hr);
+    ok(b == VARIANT_TRUE, "Failed to load source document.\n");
+
+    for (i = 0; i < 16; ++i)
+    {
+        hr = IXMLDOMDocument_transformNode(doc2, (IXMLDOMNode *)doc, &ret);
+        ok(hr == S_OK, "%u: Unexpected hr %#lx.\n", i, hr);
+        ok(!lstrcmpW(ret, L"p-aardvark:8;p-alpha:9;p-beta:10;|global|3|false"),
+                "%u: Transform result %s.\n", i, wine_dbgstr_w(ret));
+        SysFreeString(ret);
+    }
 
     IXMLDOMDocument_Release(doc2);
     IXMLDOMDocument_Release(doc);

--- a/dlls/msxml3/tests/domdoc.c
+++ b/dlls/msxml3/tests/domdoc.c
@@ -14209,67 +14209,92 @@ static void check_dynamic_name_result(BSTR result)
     static const char *const names[] = {"alpha", "beta"};
     static const char *const qnames[] = {"o:alpha", "o:beta"};
     static const char *const values[] = {"one", "two"};
-    IXMLDOMNamedNodeMap *attributes;
+    IXMLDOMNamedNodeMap *attributes = NULL;
     IXMLDOMDocument *doc;
-    IXMLDOMNodeList *children;
-    IXMLDOMElement *root;
-    IXMLDOMNode *node, *attr;
+    IXMLDOMNodeList *children = NULL;
+    IXMLDOMElement *root = NULL;
+    IXMLDOMNode *node = NULL, *attr = NULL;
     VARIANT_BOOL b;
     LONG len, i;
     HRESULT hr;
-    BSTR str;
+    BSTR str = NULL;
 
     doc = create_document(&IID_IXMLDOMDocument);
     hr = IXMLDOMDocument_loadXML(doc, result, &b);
     ok(hr == S_OK, "Unexpected hr %#lx.\n", hr);
     ok(b == VARIANT_TRUE, "Failed to load transform result %s.\n", wine_dbgstr_w(result));
+    if (hr != S_OK || b != VARIANT_TRUE) goto done;
 
     hr = IXMLDOMDocument_get_documentElement(doc, &root);
     ok(hr == S_OK, "Unexpected hr %#lx.\n", hr);
+    if (hr != S_OK || !root) goto done;
     hr = IXMLDOMElement_get_childNodes(root, &children);
     ok(hr == S_OK, "Unexpected hr %#lx.\n", hr);
+    if (hr != S_OK || !children) goto done;
     hr = IXMLDOMNodeList_get_length(children, &len);
     ok(hr == S_OK, "Unexpected hr %#lx.\n", hr);
+    if (hr != S_OK) goto done;
     ok(len == ARRAY_SIZE(names), "Got %ld child nodes.\n", len);
 
     for (i = 0; i < len && i < ARRAY_SIZE(names); ++i)
     {
         hr = IXMLDOMNodeList_get_item(children, i, &node);
         ok(hr == S_OK, "%ld: Unexpected hr %#lx.\n", i, hr);
+        if (hr != S_OK || !node) goto done;
 
         hr = IXMLDOMNode_get_baseName(node, &str);
         ok(hr == S_OK, "%ld: Unexpected hr %#lx.\n", i, hr);
-        ok(!lstrcmpW(str, _bstr_(names[i])), "%ld: Got base name %s.\n", i, wine_dbgstr_w(str));
+        if (hr != S_OK) goto done;
+        ok(str && !lstrcmpW(str, _bstr_(names[i])), "%ld: Got base name %s.\n", i, wine_dbgstr_w(str));
         SysFreeString(str);
+        str = NULL;
         hr = IXMLDOMNode_get_namespaceURI(node, &str);
         ok(hr == S_OK, "%ld: Unexpected hr %#lx.\n", i, hr);
-        ok(!lstrcmpW(str, L"urn:out"), "%ld: Got namespace URI %s.\n", i, wine_dbgstr_w(str));
+        if (hr != S_OK) goto done;
+        ok(str && !lstrcmpW(str, L"urn:out"), "%ld: Got namespace URI %s.\n", i, wine_dbgstr_w(str));
         SysFreeString(str);
+        str = NULL;
 
         hr = IXMLDOMNode_get_attributes(node, &attributes);
         ok(hr == S_OK, "%ld: Unexpected hr %#lx.\n", i, hr);
+        if (hr != S_OK || !attributes) goto done;
         hr = IXMLDOMNamedNodeMap_getNamedItem(attributes, _bstr_(qnames[i]), &attr);
         ok(hr == S_OK, "%ld: Unexpected hr %#lx.\n", i, hr);
+        if (hr != S_OK || !attr) goto done;
         hr = IXMLDOMNode_get_baseName(attr, &str);
         ok(hr == S_OK, "%ld: Unexpected hr %#lx.\n", i, hr);
-        ok(!lstrcmpW(str, _bstr_(names[i])), "%ld: Got attribute base name %s.\n", i, wine_dbgstr_w(str));
+        if (hr != S_OK) goto done;
+        ok(str && !lstrcmpW(str, _bstr_(names[i])), "%ld: Got attribute base name %s.\n", i, wine_dbgstr_w(str));
         SysFreeString(str);
+        str = NULL;
         hr = IXMLDOMNode_get_namespaceURI(attr, &str);
         ok(hr == S_OK, "%ld: Unexpected hr %#lx.\n", i, hr);
-        ok(!lstrcmpW(str, L"urn:out"), "%ld: Got attribute namespace URI %s.\n", i, wine_dbgstr_w(str));
+        if (hr != S_OK) goto done;
+        ok(str && !lstrcmpW(str, L"urn:out"), "%ld: Got attribute namespace URI %s.\n", i, wine_dbgstr_w(str));
         SysFreeString(str);
+        str = NULL;
         hr = IXMLDOMNode_get_text(attr, &str);
         ok(hr == S_OK, "%ld: Unexpected hr %#lx.\n", i, hr);
-        ok(!lstrcmpW(str, _bstr_(values[i])), "%ld: Got attribute value %s.\n", i, wine_dbgstr_w(str));
+        if (hr != S_OK) goto done;
+        ok(str && !lstrcmpW(str, _bstr_(values[i])), "%ld: Got attribute value %s.\n", i, wine_dbgstr_w(str));
         SysFreeString(str);
+        str = NULL;
 
         IXMLDOMNode_Release(attr);
+        attr = NULL;
         IXMLDOMNamedNodeMap_Release(attributes);
+        attributes = NULL;
         IXMLDOMNode_Release(node);
+        node = NULL;
     }
 
-    IXMLDOMNodeList_Release(children);
-    IXMLDOMElement_Release(root);
+done:
+    SysFreeString(str);
+    if (attr) IXMLDOMNode_Release(attr);
+    if (attributes) IXMLDOMNamedNodeMap_Release(attributes);
+    if (node) IXMLDOMNode_Release(node);
+    if (children) IXMLDOMNodeList_Release(children);
+    if (root) IXMLDOMElement_Release(root);
     IXMLDOMDocument_Release(doc);
 }
 
@@ -14310,22 +14335,27 @@ static void test_xsltext(void)
     hr = IXMLDOMDocument_loadXML(doc, _bstr_(dynamic_name_xsl), &b);
     ok(hr == S_OK, "Unexpected hr %#lx.\n", hr);
     ok(b == VARIANT_TRUE, "Failed to load stylesheet.\n");
+    if (hr != S_OK || b != VARIANT_TRUE) goto done;
     hr = IXMLDOMDocument_loadXML(doc2, _bstr_(dynamic_name_doc), &b);
     ok(hr == S_OK, "Unexpected hr %#lx.\n", hr);
     ok(b == VARIANT_TRUE, "Failed to load source document.\n");
+    if (hr != S_OK || b != VARIANT_TRUE) goto done;
 
+    ret = NULL;
     hr = IXMLDOMDocument_transformNode(doc2, (IXMLDOMNode*)doc, &ret);
     ok(hr == S_OK, "Unexpected hr %#lx.\n", hr);
-    check_dynamic_name_result(ret);
+    if (hr == S_OK) check_dynamic_name_result(ret);
     SysFreeString(ret);
 
     /* AVT evaluation failure after a successful dynamic name */
     hr = IXMLDOMDocument_loadXML(doc, _bstr_(invalid_dynamic_name_xsl), &b);
     ok(hr == S_OK, "Unexpected hr %#lx.\n", hr);
     ok(b == VARIANT_TRUE, "Failed to load stylesheet.\n");
+    if (hr != S_OK || b != VARIANT_TRUE) goto done;
     hr = IXMLDOMDocument_loadXML(doc2, _bstr_(invalid_dynamic_name_doc), &b);
     ok(hr == S_OK, "Unexpected hr %#lx.\n", hr);
     ok(b == VARIANT_TRUE, "Failed to load source document.\n");
+    if (hr != S_OK || b != VARIANT_TRUE) goto done;
 
     ret = NULL;
     hr = IXMLDOMDocument_transformNode(doc2, (IXMLDOMNode *)doc, &ret);
@@ -14338,19 +14368,24 @@ static void test_xsltext(void)
     hr = IXMLDOMDocument_loadXML(doc, _bstr_(xpath_cache_xsl), &b);
     ok(hr == S_OK, "Unexpected hr %#lx.\n", hr);
     ok(b == VARIANT_TRUE, "Failed to load stylesheet.\n");
+    if (hr != S_OK || b != VARIANT_TRUE) goto done;
     hr = IXMLDOMDocument_loadXML(doc2, _bstr_(xpath_cache_doc), &b);
     ok(hr == S_OK, "Unexpected hr %#lx.\n", hr);
     ok(b == VARIANT_TRUE, "Failed to load source document.\n");
+    if (hr != S_OK || b != VARIANT_TRUE) goto done;
 
     for (i = 0; i < 16; ++i)
     {
+        ret = NULL;
         hr = IXMLDOMDocument_transformNode(doc2, (IXMLDOMNode *)doc, &ret);
         ok(hr == S_OK, "%u: Unexpected hr %#lx.\n", i, hr);
-        ok(!lstrcmpW(ret, L"p-aardvark:8;p-alpha:9;p-beta:10;|global|3|false"),
-                "%u: Transform result %s.\n", i, wine_dbgstr_w(ret));
+        if (hr == S_OK)
+            ok(ret && !lstrcmpW(ret, L"p-aardvark:8;p-alpha:9;p-beta:10;|global|3|false"),
+                    "%u: Transform result %s.\n", i, wine_dbgstr_w(ret));
         SysFreeString(ret);
     }
 
+done:
     IXMLDOMDocument_Release(doc2);
     IXMLDOMDocument_Release(doc);
     free_bstrs();

--- a/dlls/msxml3/tests/domdoc.c
+++ b/dlls/msxml3/tests/domdoc.c
@@ -14135,6 +14135,100 @@ static const char omitxmldecl_doc[] =
 "    <item name=\"item2\"/>"
 "</a>";
 
+static const char dynamic_name_xsl[] =
+"<?xml version=\"1.0\"?>"
+"<xsl:stylesheet version=\"1.0\" xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\" "
+"        xmlns:o=\"urn:out\" exclude-result-prefixes=\"o\">"
+"<xsl:output method=\"xml\" omit-xml-declaration=\"yes\"/>"
+"<xsl:variable name=\"outputNamespace\" select=\"'urn:out'\"/>"
+"<xsl:template match=\"/\">"
+"    <result>"
+"        <xsl:for-each select=\"/items/*\">"
+"            <xsl:element name=\"o:{local-name()}\" namespace=\"{$outputNamespace}\">"
+"                <xsl:attribute name=\"o:{local-name()}\" namespace=\"{$outputNamespace}\">"
+"                    <xsl:value-of select=\"@value\"/>"
+"                </xsl:attribute>"
+"            </xsl:element>"
+"        </xsl:for-each>"
+"    </result>"
+"</xsl:template>"
+"</xsl:stylesheet>";
+
+static const char dynamic_name_doc[] =
+"<items>"
+"    <alpha value=\"one\"/>"
+"    <beta value=\"two\"/>"
+"</items>";
+
+static void check_dynamic_name_result(BSTR result)
+{
+    static const char *const names[] = {"alpha", "beta"};
+    static const char *const qnames[] = {"o:alpha", "o:beta"};
+    static const char *const values[] = {"one", "two"};
+    IXMLDOMNamedNodeMap *attributes;
+    IXMLDOMDocument *doc;
+    IXMLDOMNodeList *children;
+    IXMLDOMElement *root;
+    IXMLDOMNode *node, *attr;
+    VARIANT_BOOL b;
+    LONG len, i;
+    HRESULT hr;
+    BSTR str;
+
+    doc = create_document(&IID_IXMLDOMDocument);
+    hr = IXMLDOMDocument_loadXML(doc, result, &b);
+    ok(hr == S_OK, "Unexpected hr %#lx.\n", hr);
+    ok(b == VARIANT_TRUE, "Failed to load transform result %s.\n", wine_dbgstr_w(result));
+
+    hr = IXMLDOMDocument_get_documentElement(doc, &root);
+    ok(hr == S_OK, "Unexpected hr %#lx.\n", hr);
+    hr = IXMLDOMElement_get_childNodes(root, &children);
+    ok(hr == S_OK, "Unexpected hr %#lx.\n", hr);
+    hr = IXMLDOMNodeList_get_length(children, &len);
+    ok(hr == S_OK, "Unexpected hr %#lx.\n", hr);
+    ok(len == ARRAY_SIZE(names), "Got %ld child nodes.\n", len);
+
+    for (i = 0; i < len && i < ARRAY_SIZE(names); ++i)
+    {
+        hr = IXMLDOMNodeList_get_item(children, i, &node);
+        ok(hr == S_OK, "%ld: Unexpected hr %#lx.\n", i, hr);
+
+        hr = IXMLDOMNode_get_baseName(node, &str);
+        ok(hr == S_OK, "%ld: Unexpected hr %#lx.\n", i, hr);
+        ok(!lstrcmpW(str, _bstr_(names[i])), "%ld: Got base name %s.\n", i, wine_dbgstr_w(str));
+        SysFreeString(str);
+        hr = IXMLDOMNode_get_namespaceURI(node, &str);
+        ok(hr == S_OK, "%ld: Unexpected hr %#lx.\n", i, hr);
+        ok(!lstrcmpW(str, L"urn:out"), "%ld: Got namespace URI %s.\n", i, wine_dbgstr_w(str));
+        SysFreeString(str);
+
+        hr = IXMLDOMNode_get_attributes(node, &attributes);
+        ok(hr == S_OK, "%ld: Unexpected hr %#lx.\n", i, hr);
+        hr = IXMLDOMNamedNodeMap_getNamedItem(attributes, _bstr_(qnames[i]), &attr);
+        ok(hr == S_OK, "%ld: Unexpected hr %#lx.\n", i, hr);
+        hr = IXMLDOMNode_get_baseName(attr, &str);
+        ok(hr == S_OK, "%ld: Unexpected hr %#lx.\n", i, hr);
+        ok(!lstrcmpW(str, _bstr_(names[i])), "%ld: Got attribute base name %s.\n", i, wine_dbgstr_w(str));
+        SysFreeString(str);
+        hr = IXMLDOMNode_get_namespaceURI(attr, &str);
+        ok(hr == S_OK, "%ld: Unexpected hr %#lx.\n", i, hr);
+        ok(!lstrcmpW(str, L"urn:out"), "%ld: Got attribute namespace URI %s.\n", i, wine_dbgstr_w(str));
+        SysFreeString(str);
+        hr = IXMLDOMNode_get_text(attr, &str);
+        ok(hr == S_OK, "%ld: Unexpected hr %#lx.\n", i, hr);
+        ok(!lstrcmpW(str, _bstr_(values[i])), "%ld: Got attribute value %s.\n", i, wine_dbgstr_w(str));
+        SysFreeString(str);
+
+        IXMLDOMNode_Release(attr);
+        IXMLDOMNamedNodeMap_Release(attributes);
+        IXMLDOMNode_Release(node);
+    }
+
+    IXMLDOMNodeList_Release(children);
+    IXMLDOMElement_Release(root);
+    IXMLDOMDocument_Release(doc);
+}
+
 static void test_xsltext(void)
 {
     IXMLDOMDocument *doc, *doc2;
@@ -14165,6 +14259,19 @@ static void test_xsltext(void)
     hr = IXMLDOMDocument_transformNode(doc2, (IXMLDOMNode*)doc, &ret);
     ok(hr == S_OK, "Unexpected hr %#lx.\n", hr);
     ok(!lstrcmpW(ret, L"<node>item1</node><node>item2</node>"), "transform result %s\n", wine_dbgstr_w(ret));
+    SysFreeString(ret);
+
+    /* dynamic xsl:element and xsl:attribute name and namespace AVTs */
+    hr = IXMLDOMDocument_loadXML(doc, _bstr_(dynamic_name_xsl), &b);
+    ok(hr == S_OK, "Unexpected hr %#lx.\n", hr);
+    ok(b == VARIANT_TRUE, "Failed to load stylesheet.\n");
+    hr = IXMLDOMDocument_loadXML(doc2, _bstr_(dynamic_name_doc), &b);
+    ok(hr == S_OK, "Unexpected hr %#lx.\n", hr);
+    ok(b == VARIANT_TRUE, "Failed to load source document.\n");
+
+    hr = IXMLDOMDocument_transformNode(doc2, (IXMLDOMNode*)doc, &ret);
+    ok(hr == S_OK, "Unexpected hr %#lx.\n", hr);
+    check_dynamic_name_result(ret);
     SysFreeString(ret);
 
     IXMLDOMDocument_Release(doc2);

--- a/libs/xml2/include/libxml/xpath.h
+++ b/libs/xml2/include/libxml/xpath.h
@@ -456,6 +456,9 @@ XMLPUBVAR double xmlXPathNINF;
 
 XMLPUBFUN void
 		    xmlXPathFreeObject		(xmlXPathObjectPtr obj);
+XMLPUBFUN void
+		    xmlXPathReleaseObject	(xmlXPathContextPtr ctxt,
+                                                 xmlXPathObjectPtr obj);
 XMLPUBFUN xmlNodeSetPtr
 		    xmlXPathNodeSetCreate	(xmlNodePtr val);
 XMLPUBFUN void
@@ -464,6 +467,9 @@ XMLPUBFUN void
 		    xmlXPathFreeNodeSet		(xmlNodeSetPtr obj);
 XMLPUBFUN xmlXPathObjectPtr
 		    xmlXPathObjectCopy		(xmlXPathObjectPtr val);
+XMLPUBFUN xmlXPathObjectPtr
+		    xmlXPathCacheObjectCopy	(xmlXPathContextPtr ctxt,
+                                                 xmlXPathObjectPtr val);
 XMLPUBFUN int
 		    xmlXPathCmpNodes		(xmlNodePtr node1,
 						 xmlNodePtr node2);

--- a/libs/xml2/include/libxml/xpath.h
+++ b/libs/xml2/include/libxml/xpath.h
@@ -456,9 +456,6 @@ XMLPUBVAR double xmlXPathNINF;
 
 XMLPUBFUN void
 		    xmlXPathFreeObject		(xmlXPathObjectPtr obj);
-XMLPUBFUN void
-		    xmlXPathReleaseObject	(xmlXPathContextPtr ctxt,
-                                                 xmlXPathObjectPtr obj);
 XMLPUBFUN xmlNodeSetPtr
 		    xmlXPathNodeSetCreate	(xmlNodePtr val);
 XMLPUBFUN void
@@ -467,9 +464,6 @@ XMLPUBFUN void
 		    xmlXPathFreeNodeSet		(xmlNodeSetPtr obj);
 XMLPUBFUN xmlXPathObjectPtr
 		    xmlXPathObjectCopy		(xmlXPathObjectPtr val);
-XMLPUBFUN xmlXPathObjectPtr
-		    xmlXPathCacheObjectCopy	(xmlXPathContextPtr ctxt,
-                                                 xmlXPathObjectPtr val);
 XMLPUBFUN int
 		    xmlXPathCmpNodes		(xmlNodePtr node1,
 						 xmlNodePtr node2);

--- a/libs/xml2/include/private/xpath.h
+++ b/libs/xml2/include/private/xpath.h
@@ -1,7 +1,23 @@
 #ifndef XML_XPATH_H_PRIVATE__
 #define XML_XPATH_H_PRIVATE__
 
-XML_HIDDEN void
+#include <libxml/xpath.h>
+
+#ifdef IN_LIBXML
+#define XML_XPATH_HIDDEN XML_HIDDEN
+#else
+#define XML_XPATH_HIDDEN
+#endif
+
+XML_XPATH_HIDDEN void
 xmlInitXPathInternal(void);
+
+XML_XPATH_HIDDEN xmlXPathObjectPtr
+xmlXPathCacheObjectCopy(xmlXPathContextPtr ctxt, xmlXPathObjectPtr val);
+
+XML_XPATH_HIDDEN void
+xmlXPathReleaseObject(xmlXPathContextPtr ctxt, xmlXPathObjectPtr obj);
+
+#undef XML_XPATH_HIDDEN
 
 #endif /* XML_XPATH_H_PRIVATE__ */

--- a/libs/xml2/xpath.c
+++ b/libs/xml2/xpath.c
@@ -985,7 +985,7 @@ struct _xmlXPathCompExpr {
  ************************************************************************/
 static void
 xmlXPathFreeValueTree(xmlNodeSetPtr obj);
-static void
+void
 xmlXPathReleaseObject(xmlXPathContextPtr ctxt, xmlXPathObjectPtr obj);
 static int
 xmlXPathCompOpEvalFirst(xmlXPathParserContextPtr ctxt,
@@ -1208,12 +1208,18 @@ xmlXPathCompExprAdd(ctxt, (ch1), (ch2), (op),			\
 
 typedef struct _xmlXPathContextCache xmlXPathContextCache;
 typedef xmlXPathContextCache *xmlXPathContextCachePtr;
+
+#define XPATH_MAX_CACHED_STRING_LENGTH 1024
+#define XPATH_MAX_CACHED_STRING_BUFFERS 16
+
 struct _xmlXPathContextCache {
     xmlPointerListPtr nodesetObjs;  /* contains xmlXPathObjectPtr */
     xmlPointerListPtr stringObjs;   /* contains xmlXPathObjectPtr */
+    xmlPointerListPtr stringBufs;   /* contains reusable xmlChar buffers */
     xmlPointerListPtr booleanObjs;  /* contains xmlXPathObjectPtr */
     xmlPointerListPtr numberObjs;   /* contains xmlXPathObjectPtr */
     xmlPointerListPtr miscObjs;     /* contains xmlXPathObjectPtr */
+    xmlXPathParserContextPtr evalCtxt;
     int maxNodeset;
     int maxString;
     int maxBoolean;
@@ -1735,12 +1741,27 @@ xmlXPathCacheFreeObjectList(xmlPointerListPtr list)
 }
 
 static void
+xmlXPathCacheFreeStringList(xmlPointerListPtr list)
+{
+    int i;
+
+    if (list == NULL)
+        return;
+
+    for (i = 0; i < list->number; i++)
+        xmlFree(list->items[i]);
+    xmlPointerListFree(list);
+}
+
+static void
 xmlXPathFreeCache(xmlXPathContextCachePtr cache)
 {
     if (cache == NULL)
 	return;
     if (cache->nodesetObjs)
 	xmlXPathCacheFreeObjectList(cache->nodesetObjs);
+    if (cache->stringBufs)
+        xmlXPathCacheFreeStringList(cache->stringBufs);
     if (cache->stringObjs)
 	xmlXPathCacheFreeObjectList(cache->stringObjs);
     if (cache->booleanObjs)
@@ -1749,6 +1770,8 @@ xmlXPathFreeCache(xmlXPathContextCachePtr cache)
 	xmlXPathCacheFreeObjectList(cache->numberObjs);
     if (cache->miscObjs)
 	xmlXPathCacheFreeObjectList(cache->miscObjs);
+    if (cache->evalCtxt)
+        xmlXPathFreeParserContext(cache->evalCtxt);
     xmlFree(cache);
 }
 
@@ -1956,6 +1979,34 @@ xmlXPathCacheNewNodeSet(xmlXPathContextPtr ctxt, xmlNodePtr val)
     return(xmlXPathNewNodeSet(val));
 }
 
+static xmlChar *
+xmlXPathCacheCopyString(xmlXPathContextPtr ctxt, const xmlChar *val)
+{
+    xmlXPathContextCachePtr cache = (xmlXPathContextCachePtr) ctxt->cache;
+    xmlChar *ret = NULL;
+    size_t len;
+
+    if (val == NULL)
+        val = BAD_CAST "";
+    len = xmlStrlen(val);
+
+    if ((cache->stringBufs != NULL) && (cache->stringBufs->number != 0))
+        ret = cache->stringBufs->items[--cache->stringBufs->number];
+
+    if ((ret == NULL) || ((size_t)xmlStrlen(ret) < len)) {
+        xmlChar *tmp = xmlRealloc(ret, len + 1);
+
+        if (tmp == NULL) {
+            xmlFree(ret);
+            xmlXPathErrMemory(ctxt, NULL);
+            return(NULL);
+        }
+        ret = tmp;
+    }
+    memcpy(ret, val, len + 1);
+    return(ret);
+}
+
 /**
  * xmlXPathCacheNewString:
  * @ctxt: the XPath context
@@ -1969,23 +2020,19 @@ xmlXPathCacheNewNodeSet(xmlXPathContextPtr ctxt, xmlNodePtr val)
 static xmlXPathObjectPtr
 xmlXPathCacheNewString(xmlXPathContextPtr ctxt, const xmlChar *val)
 {
+    xmlXPathObjectPtr ret;
+    xmlChar *copy;
+
     if ((ctxt != NULL) && (ctxt->cache)) {
 	xmlXPathContextCachePtr cache = (xmlXPathContextCachePtr) ctxt->cache;
+
+        copy = xmlXPathCacheCopyString(ctxt, val);
+        if (copy == NULL)
+            return(NULL);
 
 	if ((cache->stringObjs != NULL) &&
 	    (cache->stringObjs->number != 0))
 	{
-	    xmlXPathObjectPtr ret;
-            xmlChar *copy;
-
-            if (val == NULL)
-                val = BAD_CAST "";
-            copy = xmlStrdup(val);
-            if (copy == NULL) {
-                xmlXPathErrMemory(ctxt, NULL);
-                return(NULL);
-            }
-
 	    ret = (xmlXPathObjectPtr)
 		cache->stringObjs->items[--cache->stringObjs->number];
 	    ret->type = XPATH_STRING;
@@ -1994,24 +2041,14 @@ xmlXPathCacheNewString(xmlXPathContextPtr ctxt, const xmlChar *val)
 	} else if ((cache->miscObjs != NULL) &&
 	    (cache->miscObjs->number != 0))
 	{
-	    xmlXPathObjectPtr ret;
-            xmlChar *copy;
-
-            if (val == NULL)
-                val = BAD_CAST "";
-            copy = xmlStrdup(val);
-            if (copy == NULL) {
-                xmlXPathErrMemory(ctxt, NULL);
-                return(NULL);
-            }
-
 	    ret = (xmlXPathObjectPtr)
 		cache->miscObjs->items[--cache->miscObjs->number];
 
 	    ret->type = XPATH_STRING;
-            ret->stringval = copy;
+	    ret->stringval = copy;
 	    return(ret);
 	}
+        return(xmlXPathWrapString(copy));
     }
     return(xmlXPathNewString(val));
 }
@@ -2175,7 +2212,7 @@ xmlXPathCacheConvertString(xmlXPathContextPtr ctxt, xmlXPathObjectPtr val) {
  *
  * Returns a created or reused created object.
  */
-static xmlXPathObjectPtr
+xmlXPathObjectPtr
 xmlXPathCacheObjectCopy(xmlXPathContextPtr ctxt, xmlXPathObjectPtr val)
 {
     if (val == NULL)
@@ -4857,7 +4894,7 @@ xmlXPathFreeObjectEntry(void *obj, const xmlChar *name ATTRIBUTE_UNUSED) {
  * Depending on the state of the cache this frees the given
  * XPath object or stores it in the cache.
  */
-static void
+void
 xmlXPathReleaseObject(xmlXPathContextPtr ctxt, xmlXPathObjectPtr obj)
 {
 #define XP_CACHE_ADD(sl, o) if (sl == NULL) { \
@@ -4900,8 +4937,25 @@ xmlXPathReleaseObject(xmlXPathContextPtr ctxt, xmlXPathObjectPtr obj)
 		}
 		break;
 	    case XPATH_STRING:
-		if (obj->stringval != NULL)
-		    xmlFree(obj->stringval);
+		if (obj->stringval != NULL) {
+                    size_t len = xmlStrlen(obj->stringval);
+                    int max_buffers = cache->maxString;
+
+                    if (max_buffers > XPATH_MAX_CACHED_STRING_BUFFERS)
+                        max_buffers = XPATH_MAX_CACHED_STRING_BUFFERS;
+
+                    if ((len <= XPATH_MAX_CACHED_STRING_LENGTH) &&
+                        XP_CACHE_WANTS(cache->stringBufs, max_buffers)) {
+                        if (cache->stringBufs == NULL)
+                            cache->stringBufs = xmlPointerListCreate(10);
+                        if ((cache->stringBufs != NULL) &&
+                            (xmlPointerListAddSize(cache->stringBufs,
+                                obj->stringval, 0) != -1))
+                            obj->stringval = NULL;
+                    }
+                    xmlFree(obj->stringval);
+                    obj->stringval = NULL;
+                }
 
 		if (XP_CACHE_WANTS(cache->stringObjs, cache->maxString)) {
 		    XP_CACHE_ADD(cache->stringObjs, obj);
@@ -5582,30 +5636,76 @@ xmlXPathNewParserContext(const xmlChar *str, xmlXPathContextPtr ctxt) {
 static xmlXPathParserContextPtr
 xmlXPathCompParserContext(xmlXPathCompExprPtr comp, xmlXPathContextPtr ctxt) {
     xmlXPathParserContextPtr ret;
+    xmlXPathContextCachePtr cache = ctxt ? ctxt->cache : NULL;
 
-    ret = (xmlXPathParserContextPtr) xmlMalloc(sizeof(xmlXPathParserContext));
-    if (ret == NULL) {
-        xmlXPathErrMemory(ctxt, "creating evaluation context\n");
-	return(NULL);
-    }
-    memset(ret, 0 , sizeof(xmlXPathParserContext));
+    if ((cache != NULL) && (cache->evalCtxt != NULL)) {
+        xmlXPathObjectPtr *valueTab;
+        int valueMax;
 
-    /* Allocate the value stack */
-    ret->valueTab = (xmlXPathObjectPtr *)
-                     xmlMalloc(10 * sizeof(xmlXPathObjectPtr));
-    if (ret->valueTab == NULL) {
-	xmlFree(ret);
-	xmlXPathErrMemory(ctxt, "creating evaluation context\n");
-	return(NULL);
+        ret = cache->evalCtxt;
+        cache->evalCtxt = NULL;
+        valueTab = ret->valueTab;
+        valueMax = ret->valueMax;
+        memset(ret, 0, sizeof(xmlXPathParserContext));
+        ret->valueTab = valueTab;
+        ret->valueMax = valueMax;
+    } else {
+        ret = (xmlXPathParserContextPtr) xmlMalloc(sizeof(xmlXPathParserContext));
+        if (ret == NULL) {
+            xmlXPathErrMemory(ctxt, "creating evaluation context\n");
+            return(NULL);
+        }
+        memset(ret, 0 , sizeof(xmlXPathParserContext));
+
+        /* Allocate the value stack */
+        ret->valueTab = (xmlXPathObjectPtr *)
+                         xmlMalloc(10 * sizeof(xmlXPathObjectPtr));
+        if (ret->valueTab == NULL) {
+            xmlFree(ret);
+            xmlXPathErrMemory(ctxt, "creating evaluation context\n");
+            return(NULL);
+        }
+        ret->valueMax = 10;
     }
     ret->valueNr = 0;
-    ret->valueMax = 10;
     ret->value = NULL;
 
     ret->context = ctxt;
     ret->comp = comp;
 
     return(ret);
+}
+
+static void
+xmlXPathReleaseParserContext(xmlXPathParserContextPtr ctxt)
+{
+    xmlXPathContextCachePtr cache;
+    int i;
+
+    if (ctxt == NULL)
+        return;
+
+    if (ctxt->valueTab != NULL) {
+        for (i = 0; i < ctxt->valueNr; i++) {
+            if (ctxt->context)
+                xmlXPathReleaseObject(ctxt->context, ctxt->valueTab[i]);
+            else
+                xmlXPathFreeObject(ctxt->valueTab[i]);
+        }
+    }
+    ctxt->valueNr = 0;
+    ctxt->value = NULL;
+    ctxt->comp = NULL;
+
+    cache = ctxt->context ? ctxt->context->cache : NULL;
+    if ((cache != NULL) && (cache->evalCtxt == NULL) &&
+        (ctxt->valueMax <= 40)) {
+        cache->evalCtxt = ctxt;
+        return;
+    }
+
+    xmlFree(ctxt->valueTab);
+    xmlFree(ctxt);
 }
 
 /**
@@ -13457,8 +13557,7 @@ xmlXPathCompiledEvalInternal(xmlXPathCompExprPtr comp,
     else
         xmlXPathReleaseObject(ctxt, resObj);
 
-    pctxt->comp = NULL;
-    xmlXPathFreeParserContext(pctxt);
+    xmlXPathReleaseParserContext(pctxt);
 #ifndef LIBXML_THREAD_ENABLED
     reentance--;
 #endif

--- a/libs/xml2/xpath.c
+++ b/libs/xml2/xpath.c
@@ -1874,7 +1874,7 @@ xmlXPathCacheWrapString(xmlXPathContextPtr ctxt, xmlChar *val)
 	    ret = (xmlXPathObjectPtr)
 		cache->stringObjs->items[--cache->stringObjs->number];
 	    xmlFree(ret->stringval);
-	    ret->index = 0;
+	    ret->index2 = 0;
 	} else if ((cache->miscObjs != NULL) &&
 	    (cache->miscObjs->number != 0))
 	{
@@ -1962,7 +1962,7 @@ static int
 xmlXPathCacheSetString(xmlXPathContextPtr ctxt, xmlXPathObjectPtr obj,
                        const xmlChar *val, size_t len)
 {
-    if ((obj->stringval == NULL) || ((size_t)obj->index <= len)) {
+    if ((obj->stringval == NULL) || ((size_t)obj->index2 <= len)) {
         xmlChar *tmp = xmlRealloc(obj->stringval, len + 1);
 
         if (tmp == NULL) {
@@ -1970,7 +1970,7 @@ xmlXPathCacheSetString(xmlXPathContextPtr ctxt, xmlXPathObjectPtr obj,
             return(-1);
         }
         obj->stringval = tmp;
-        obj->index = len < INT_MAX ? len + 1 : 0;
+        obj->index2 = len < INT_MAX ? len + 1 : 0;
     }
     memcpy(obj->stringval, val, len + 1);
     obj->type = XPATH_STRING;
@@ -4754,6 +4754,7 @@ xmlXPathObjectCopy(xmlXPathObjectPtr val) {
                 xmlFree(ret);
                 return(NULL);
             }
+	    ret->index2 = 0;
 	    break;
 	case XPATH_XSLT_TREE:
 #if 0
@@ -4906,18 +4907,18 @@ xmlXPathReleaseObject(xmlXPathContextPtr ctxt, xmlXPathObjectPtr obj)
 		break;
 	    case XPATH_STRING:
 		if (obj->stringval != NULL) {
-                    size_t len = xmlStrlen(obj->stringval) + 1;
                     int max_objects = cache->maxString;
 
                     if (max_objects > XPATH_MAX_CACHED_STRING_OBJECTS)
                         max_objects = XPATH_MAX_CACHED_STRING_OBJECTS;
 
-                    if (len <= XPATH_MAX_CACHED_STRING_LENGTH + 1) {
-                        if ((obj->index <= 0) ||
-                            ((size_t)obj->index < len))
-                            obj->index = len;
+                    if (obj->index2 <= 0) {
+                        size_t len = xmlStrlen(obj->stringval) + 1;
+
+                        if (len <= XPATH_MAX_CACHED_STRING_LENGTH + 1)
+                            obj->index2 = len;
                     }
-                    if ((obj->index > 0) && ((size_t)obj->index <=
+                    if ((obj->index2 > 0) && ((size_t)obj->index2 <=
                             XPATH_MAX_CACHED_STRING_LENGTH + 1) &&
                         XP_CACHE_WANTS(cache->stringObjs, max_objects)) {
                         XP_CACHE_ADD(cache->stringObjs, obj);
@@ -4927,7 +4928,7 @@ xmlXPathReleaseObject(xmlXPathContextPtr ctxt, xmlXPathObjectPtr obj)
 
 		xmlFree(obj->stringval);
 		obj->stringval = NULL;
-		obj->index = 0;
+		obj->index2 = 0;
 		break;
 	    case XPATH_BOOLEAN:
 		if (XP_CACHE_WANTS(cache->booleanObjs, cache->maxBoolean)) {
@@ -4992,11 +4993,11 @@ obj_cached:
 	    obj->nodesetval = tmpset;
 	} else if (obj->stringval != NULL) {
 	    xmlChar *stringval = obj->stringval;
-	    int stringmax = obj->index;
+	    int stringmax = obj->index2;
 
 	    memset(obj, 0, sizeof(xmlXPathObject));
 	    obj->stringval = stringval;
-	    obj->index = stringmax;
+	    obj->index2 = stringmax;
 	} else {
 	    memset(obj, 0, sizeof(xmlXPathObject));
 	}
@@ -8340,11 +8341,11 @@ xmlXPathConcatFunction(xmlXPathParserContextPtr ctxt, int nargs) {
 	    XP_ERROR(XPATH_INVALID_TYPE);
 	}
 	tmp = xmlStrcat(newobj->stringval, cur->stringval);
-	stringmax = cur->index;
+	stringmax = cur->index2;
 	newobj->stringval = cur->stringval;
-	newobj->index = stringmax;
+	newobj->index2 = stringmax;
 	cur->stringval = tmp;
-	cur->index = xmlStrlen(tmp) + 1;
+	cur->index2 = xmlStrlen(tmp) + 1;
 	xmlXPathReleaseObject(ctxt->context, newobj);
 	nargs--;
     }

--- a/libs/xml2/xpath.c
+++ b/libs/xml2/xpath.c
@@ -1210,16 +1210,15 @@ typedef struct _xmlXPathContextCache xmlXPathContextCache;
 typedef xmlXPathContextCache *xmlXPathContextCachePtr;
 
 #define XPATH_MAX_CACHED_STRING_LENGTH 1024
-#define XPATH_MAX_CACHED_STRING_BUFFERS 16
+#define XPATH_MAX_CACHED_STRING_OBJECTS 16
 
 struct _xmlXPathContextCache {
     xmlPointerListPtr nodesetObjs;  /* contains xmlXPathObjectPtr */
     xmlPointerListPtr stringObjs;   /* contains xmlXPathObjectPtr */
-    xmlPointerListPtr stringBufs;   /* contains reusable xmlChar buffers */
     xmlPointerListPtr booleanObjs;  /* contains xmlXPathObjectPtr */
     xmlPointerListPtr numberObjs;   /* contains xmlXPathObjectPtr */
     xmlPointerListPtr miscObjs;     /* contains xmlXPathObjectPtr */
-    xmlXPathParserContextPtr evalCtxt;
+    xmlXPathParserContextPtr evalCtxt; /* reusable evaluation context */
     int maxNodeset;
     int maxString;
     int maxBoolean;
@@ -1735,21 +1734,9 @@ xmlXPathCacheFreeObjectList(xmlPointerListPtr list)
 		xmlFree(obj->nodesetval->nodeTab);
 	    xmlFree(obj->nodesetval);
 	}
+        xmlFree(obj->stringval);
 	xmlFree(obj);
     }
-    xmlPointerListFree(list);
-}
-
-static void
-xmlXPathCacheFreeStringList(xmlPointerListPtr list)
-{
-    int i;
-
-    if (list == NULL)
-        return;
-
-    for (i = 0; i < list->number; i++)
-        xmlFree(list->items[i]);
     xmlPointerListFree(list);
 }
 
@@ -1760,8 +1747,6 @@ xmlXPathFreeCache(xmlXPathContextCachePtr cache)
 	return;
     if (cache->nodesetObjs)
 	xmlXPathCacheFreeObjectList(cache->nodesetObjs);
-    if (cache->stringBufs)
-        xmlXPathCacheFreeStringList(cache->stringBufs);
     if (cache->stringObjs)
 	xmlXPathCacheFreeObjectList(cache->stringObjs);
     if (cache->booleanObjs)
@@ -1881,28 +1866,22 @@ xmlXPathCacheWrapString(xmlXPathContextPtr ctxt, xmlChar *val)
 {
     if ((ctxt != NULL) && (ctxt->cache != NULL)) {
 	xmlXPathContextCachePtr cache = (xmlXPathContextCachePtr) ctxt->cache;
+	xmlXPathObjectPtr ret = NULL;
 
 	if ((cache->stringObjs != NULL) &&
 	    (cache->stringObjs->number != 0))
 	{
-
-	    xmlXPathObjectPtr ret;
-
 	    ret = (xmlXPathObjectPtr)
 		cache->stringObjs->items[--cache->stringObjs->number];
-	    ret->type = XPATH_STRING;
-	    ret->stringval = val;
-	    return(ret);
+	    xmlFree(ret->stringval);
+	    ret->index = 0;
 	} else if ((cache->miscObjs != NULL) &&
 	    (cache->miscObjs->number != 0))
 	{
-	    xmlXPathObjectPtr ret;
-	    /*
-	    * Fallback to misc-cache.
-	    */
 	    ret = (xmlXPathObjectPtr)
 		cache->miscObjs->items[--cache->miscObjs->number];
-
+	}
+	if (ret != NULL) {
 	    ret->type = XPATH_STRING;
 	    ret->stringval = val;
 	    return(ret);
@@ -1979,32 +1958,23 @@ xmlXPathCacheNewNodeSet(xmlXPathContextPtr ctxt, xmlNodePtr val)
     return(xmlXPathNewNodeSet(val));
 }
 
-static xmlChar *
-xmlXPathCacheCopyString(xmlXPathContextPtr ctxt, const xmlChar *val)
+static int
+xmlXPathCacheSetString(xmlXPathContextPtr ctxt, xmlXPathObjectPtr obj,
+                       const xmlChar *val, size_t len)
 {
-    xmlXPathContextCachePtr cache = (xmlXPathContextCachePtr) ctxt->cache;
-    xmlChar *ret = NULL;
-    size_t len;
-
-    if (val == NULL)
-        val = BAD_CAST "";
-    len = xmlStrlen(val);
-
-    if ((cache->stringBufs != NULL) && (cache->stringBufs->number != 0))
-        ret = cache->stringBufs->items[--cache->stringBufs->number];
-
-    if ((ret == NULL) || ((size_t)xmlStrlen(ret) < len)) {
-        xmlChar *tmp = xmlRealloc(ret, len + 1);
+    if ((obj->stringval == NULL) || ((size_t)obj->index <= len)) {
+        xmlChar *tmp = xmlRealloc(obj->stringval, len + 1);
 
         if (tmp == NULL) {
-            xmlFree(ret);
             xmlXPathErrMemory(ctxt, NULL);
-            return(NULL);
+            return(-1);
         }
-        ret = tmp;
+        obj->stringval = tmp;
+        obj->index = len < INT_MAX ? len + 1 : 0;
     }
-    memcpy(ret, val, len + 1);
-    return(ret);
+    memcpy(obj->stringval, val, len + 1);
+    obj->type = XPATH_STRING;
+    return(0);
 }
 
 /**
@@ -2020,35 +1990,33 @@ xmlXPathCacheCopyString(xmlXPathContextPtr ctxt, const xmlChar *val)
 static xmlXPathObjectPtr
 xmlXPathCacheNewString(xmlXPathContextPtr ctxt, const xmlChar *val)
 {
-    xmlXPathObjectPtr ret;
-    xmlChar *copy;
-
     if ((ctxt != NULL) && (ctxt->cache)) {
 	xmlXPathContextCachePtr cache = (xmlXPathContextCachePtr) ctxt->cache;
-
-        copy = xmlXPathCacheCopyString(ctxt, val);
-        if (copy == NULL)
-            return(NULL);
+	const xmlChar *value = val != NULL ? val : BAD_CAST "";
+	size_t len = xmlStrlen(value);
+	xmlXPathObjectPtr ret;
 
 	if ((cache->stringObjs != NULL) &&
 	    (cache->stringObjs->number != 0))
 	{
 	    ret = (xmlXPathObjectPtr)
 		cache->stringObjs->items[--cache->stringObjs->number];
-	    ret->type = XPATH_STRING;
-            ret->stringval = copy;
-	    return(ret);
 	} else if ((cache->miscObjs != NULL) &&
 	    (cache->miscObjs->number != 0))
 	{
 	    ret = (xmlXPathObjectPtr)
 		cache->miscObjs->items[--cache->miscObjs->number];
-
-	    ret->type = XPATH_STRING;
-	    ret->stringval = copy;
-	    return(ret);
+	} else {
+	    ret = NULL;
 	}
-        return(xmlXPathWrapString(copy));
+
+	if (ret != NULL) {
+	    if (xmlXPathCacheSetString(ctxt, ret, value, len) == 0)
+		return(ret);
+	    xmlFree(ret->stringval);
+	    xmlFree(ret);
+	    return(NULL);
+	}
     }
     return(xmlXPathNewString(val));
 }
@@ -4938,29 +4906,28 @@ xmlXPathReleaseObject(xmlXPathContextPtr ctxt, xmlXPathObjectPtr obj)
 		break;
 	    case XPATH_STRING:
 		if (obj->stringval != NULL) {
-                    size_t len = xmlStrlen(obj->stringval);
-                    int max_buffers = cache->maxString;
+                    size_t len = xmlStrlen(obj->stringval) + 1;
+                    int max_objects = cache->maxString;
 
-                    if (max_buffers > XPATH_MAX_CACHED_STRING_BUFFERS)
-                        max_buffers = XPATH_MAX_CACHED_STRING_BUFFERS;
+                    if (max_objects > XPATH_MAX_CACHED_STRING_OBJECTS)
+                        max_objects = XPATH_MAX_CACHED_STRING_OBJECTS;
 
-                    if ((len <= XPATH_MAX_CACHED_STRING_LENGTH) &&
-                        XP_CACHE_WANTS(cache->stringBufs, max_buffers)) {
-                        if (cache->stringBufs == NULL)
-                            cache->stringBufs = xmlPointerListCreate(10);
-                        if ((cache->stringBufs != NULL) &&
-                            (xmlPointerListAddSize(cache->stringBufs,
-                                obj->stringval, 0) != -1))
-                            obj->stringval = NULL;
+                    if (len <= XPATH_MAX_CACHED_STRING_LENGTH + 1) {
+                        if ((obj->index <= 0) ||
+                            ((size_t)obj->index < len))
+                            obj->index = len;
                     }
-                    xmlFree(obj->stringval);
-                    obj->stringval = NULL;
+                    if ((obj->index > 0) && ((size_t)obj->index <=
+                            XPATH_MAX_CACHED_STRING_LENGTH + 1) &&
+                        XP_CACHE_WANTS(cache->stringObjs, max_objects)) {
+                        XP_CACHE_ADD(cache->stringObjs, obj);
+                        goto obj_cached;
+                    }
                 }
 
-		if (XP_CACHE_WANTS(cache->stringObjs, cache->maxString)) {
-		    XP_CACHE_ADD(cache->stringObjs, obj);
-		    goto obj_cached;
-		}
+		xmlFree(obj->stringval);
+		obj->stringval = NULL;
+		obj->index = 0;
 		break;
 	    case XPATH_BOOLEAN:
 		if (XP_CACHE_WANTS(cache->booleanObjs, cache->maxBoolean)) {
@@ -5023,8 +4990,16 @@ obj_cached:
 	    tmpset->nodeNr = 0;
 	    memset(obj, 0, sizeof(xmlXPathObject));
 	    obj->nodesetval = tmpset;
-	} else
+	} else if (obj->stringval != NULL) {
+	    xmlChar *stringval = obj->stringval;
+	    int stringmax = obj->index;
+
 	    memset(obj, 0, sizeof(xmlXPathObject));
+	    obj->stringval = stringval;
+	    obj->index = stringmax;
+	} else {
+	    memset(obj, 0, sizeof(xmlXPathObject));
+	}
 
 	return;
 
@@ -5032,6 +5007,7 @@ free_obj:
 	/*
 	* Cache is full; free the object.
 	*/
+	xmlFree(obj->stringval);
 	if (obj->nodesetval != NULL)
 	    xmlXPathFreeNodeSet(obj->nodesetval);
 	xmlFree(obj);
@@ -8340,6 +8316,7 @@ void
 xmlXPathConcatFunction(xmlXPathParserContextPtr ctxt, int nargs) {
     xmlXPathObjectPtr cur, newobj;
     xmlChar *tmp;
+    int stringmax;
 
     if (ctxt == NULL) return;
     if (nargs < 2) {
@@ -8363,8 +8340,11 @@ xmlXPathConcatFunction(xmlXPathParserContextPtr ctxt, int nargs) {
 	    XP_ERROR(XPATH_INVALID_TYPE);
 	}
 	tmp = xmlStrcat(newobj->stringval, cur->stringval);
+	stringmax = cur->index;
 	newobj->stringval = cur->stringval;
+	newobj->index = stringmax;
 	cur->stringval = tmp;
+	cur->index = xmlStrlen(tmp) + 1;
 	xmlXPathReleaseObject(ctxt->context, newobj);
 	nargs--;
     }

--- a/libs/xml2/xpath.c
+++ b/libs/xml2/xpath.c
@@ -8317,7 +8317,6 @@ void
 xmlXPathConcatFunction(xmlXPathParserContextPtr ctxt, int nargs) {
     xmlXPathObjectPtr cur, newobj;
     xmlChar *tmp;
-    int stringmax;
 
     if (ctxt == NULL) return;
     if (nargs < 2) {
@@ -8340,12 +8339,42 @@ xmlXPathConcatFunction(xmlXPathParserContextPtr ctxt, int nargs) {
 	    xmlXPathReleaseObject(ctxt->context, cur);
 	    XP_ERROR(XPATH_INVALID_TYPE);
 	}
-	tmp = xmlStrcat(newobj->stringval, cur->stringval);
-	stringmax = cur->index2;
-	newobj->stringval = cur->stringval;
-	newobj->index2 = stringmax;
-	cur->stringval = tmp;
-	cur->index2 = xmlStrlen(tmp) + 1;
+	{
+	    int cur_len = xmlStrlen(cur->stringval);
+	    int left_len = xmlStrlen(newobj->stringval);
+	    int capacity = cur->index2;
+	    int needed;
+
+	    if ((cur_len < 0) || (left_len < 0) ||
+		(cur_len > INT_MAX - left_len - 1)) {
+		xmlXPathReleaseObject(ctxt->context, newobj);
+		xmlXPathReleaseObject(ctxt->context, cur);
+		XP_ERROR(XPATH_MEMORY_ERROR);
+	    }
+	    needed = left_len + cur_len + 1;
+	    if (capacity < needed) {
+		if (capacity <= 0)
+		    capacity = cur_len + 1;
+		while (capacity < needed) {
+		    if (capacity > INT_MAX / 2) {
+			capacity = needed;
+			break;
+		    }
+		    capacity *= 2;
+		}
+		tmp = xmlRealloc(cur->stringval, capacity);
+		if (tmp == NULL) {
+		    xmlXPathReleaseObject(ctxt->context, newobj);
+		    xmlXPathReleaseObject(ctxt->context, cur);
+		    xmlXPathPErrMemory(ctxt, NULL);
+		    return;
+		}
+		cur->stringval = tmp;
+		cur->index2 = capacity;
+	    }
+	    memmove(cur->stringval + left_len, cur->stringval, cur_len + 1);
+	    memcpy(cur->stringval, newobj->stringval, left_len);
+	}
 	xmlXPathReleaseObject(ctxt->context, newobj);
 	nargs--;
     }

--- a/libs/xslt/libxslt/preproc.c
+++ b/libs/xslt/libxslt/preproc.c
@@ -852,6 +852,20 @@ xsltTextComp(xsltStylesheetPtr style, xmlNodePtr inst) {
 }
 #endif /* else of XSLT_REFACTORED */
 
+static void
+xsltCompileInstructionAttr(xsltStylesheetPtr style, xmlNodePtr inst,
+                           const xmlChar *name)
+{
+    xmlAttrPtr attr;
+
+    for (attr = inst->properties; attr != NULL; attr = attr->next) {
+        if ((attr->ns == NULL) && xmlStrEqual(attr->name, name)) {
+            xsltCompileAttr(style, attr);
+            return;
+        }
+    }
+}
+
 /**
  * xsltElementComp:
  * @style: an XSLT compiled stylesheet
@@ -892,9 +906,6 @@ xsltElementComp(xsltStylesheetPtr style, xmlNodePtr inst) {
     /*
     * Attribute "name".
     */
-    /*
-    * TODO: Precompile the AVT. See bug #344894.
-    */
     comp->name = xsltEvalStaticAttrValueTemplate(style, inst,
 	(const xmlChar *)"name", NULL, &comp->has_name);
     if (! comp->has_name) {
@@ -903,14 +914,15 @@ xsltElementComp(xsltStylesheetPtr style, xmlNodePtr inst) {
 	style->errors++;
 	goto error;
     }
+    if (comp->name == NULL)
+        xsltCompileInstructionAttr(style, inst, BAD_CAST "name");
     /*
     * Attribute "namespace".
     */
-    /*
-    * TODO: Precompile the AVT. See bug #344894.
-    */
     comp->ns = xsltEvalStaticAttrValueTemplate(style, inst,
 	(const xmlChar *)"namespace", NULL, &comp->has_ns);
+    if ((comp->ns == NULL) && comp->has_ns)
+        xsltCompileInstructionAttr(style, inst, BAD_CAST "namespace");
 
     if (comp->name != NULL) {
 	if (xmlValidateQName(comp->name, 0)) {
@@ -1012,9 +1024,6 @@ xsltAttributeComp(xsltStylesheetPtr style, xmlNodePtr inst) {
     /*
     * Attribute "name".
     */
-    /*
-    * TODO: Precompile the AVT. See bug #344894.
-    */
     comp->name = xsltEvalStaticAttrValueTemplate(style, inst,
 				 (const xmlChar *)"name",
 				 NULL, &comp->has_name);
@@ -1024,15 +1033,16 @@ xsltAttributeComp(xsltStylesheetPtr style, xmlNodePtr inst) {
 	style->errors++;
 	return;
     }
+    if (comp->name == NULL)
+        xsltCompileInstructionAttr(style, inst, BAD_CAST "name");
     /*
     * Attribute "namespace".
-    */
-    /*
-    * TODO: Precompile the AVT. See bug #344894.
     */
     comp->ns = xsltEvalStaticAttrValueTemplate(style, inst,
 	(const xmlChar *)"namespace",
 	NULL, &comp->has_ns);
+    if ((comp->ns == NULL) && comp->has_ns)
+        xsltCompileInstructionAttr(style, inst, BAD_CAST "namespace");
 
     if (comp->name != NULL) {
 	if (xmlValidateQName(comp->name, 0)) {

--- a/libs/xslt/libxslt/templates.c
+++ b/libs/xslt/libxslt/templates.c
@@ -394,6 +394,28 @@ xsltAttrTemplateValueProcess(xsltTransformContextPtr ctxt, const xmlChar *str) {
     return(xsltAttrTemplateValueProcessNode(ctxt, str, NULL));
 }
 
+static xmlAttrPtr
+xsltGetNsPropNode(xmlNodePtr node, const xmlChar *name,
+                  const xmlChar *nameSpace)
+{
+    xmlAttrPtr prop;
+
+    if ((node == NULL) || (node->type != XML_ELEMENT_NODE))
+        return(NULL);
+
+    for (prop = node->properties; prop != NULL; prop = prop->next) {
+        if (!xmlStrEqual(prop->name, name))
+            continue;
+        if (nameSpace == NULL)
+            return(prop);
+        if (((prop->ns == NULL) && (node->ns != NULL) &&
+             xmlStrEqual(node->ns->href, nameSpace)) ||
+            ((prop->ns != NULL) && xmlStrEqual(prop->ns->href, nameSpace)))
+            return(prop);
+    }
+    return(NULL);
+}
+
 /**
  * xsltEvalAttrValueTemplate:
  * @ctxt:  the XSLT transformation context
@@ -413,12 +435,23 @@ xmlChar *
 xsltEvalAttrValueTemplate(xsltTransformContextPtr ctxt, xmlNodePtr inst,
 	                  const xmlChar *name, const xmlChar *ns)
 {
+    xmlAttrPtr attr;
     xmlChar *ret;
     xmlChar *expr;
 
     if ((ctxt == NULL) || (inst == NULL) || (name == NULL) ||
         (inst->type != XML_ELEMENT_NODE))
 	return(NULL);
+
+    attr = xsltGetNsPropNode(inst, name, ns);
+    if ((attr != NULL) && (attr->psvi != NULL)) {
+#ifdef XSLT_REFACTORED
+        if (attr->psvi != xsltXSLTAttrMarker)
+            return(xsltEvalAVT(ctxt, attr->psvi, inst));
+#else
+        return(xsltEvalAVT(ctxt, attr->psvi, inst));
+#endif
+    }
 
     expr = xsltGetNsProp(inst, name, ns);
     if (expr == NULL)

--- a/libs/xslt/libxslt/templates.c
+++ b/libs/xslt/libxslt/templates.c
@@ -21,6 +21,7 @@
 #include <libxml/dict.h>
 #include <libxml/xpathInternals.h>
 #include <libxml/parserInternals.h>
+#include "private/xpath.h"
 #include "xslt.h"
 #include "xsltInternals.h"
 #include "xsltutils.h"

--- a/libs/xslt/libxslt/templates.c
+++ b/libs/xslt/libxslt/templates.c
@@ -85,7 +85,7 @@ xsltEvalXPathPredicate(xsltTransformContextPtr ctxt, xmlXPathCompExprPtr comp,
 
     if (res != NULL) {
 	ret = xmlXPathEvalPredicate(ctxt->xpathCtxt, res);
-	xmlXPathFreeObject(res);
+	xmlXPathReleaseObject(ctxt->xpathCtxt, res);
 #ifdef WITH_XSLT_DEBUG_TEMPLATES
 	XSLT_TRACE(ctxt,XSLT_TRACE_TEMPLATES,xsltGenericDebug(xsltGenericDebugContext,
 	     "xsltEvalXPathPredicate: returns %d\n", ret));
@@ -161,7 +161,7 @@ xsltEvalXPathStringNs(xsltTransformContextPtr ctxt, xmlXPathCompExprPtr comp,
 	    xsltTransformError(ctxt, NULL, NULL,
 		 "xpath : string() function didn't return a String\n");
 	}
-	xmlXPathFreeObject(res);
+	xmlXPathReleaseObject(ctxt->xpathCtxt, res);
     } else {
 	ctxt->state = XSLT_STATE_STOPPED;
     }

--- a/libs/xslt/libxslt/transform.c
+++ b/libs/xslt/libxslt/transform.c
@@ -2300,6 +2300,22 @@ xsltReleaseLocalRVTs(xsltTransformContextPtr ctxt, xmlDocPtr base)
     } while (cur != base);
 }
 
+#ifndef XSLT_REFACTORED
+static int
+xsltIsCompiledInstruction(xmlNodePtr node, xsltStyleType type)
+{
+    xsltStylePreCompPtr info;
+
+    if ((node == NULL) || (node->type != XML_ELEMENT_NODE) ||
+        (node->psvi == NULL) || (node->psvi == xsltExtMarker))
+        return(0);
+
+    info = (xsltStylePreCompPtr) node->psvi;
+    return((info->inst == node) && (info->type != XSLT_FUNC_EXTENSION) &&
+        ((type == 0) || (info->type == type)));
+}
+#endif
+
 /**
  * xsltApplySequenceConstructor:
  * @ctxt:  a XSLT process context
@@ -2730,7 +2746,8 @@ xsltApplySequenceConstructor(xsltTransformContextPtr ctxt,
 
 #else /* XSLT_REFACTORED */
 
-        if (IS_XSLT_ELEM(cur)) {
+        if (xsltIsCompiledInstruction(cur, 0) ||
+            IS_XSLT_ELEM(cur)) {
             /*
              * This is an XSLT node
              */
@@ -5158,7 +5175,9 @@ xsltChoose(xsltTransformContextPtr ctxt, xmlNodePtr contextNode,
     * We don't check the content model during transformation.
     */
 #else
-    if ((! IS_XSLT_ELEM(cur)) || (! IS_XSLT_NAME(cur, "when"))) {
+    if ((! xsltIsCompiledInstruction(cur, XSLT_FUNC_WHEN)) &&
+        ((! IS_XSLT_ELEM(cur)) ||
+         (! IS_XSLT_NAME(cur, "when")))) {
 	xsltTransformError(ctxt, NULL, inst,
 	     "xsl:choose: xsl:when expected first\n");
 	return;
@@ -5177,7 +5196,8 @@ xsltChoose(xsltTransformContextPtr ctxt, xmlNodePtr contextNode,
 	/*
 	* Process xsl:when ---------------------------------------------------
 	*/
-	while (IS_XSLT_ELEM(cur) && IS_XSLT_NAME(cur, "when")) {
+	while (xsltIsCompiledInstruction(cur, XSLT_FUNC_WHEN) ||
+	       (IS_XSLT_ELEM(cur) && IS_XSLT_NAME(cur, "when"))) {
 	    wcomp = cur->psvi;
 
 	    if ((wcomp == NULL) || (wcomp->test == NULL) ||

--- a/libs/xslt/libxslt/transform.c
+++ b/libs/xslt/libxslt/transform.c
@@ -4079,7 +4079,7 @@ xsltElement(xsltTransformContextPtr ctxt, xmlNodePtr node,
 #else
     xsltStylePreCompPtr comp = (xsltStylePreCompPtr) castedComp;
 #endif
-    xmlChar *prop = NULL;
+    xmlChar *prop = NULL, *tmpNsName = NULL;
     const xmlChar *name, *prefix = NULL, *nsName = NULL;
     xmlNodePtr copy;
     xmlNodePtr oldInsert;
@@ -4160,7 +4160,6 @@ xsltElement(xsltTransformContextPtr ctxt, xmlNodePtr node,
 	    if (comp->ns[0] != 0)
 		nsName = comp->ns;
 	} else {
-	    xmlChar *tmpNsName;
 	    /*
 	    * Eval the AVT.
 	    */
@@ -4173,8 +4172,7 @@ xsltElement(xsltTransformContextPtr ctxt, xmlNodePtr node,
 	    *  attribute has a null namespace URI."
 	    */
 	    if ((tmpNsName != NULL) && (tmpNsName[0] != 0))
-		nsName = xmlDictLookup(ctxt->dict, BAD_CAST tmpNsName, -1);
-	    xmlFree(tmpNsName);
+		nsName = tmpNsName;
 	}
 
         if (xmlStrEqual(nsName, BAD_CAST "http://www.w3.org/2000/xmlns/")) {
@@ -4237,6 +4235,8 @@ xsltElement(xsltTransformContextPtr ctxt, xmlNodePtr node,
 	*/
 	xsltGetSpecialNamespace(ctxt, inst, NULL, NULL, copy);
     }
+    xmlFree(tmpNsName);
+    tmpNsName = NULL;
 
     ctxt->insert = copy;
 
@@ -4265,6 +4265,7 @@ xsltElement(xsltTransformContextPtr ctxt, xmlNodePtr node,
 	    NULL);
 
 error:
+    xmlFree(tmpNsName);
     ctxt->insert = oldInsert;
     return;
 }

--- a/libs/xslt/libxslt/variables.c
+++ b/libs/xslt/libxslt/variables.c
@@ -23,6 +23,7 @@
 #include <libxml/xpathInternals.h>
 #include <libxml/parserInternals.h>
 #include <libxml/dict.h>
+#include "private/xpath.h"
 #include "xslt.h"
 #include "xsltInternals.h"
 #include "xsltutils.h"

--- a/libs/xslt/libxslt/variables.c
+++ b/libs/xslt/libxslt/variables.c
@@ -2310,8 +2310,10 @@ xsltXPathVariableLookup(void *ctxt, const xmlChar *name,
 	{
 	    const xmlChar *tmpName = name, *tmpNsName = ns_uri;
 
-	    name = xmlDictLookup(tctxt->dict, name, -1);
-	    if (ns_uri)
+	    if (xmlDictOwns(tctxt->dict, name) != 1)
+		name = xmlDictLookup(tctxt->dict, name, -1);
+	    if ((ns_uri != NULL) &&
+		(xmlDictOwns(tctxt->dict, ns_uri) != 1))
 		ns_uri = xmlDictLookup(tctxt->dict, ns_uri, -1);
 	    if ((tmpName != name) || (tmpNsName != ns_uri)) {
 		for (i = tctxt->varsNr; i > tctxt->varsBase; i--) {

--- a/libs/xslt/libxslt/variables.c
+++ b/libs/xslt/libxslt/variables.c
@@ -647,7 +647,8 @@ xsltStackLookup(xsltTransformContextPtr ctxt, const xmlChar *name,
     int i;
     xsltStackElemPtr cur;
 
-    if ((ctxt == NULL) || (name == NULL) || (ctxt->varsNr == 0))
+    if ((ctxt == NULL) || (name == NULL)
+            || (ctxt->varsNr <= ctxt->varsBase))
 	return(NULL);
 
     /*
@@ -1928,7 +1929,7 @@ xsltGlobalVariableLookup(xsltTransformContextPtr ctxt, const xmlChar *name,
 	ret = xsltEvalGlobalVariable(elem, ctxt);
     } else
 	ret = elem->value;
-    return(xmlXPathObjectCopy(ret));
+    return(xmlXPathCacheObjectCopy(ctxt->xpathCtxt, ret));
 }
 
 /**
@@ -1963,7 +1964,7 @@ xsltVariableLookup(xsltTransformContextPtr ctxt, const xmlChar *name,
 	elem->computed = 1;
     }
     if (elem->value != NULL)
-	return(xmlXPathObjectCopy(elem->value));
+	return(xmlXPathCacheObjectCopy(ctxt->xpathCtxt, elem->value));
 #ifdef WITH_XSLT_DEBUG_VARIABLE
     XSLT_TRACE(ctxt,XSLT_TRACE_VARIABLES,xsltGenericDebug(xsltGenericDebugContext,
 		     "variable not found %s\n", name));
@@ -2288,7 +2289,7 @@ xsltXPathVariableLookup(void *ctxt, const xmlChar *name,
     * First lookup expects the variable name and URI to
     * come from the disctionnary and hence pointer comparison.
     */
-    if (tctxt->varsNr != 0) {
+    if (tctxt->varsNr > tctxt->varsBase) {
 	int i;
 	xsltStackElemPtr variable = NULL, cur;
 
@@ -2336,7 +2337,7 @@ local_variable_found:
 		variable->computed = 1;
 	    }
 	    if (variable->value != NULL) {
-		valueObj = xmlXPathObjectCopy(variable->value);
+		valueObj = xmlXPathCacheObjectCopy(tctxt->xpathCtxt, variable->value);
 	    }
 	    return(valueObj);
 	}

--- a/libs/xslt/libxslt/xsltutils.c
+++ b/libs/xslt/libxslt/xsltutils.c
@@ -1119,6 +1119,7 @@ xsltComputeSortResultInternal(xsltTransformContextPtr ctxt, xmlNodePtr sort,
                                 "xsltComputeSortResult: sort key is null\n");
                         } else {
                             res->stringval = sortKey;
+                            res->index2 = 0;
                             xmlFree(str);
                         }
 		    }


### PR DESCRIPTION
## Summary

- precompile dynamic `name` and `namespace` attribute value templates for `xsl:element` and `xsl:attribute`
- reuse libxslt's stylesheet-owned compiled XPath representation instead of recompiling expressions for every source node
- reuse bounded XPath evaluation contexts, value stacks, result objects, and short string buffers
- use validated compiled-instruction metadata before repeating XSLT namespace and local-name comparisons
- skip local-variable lookup when the local scope is empty
- avoid hashing variable names that are already owned by the transform dictionary
- keep dynamic `xsl:element` namespace values alive through namespace creation instead of interning a transient copy
- grow the retained XPath string buffer geometrically while evaluating multi-argument `concat()`
- add public-API regression coverage for repeated dynamic element and attribute transformations

## Performance evidence

Two readiness-bounded LBR profiles per side measured the AVT precompile:

| Two-run mean | Before | After | Change |
|---|---:|---:|---:|
| Click-to-Run weighted cycles | 7.124B | 5.578B | -21.70% |
| `xsltApplySequenceConstructor` cycles | 3.570B | 2.075B | -41.87% |
| Heap/allocation leaf cycles | 2.679B | 1.808B | -32.51% |
| Profiled readiness window | 17.870 s | 16.651 s | -6.82% |

`xmlXPathCtxtCompile` and `xsltAttrTemplateValueProcessNode` disappeared from both candidate profiles. Required XPath evaluation remains under `xsltEvalAVT`.

For the later runtime changes:

- a repeated-XPath microbenchmark improved from a 173.405 ms median to 169.812 ms, about 2.1%
- allocation calls fell from 1,000,099 to 400,099; the current short-string pool trades part of that saving for more `realloc` calls
- the compiled-instruction dispatch removed about 42.1M cycles of repeated sequence/choose classification, 0.82% of the reference Click-to-Run cycles
- the empty-local-scope guard removed a sampled 10.224M-cycle dictionary lookup path; `xmlDictHashName` fell from 96.682M to 59.839M inclusive cycles in the next profile
- the dictionary-ownership guard removed the remaining variable-lookup hash path: 42.027M sampled cycles before, zero after; the only remaining `xmlDictHashName` samples came from dynamic `xsl:element` namespaces
- across two follow-up profiles, Click-to-Run weighted cycles averaged 4.400B versus 4.521B in the immediately preceding profile (-2.67%); readiness wall time remained noisy and regressed overall, so the eliminated call path is the stronger evidence
- retaining the evaluated namespace value reduced `xmlDictHashName` from a 49.852M-cycle two-profile mean to 19.372M cycles; the remaining path interns dynamic element names, whose lifetime must match the result document
- total Click-to-Run cycles were effectively unchanged for that last step (4.400B before and 4.400B after), so it should be treated as a small call-path cleanup of about 0.7%, not a startup-time claim
- geometric concatenation removed the 75.775M-cycle `xmlStrncat` path and reduced `xmlXPathConcatFunction` from 119.123M cycles to a 63.483M two-profile mean (-46.7%); total Click-to-Run cycles did not improve reliably in those samples

The removed call paths are the primary evidence. Whole-startup time and total cycles vary between runs, so these percentages should not be added together.

### Combined end-to-end result with PR 71

Three clean prefix-matched pairs measured this PR together with the companion MSXML parser and buffering changes in [PR 71](https://github.com/ttv20/wine4office/pull/71):

| Metric | Baseline | Combined candidate | Change |
|---|---:|---:|---:|
| Useful-ready | 17.678 s | 12.431 s | -5.247 s (-29.7%) |
| Office launch to window | 15.845 s | 10.665 s | -5.180 s (-32.7%) |
| Peak RSS | 886.3 MiB | 853.0 MiB | -33.3 MiB (-3.8%) |
| Peak PSS | 650.9 MiB | 610.7 MiB | -40.2 MiB (-6.2%) |
| Peak private | 566.3 MiB | 526.0 MiB | -40.3 MiB (-7.1%) |
| OfficeClickToRun CPU to window | 6.923 s | 2.273 s | -4.650 s (-67.2%) |

The runner synchronizes the restored prefix's `.update-timestamp` with the selected `wine.inf`, rejects any run that invokes `InstallHinfSection`, and compares absolute monotonic timestamps from Office launch. This corrected two earlier measurement errors: a baseline-only prefix upgrade and a probe-relative clock that omitted about 2.1 seconds. The result measures both PRs together and is not an attribution to this PR alone. It does not include the later experimental wineserver PE-backing cache.

## Validation

- the exact PR branch built `msxml3.dll` and `msxml3_test.exe` independently for x86-64 and i386
- the `domdoc` suite passed on both architectures and exercises the XSLT path through public MSXML interfaces
- the dynamic XSLT test covers `name` and `namespace` AVTs on both `xsl:element` and `xsl:attribute`, including repeated use of one compiled instruction
- the test parses the result and checks local names, namespace URIs, and values instead of relying on serializer formatting
- the equivalent transformation passed with native MSXML 3 on the dedicated Windows endpoint
- the combined research runner also passed `saxreader`, `schema`, `xmldoc`, and `xmlparser` on x86-64 and i386 and launched Excel to useful UI
- after the dictionary and transient-namespace changes, all five MSXML suites (`domdoc`, `saxreader`, `schema`, `xmldoc`, and `xmlparser`) passed serially on both x86-64 and i386, and Excel again reached useful UI
- after the concat change, the five suites passed again on both architectures; the standalone 100,000-iteration XPath test passed concat, cache-toggle, and object-copy stress checks in five runs

### Review follow-up, 2026-09-06

- Stop dependent DOM calls after a failed result load, element lookup, or attribute lookup, including `S_FALSE`; release every acquired interface and string through cleanup.
- Initialize each repeated transform result and compare it only after success.
- Updated the branch with `origin/main` at `26cb4e6206ea` and added a changelog entry.
- Commit `2ecbc612fe5`: focused libxml2/libxslt, MSXML DLL and test builds passed for x86-64 and i386 with no compiler warnings. The `domdoc` suite passed serially on both architectures: 43,591 checks, 253 expected todo results, zero failures and zero skips per run.

## Risk notes

- the XPath cache is owned by the existing transform context; parser-context reuse is one-deep and retains only stacks of at most 40 entries
- the separate short-string pool is capped at 16 buffers of at most 1,024 bytes
- cached string capacity is kept in the secondary XPath index field, separate from the primary index used by XSLT sorting; generic object copies and sort-key replacement clear that cache-only metadata
- compiled dispatch accepts metadata only when it points back to the current instruction, has the expected type, and is not an extension marker; all other cases retain the existing checks
- DTD-provided attributes and instructions without compiled AVT metadata retain the existing runtime path
- dictionary ownership is checked before skipping interning; names from external dictionaries still take the original lookup and second-scan path
- the transient namespace string is freed only after namespace search/creation has duplicated or reused it; all error paths retain ownership cleanup
- concat growth checks integer overflow, reports allocation failure through the XPath context, and retains only buffers within the existing 1,024-byte cache limit

## Summary by Sourcery

Reduce repeated XSLT and XPath processing overhead during Office startup while adding regression coverage for dynamic transformations and failure handling.

Bug Fixes:
- Prevent failed XML transformation checks from crashing the test suite.

Enhancements:
- Speed up repeated XSLT and XPath evaluation during Office startup by reducing recompilation, allocations, variable-lookup overhead, and repeated instruction classification.
- Improve XPath object, evaluation-context, string-buffer, and dynamic namespace reuse while preserving bounded caching and existing fallback behavior.

Tests:
- Add MSXML public-API regression coverage for dynamic XSLT element and attribute names, namespaces, transformation failures, and repeated XPath evaluation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance Improvements**
  - Improved performance for repeated XSLT and XPath evaluations during Office startup.
  - Reduced overhead when reusing XPath expressions, values, and string results.

- **Bug Fixes**
  - Improved support for dynamically generated XSLT element and attribute names, including namespaces.
  - Improved reliability for repeated transformations involving variables, nested functions, and sorting.
  - Added handling for compiled XSLT instructions and dynamic attribute-value templates.
  - Failed XML transformation checks are now reported without crashing the test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->