### PR TITLE
dwrite: Reuse consecutive font family lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Reduce CPU work while building DirectWrite font collections.
 - Speed up small Office gallery images rendered through Direct2D.
 - Improve antialiasing quality and rendering performance while reducing GPU memory use for complex Direct2D geometry with analytic coverage rendering.
 - Reduce Word CPU use by coalescing Office timers that allow delayed delivery.

--- a/dlls/dwrite/font.c
+++ b/dlls/dwrite/font.c
@@ -4768,7 +4768,7 @@ static HRESULT collection_add_font_entry(struct dwrite_fontcollection *collectio
     }
 
     /* Font set faces from one family are normally consecutive. */
-    if (recent->index != ~0u && !wcsicmp(recent->name, familyW))
+    if (familyW[0] && recent->index != ~0u && !wcsicmp(recent->name, familyW))
         index = recent->index;
     else
         index = collection_find_family(collection, familyW);
@@ -4794,12 +4794,14 @@ static HRESULT collection_add_font_entry(struct dwrite_fontcollection *collectio
 
     if (FAILED(hr))
         release_font_data(font_data);
-    else
+    else if (familyW[0])
     {
         if (index == ~0u) index = collection->count - 1;
         lstrcpynW(recent->name, familyW, ARRAY_SIZE(recent->name));
         recent->index = index;
     }
+    else
+        recent->index = ~0u;
 
     return hr;
 }

--- a/dlls/dwrite/font.c
+++ b/dlls/dwrite/font.c
@@ -4740,7 +4740,14 @@ HRESULT create_font_collection(IDWriteFactory7 *factory, IDWriteFontFileEnumerat
     return hr;
 }
 
-static HRESULT collection_add_font_entry(struct dwrite_fontcollection *collection, const struct fontface_desc *desc)
+struct recent_font_family
+{
+    WCHAR name[255];
+    UINT32 index;
+};
+
+static HRESULT collection_add_font_entry(struct dwrite_fontcollection *collection, const struct fontface_desc *desc,
+        struct recent_font_family *recent)
 {
     struct dwrite_font_data *font_data;
     WCHAR familyW[255];
@@ -4760,7 +4767,11 @@ static HRESULT collection_add_font_entry(struct dwrite_fontcollection *collectio
         return S_OK;
     }
 
-    index = collection_find_family(collection, familyW);
+    /* Font set faces from one family are normally consecutive. */
+    if (recent->index != ~0u && !wcsicmp(recent->name, familyW))
+        index = recent->index;
+    else
+        index = collection_find_family(collection, familyW);
     if (index != ~0u)
         hr = fontfamily_add_font(collection->family_data[index], font_data);
     else
@@ -4783,6 +4794,12 @@ static HRESULT collection_add_font_entry(struct dwrite_fontcollection *collectio
 
     if (FAILED(hr))
         release_font_data(font_data);
+    else
+    {
+        if (index == ~0u) index = collection->count - 1;
+        lstrcpynW(recent->name, familyW, ARRAY_SIZE(recent->name));
+        recent->index = index;
+    }
 
     return hr;
 }
@@ -4792,6 +4809,7 @@ HRESULT create_font_collection_from_set(IDWriteFactory7 *factory, IDWriteFontSet
 {
     struct dwrite_fontset *set = unsafe_impl_from_IDWriteFontSet(fontset);
     struct dwrite_fontcollection *collection;
+    struct recent_font_family recent = {.index = ~0u};
     HRESULT hr = S_OK;
     size_t i;
 
@@ -4831,7 +4849,7 @@ HRESULT create_font_collection_from_set(IDWriteFactory7 *factory, IDWriteFontSet
         desc.simulations = entry->simulations;
         desc.font_data = NULL;
 
-        if (FAILED(hr = collection_add_font_entry(collection, &desc)))
+        if (FAILED(hr = collection_add_font_entry(collection, &desc, &recent)))
             WARN("Failed to add font collection element, hr %#lx.\n", hr);
 
         IDWriteFontFileStream_Release(stream);

--- a/dlls/dwrite/tests/font.c
+++ b/dlls/dwrite/tests/font.c
@@ -557,6 +557,100 @@ static WCHAR *create_testfontfile(const WCHAR *filename)
     return pathW;
 }
 
+static WORD read_be_word(const BYTE *data)
+{
+    return (data[0] << 8) | data[1];
+}
+
+static DWORD read_be_dword(const BYTE *data)
+{
+    return ((DWORD)data[0] << 24) | ((DWORD)data[1] << 16) | ((DWORD)data[2] << 8) | data[3];
+}
+
+static void write_be_word(BYTE *data, WORD value)
+{
+    data[0] = value >> 8;
+    data[1] = value;
+}
+
+static BOOL make_testfont_localized_only(const WCHAR *path, WCHAR family_initial)
+{
+    DWORD size, read, written, table_offset = 0, table_size = 0;
+    BOOL family_changed = FALSE, language_changed = FALSE, ret = FALSE;
+    unsigned int table_count, name_count, string_offset, i;
+    BYTE *data = NULL, *name;
+    HANDLE file;
+
+    file = CreateFileW(path, GENERIC_READ | GENERIC_WRITE, 0, NULL, OPEN_EXISTING, 0, NULL);
+    if (file == INVALID_HANDLE_VALUE)
+        return FALSE;
+
+    size = GetFileSize(file, NULL);
+    if (size == INVALID_FILE_SIZE || size < 12 || !(data = malloc(size)))
+        goto done;
+    if (!ReadFile(file, data, size, &read, NULL) || read != size)
+        goto done;
+
+    table_count = read_be_word(data + 4);
+    if (table_count > (size - 12) / 16)
+        goto done;
+    for (i = 0; i < table_count; ++i)
+    {
+        BYTE *record = data + 12 + i * 16;
+
+        if (!memcmp(record, "name", 4))
+        {
+            table_offset = read_be_dword(record + 8);
+            table_size = read_be_dword(record + 12);
+            break;
+        }
+    }
+    if (!table_offset || table_offset > size || table_size > size - table_offset || table_size < 6)
+        goto done;
+
+    name = data + table_offset;
+    name_count = read_be_word(name + 2);
+    string_offset = read_be_word(name + 4);
+    if (name_count > (table_size - 6) / 12 || string_offset > table_size)
+        goto done;
+
+    for (i = 0; i < name_count; ++i)
+    {
+        BYTE *record = name + 6 + i * 12;
+        unsigned int length, offset, platform = read_be_word(record);
+
+        if (platform != 1 && platform != 3)
+            continue;
+
+        write_be_word(record + 4, platform == 3 ? 0x0411 : 11);
+        language_changed = TRUE;
+
+        if (read_be_word(record + 6) != 1)
+            continue;
+        length = read_be_word(record + 8);
+        offset = read_be_word(record + 10);
+        if (length < (platform == 3 ? 2 : 1) || offset > table_size - string_offset ||
+                length > table_size - string_offset - offset)
+            goto done;
+        if (platform == 3)
+            write_be_word(name + string_offset + offset, family_initial);
+        else
+            name[string_offset + offset] = family_initial;
+        family_changed = TRUE;
+    }
+
+    if (!family_changed || !language_changed || SetFilePointer(file, 0, NULL, FILE_BEGIN) == INVALID_SET_FILE_POINTER)
+        goto done;
+    if (!WriteFile(file, data, size, &written, NULL) || written != size)
+        goto done;
+    ret = TRUE;
+
+done:
+    free(data);
+    CloseHandle(file);
+    return ret;
+}
+
 #define DELETE_FONTFILE(filename) _delete_testfontfile(filename, __LINE__)
 static void _delete_testfontfile(const WCHAR *filename, int line)
 {
@@ -10724,6 +10818,71 @@ static void test_CreateFontCollectionFromFontSet(void)
     DELETE_FONTFILE(path);
 }
 
+static void test_localized_family_collection(void)
+{
+    static const WCHAR filenames[][32] = {L"wine_test_ja_a.ttf", L"wine_test_ja_b.ttf"};
+    IDWriteFontCollection1 *collection = NULL;
+    IDWriteFontSetBuilder1 *builder = NULL;
+    IDWriteFontFile *files[2] = {0};
+    WCHAR paths[2][MAX_PATH] = {{0}};
+    IDWriteFactory5 *factory;
+    IDWriteFontSet *fontset = NULL;
+    unsigned int count, i;
+    HRESULT hr;
+
+    if (!(factory = create_factory_iid(&IID_IDWriteFactory5)))
+    {
+        win_skip("CreateFontCollectionFromFontSet() is not available.\n");
+        return;
+    }
+
+    hr = IDWriteFactory5_CreateFontSetBuilder(factory, &builder);
+    ok(hr == S_OK, "Failed to create font set builder, hr %#lx.\n", hr);
+    if (FAILED(hr))
+        goto done;
+
+    for (i = 0; i < ARRAY_SIZE(files); ++i)
+    {
+        lstrcpyW(paths[i], create_testfontfile(filenames[i]));
+        if (!make_testfont_localized_only(paths[i], 'A' + i))
+        {
+            ok(0, "Failed to localize test font %u.\n", i);
+            goto done;
+        }
+        hr = IDWriteFactory5_CreateFontFileReference(factory, paths[i], NULL, &files[i]);
+        ok(hr == S_OK, "Failed to create font file %u, hr %#lx.\n", i, hr);
+        if (FAILED(hr))
+            goto done;
+        hr = IDWriteFontSetBuilder1_AddFontFile(builder, files[i]);
+        ok(hr == S_OK, "Failed to add font file %u, hr %#lx.\n", i, hr);
+        if (FAILED(hr))
+            goto done;
+    }
+
+    hr = IDWriteFontSetBuilder1_CreateFontSet(builder, &fontset);
+    ok(hr == S_OK, "Failed to create font set, hr %#lx.\n", hr);
+    if (FAILED(hr))
+        goto done;
+    hr = IDWriteFactory5_CreateFontCollectionFromFontSet(factory, fontset, &collection);
+    ok(hr == S_OK, "Failed to create font collection, hr %#lx.\n", hr);
+    if (FAILED(hr))
+        goto done;
+
+    count = IDWriteFontCollection1_GetFontFamilyCount(collection);
+    ok(count == 2, "Expected two localized-only families, got %u.\n", count);
+
+done:
+    if (collection) IDWriteFontCollection1_Release(collection);
+    if (fontset) IDWriteFontSet_Release(fontset);
+    for (i = 0; i < ARRAY_SIZE(files); ++i)
+    {
+        if (files[i]) IDWriteFontFile_Release(files[i]);
+        if (paths[i][0]) DELETE_FONTFILE(paths[i]);
+    }
+    if (builder) IDWriteFontSetBuilder1_Release(builder);
+    IDWriteFactory5_Release(factory);
+}
+
 static void test_GetMatchingFontsByLOGFONT(void)
 {
     IDWriteFontSet *systemset, *set;
@@ -10898,6 +11057,7 @@ START_TEST(font)
     test_family_font_set();
     test_system_font_set();
     test_CreateFontCollectionFromFontSet();
+    test_localized_family_collection();
     test_GetMatchingFontsByLOGFONT();
     test_font_download_queue();
 


### PR DESCRIPTION
## Summary

- remember the exact family index returned for the previous font-set face while building a DirectWrite collection
- reuse that index when the next face has the same case-insensitive family name
- keep the existing complete localized-family search for every different name

Office's system font set groups many consecutive faces by family. The previous code restarted a linear scan of all existing families and localized names for every face.

## Profile evidence

During Excel startup the system collection contained 968 faces in 381 families:

| Metric | Before | After | Change |
|---|---:|---:|---:|
| Full family searches | 968 | 450 | -53.5% |
| Family checks | 199,704 | 80,896 | -59.5% |
| Localized-name checks | 218,435 | 88,601 | -59.4% |
| `create_font_collection_from_set` | 263.7M cycles | 187.7M | -28.8% |
| `collection_find_family` | 192.4M cycles | 138.2M | -28.1% |

Three Office startup pairs did not show a reliable wall-time improvement. The paired median changed by +0.17 seconds within run-to-run noise, and Excel CPU to window fell by about 0.04 seconds at the sampler's resolution. This PR is therefore presented as a bounded CPU cleanup, not a startup-seconds claim.

## Correctness

- the shortcut is used only for an identical consecutive family name
- it reuses the exact index returned by the existing search or the family just appended
- different names still call `collection_find_family()`, preserving localized-name and collision behavior
- failed additions do not update the remembered family

## Validation

- based on `origin/main` at `a39f0ded6474876e2142d42a0a509818da918708`
- x86-64 and i386 `dwrite.dll` rebuilt warning-free
- `dwrite:font` passed serially on x86-64
- `dwrite:font` passed serially on i386
- Excel reached useful UI with DLLs built from this branch

## Scope

This PR contains no MSXML, libxml2, libxslt, or PE backing-cache changes.

## Summary by Sourcery

Optimize DirectWrite font collection construction by reusing consecutive family lookups.

Enhancements:
- Reduce CPU work when constructing DirectWrite font collections by reusing consecutive faces' family lookups while preserving localized-name handling for different families.

Tests:
- Add coverage for font collections containing families identified only through localized names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced CPU usage when constructing DirectWrite font collections.
  * Improved processing of consecutive font faces from the same family by reusing resolved family information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->