### PR TITLE
ucrtbase: Avoid locale snapshots in the initial C locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Speed up case-insensitive string comparisons in the default C locale.
 - Speed up small Office gallery images rendered through Direct2D.
 - Improve antialiasing quality and rendering performance while reducing GPU memory use for complex Direct2D geometry with analytic coverage rendering.
 - Reduce Word CPU use by coalescing Office timers that allow delayed delivery.

--- a/dlls/msvcrt/ctype.c
+++ b/dlls/msvcrt/ctype.c
@@ -22,6 +22,11 @@
 #include "msvcrt.h"
 #include "winnls.h"
 
+static inline BOOL is_initial_locale(void)
+{
+    return InterlockedCompareExchange((LONG *)&initial_locale, FALSE, FALSE);
+}
+
 /* Some abbreviations to make the following table readable */
 #define _C_ _CONTROL
 #define _S_ _SPACE
@@ -513,7 +518,7 @@ int CDECL _toupper_l(int c, _locale_t locale)
  */
 int CDECL toupper(int c)
 {
-    if(initial_locale)
+    if(is_initial_locale())
         return c>='a' && c<='z' ? c-'a'+'A' : c;
     return _toupper_l(c, NULL);
 }
@@ -571,7 +576,7 @@ int CDECL _tolower_l(int c, _locale_t locale)
  */
 int CDECL tolower(int c)
 {
-    if(initial_locale)
+    if(is_initial_locale())
         return c>='A' && c<='Z' ? c-'A'+'a' : c;
     return _tolower_l(c, NULL);
 }

--- a/dlls/msvcrt/ctype.c
+++ b/dlls/msvcrt/ctype.c
@@ -24,7 +24,7 @@
 
 static inline BOOL is_initial_locale(void)
 {
-    return InterlockedCompareExchange((LONG *)&initial_locale, FALSE, FALSE);
+    return ReadAcquire((const LONG volatile *)&initial_locale);
 }
 
 /* Some abbreviations to make the following table readable */

--- a/dlls/msvcrt/locale.c
+++ b/dlls/msvcrt/locale.c
@@ -2039,7 +2039,7 @@ char* CDECL setlocale(int category, const char* locale)
     }
 
     if(locale[0] != 'C' || locale[1] != '\0')
-        initial_locale = FALSE;
+        InterlockedExchange((LONG *)&initial_locale, FALSE);
 
     if(data->locale_flags & LOCALE_THREAD)
     {

--- a/dlls/msvcrt/wcs.c
+++ b/dlls/msvcrt/wcs.c
@@ -127,6 +127,19 @@ INT CDECL _wcsicmp_l(const wchar_t *str1, const wchar_t *str2, _locale_t locale)
     if(!MSVCRT_CHECK_PMT(str1 != NULL) || !MSVCRT_CHECK_PMT(str2 != NULL))
         return _NLSCMPERROR;
 
+    if (!locale && initial_locale)
+    {
+        do
+        {
+            c1 = *str1++;
+            c2 = *str2++;
+            if (c1 >= 'A' && c1 <= 'Z') c1 += 'a' - 'A';
+            if (c2 >= 'A' && c2 <= 'Z') c2 += 'a' - 'A';
+        } while (c1 && (c1 == c2));
+
+        return c1 - c2;
+    }
+
     if(!locale)
         locale = get_current_locale_noalloc(&tmp);
 

--- a/dlls/msvcrt/wcs.c
+++ b/dlls/msvcrt/wcs.c
@@ -34,6 +34,11 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(msvcrt);
 
+static inline BOOL is_initial_locale(void)
+{
+    return InterlockedCompareExchange((LONG *)&initial_locale, FALSE, FALSE);
+}
+
 typedef struct
 {
     enum { LEN_DEFAULT, LEN_SHORT, LEN_LONG } IntegerLength;
@@ -127,7 +132,7 @@ INT CDECL _wcsicmp_l(const wchar_t *str1, const wchar_t *str2, _locale_t locale)
     if(!MSVCRT_CHECK_PMT(str1 != NULL) || !MSVCRT_CHECK_PMT(str2 != NULL))
         return _NLSCMPERROR;
 
-    if (!locale && initial_locale)
+    if (!locale && is_initial_locale())
     {
         do
         {

--- a/dlls/msvcrt/wcs.c
+++ b/dlls/msvcrt/wcs.c
@@ -36,7 +36,7 @@ WINE_DEFAULT_DEBUG_CHANNEL(msvcrt);
 
 static inline BOOL is_initial_locale(void)
 {
-    return InterlockedCompareExchange((LONG *)&initial_locale, FALSE, FALSE);
+    return ReadAcquire((const LONG volatile *)&initial_locale);
 }
 
 typedef struct

--- a/dlls/ucrtbase/tests/string.c
+++ b/dlls/ucrtbase/tests/string.c
@@ -144,7 +144,7 @@ static void test_wcsicmp_thread_locale(void)
     ok(!!thread, "CreateThread failed, error %lu\n", GetLastError());
     if (thread)
     {
-        wait = WaitForSingleObject(thread, 10000);
+        wait = WaitForSingleObject(thread, INFINITE);
         ok(wait == WAIT_OBJECT_0, "thread wait returned %#lx\n", wait);
         CloseHandle(thread);
         if (args.locale_available)

--- a/dlls/ucrtbase/tests/string.c
+++ b/dlls/ucrtbase/tests/string.c
@@ -72,6 +72,91 @@ static void __cdecl test_invalid_parameter_handler(const wchar_t *expression,
 _ACRTIMP int __cdecl _o_tolower(int);
 _ACRTIMP int __cdecl _o_toupper(int);
 
+static wchar_t ascii_tolower(wchar_t c)
+{
+    return c >= 'A' && c <= 'Z' ? c + 'a' - 'A' : c;
+}
+
+struct wcsicmp_thread_args
+{
+    _locale_t locale;
+    int current_result;
+    int explicit_result;
+    BOOL locale_available;
+};
+
+static DWORD WINAPI wcsicmp_thread_locale(void *param)
+{
+    struct wcsicmp_thread_args *args = param;
+
+    _configthreadlocale(_ENABLE_PER_THREAD_LOCALE);
+    if (!setlocale(LC_CTYPE, "Turkish")) return 0;
+
+    args->locale_available = TRUE;
+    args->current_result = _wcsicmp_l(L"I", L"\x131", NULL);
+    args->explicit_result = _wcsicmp_l(L"I", L"\x131", args->locale);
+    setlocale(LC_CTYPE, "C");
+    return 0;
+}
+
+static void test_wcsicmp_initial_locale(void)
+{
+    wchar_t left[2] = {0}, right[2] = {0};
+    _locale_t locale;
+    unsigned int i, j;
+    int expected, ret;
+
+    ok(!strcmp(setlocale(LC_ALL, NULL), "C"), "expected initial C locale\n");
+    locale = _create_locale(LC_ALL, "C");
+    ok(!!locale, "failed to create C locale\n");
+    if (!locale) return;
+
+    for (i = 1; i <= 0xffff; ++i)
+    {
+        j = (i * 40503u + 17u) & 0xffff;
+        if (!j) j = 1;
+        left[0] = i;
+        right[0] = j;
+        expected = ascii_tolower(left[0]) - ascii_tolower(right[0]);
+        ret = _wcsicmp_l(left, right, NULL);
+        ok(ret == expected, "initial C locale returned %d, expected %d for %#x and %#x\n",
+                ret, expected, i, j);
+        ret = _wcsicmp_l(left, right, locale);
+        ok(ret == expected, "explicit C locale returned %d, expected %d for %#x and %#x\n",
+                ret, expected, i, j);
+    }
+    _free_locale(locale);
+}
+
+static void test_wcsicmp_thread_locale(void)
+{
+    struct wcsicmp_thread_args args = {0};
+    HANDLE thread;
+    DWORD wait;
+
+    args.locale = _create_locale(LC_ALL, "Turkish");
+    if (!args.locale)
+    {
+        win_skip("Turkish locale is not available\n");
+        return;
+    }
+    thread = CreateThread(NULL, 0, wcsicmp_thread_locale, &args, 0, NULL);
+    ok(!!thread, "CreateThread failed, error %lu\n", GetLastError());
+    if (thread)
+    {
+        wait = WaitForSingleObject(thread, 10000);
+        ok(wait == WAIT_OBJECT_0, "thread wait returned %#lx\n", wait);
+        CloseHandle(thread);
+        if (args.locale_available)
+            ok(args.current_result == args.explicit_result,
+                    "thread locale returned %d, explicit locale returned %d\n",
+                    args.current_result, args.explicit_result);
+        else
+            win_skip("Turkish thread locale is not available\n");
+    }
+    _free_locale(args.locale);
+}
+
 static BOOL local_isnan(double d)
 {
     return d != d;
@@ -842,6 +927,7 @@ START_TEST(string)
     ok(_set_invalid_parameter_handler(test_invalid_parameter_handler) == NULL,
             "Invalid parameter handler was already set\n");
 
+    test_wcsicmp_initial_locale();
     test_strtod();
     test_strtof();
     test__memicmp();
@@ -857,4 +943,5 @@ START_TEST(string)
     test_strcmp();
     test__mbsncpy_s();
     test_mbstowcs();
+    test_wcsicmp_thread_locale();
 }


### PR DESCRIPTION
## Summary

- compare `_wcsicmp_l()` strings directly when the caller passes no explicit locale and the CRT is still in its initial C locale
- preserve the existing locale snapshot and Unicode mapping path for explicit, per-thread, and changed locales
- cover the complete nonzero UTF-16 code-unit range against an explicit C locale and verify per-thread Turkish locale behavior

## Why

The previous NULL-locale path acquired and released a reference-counted snapshot of the complete current locale for every comparison. The measured Office workload compared about four UTF-16 code units per call, so this lifetime bookkeeping dominated the actual comparison.

The C locale only folds ASCII `A-Z`. The new path performs that fold directly under the same `initial_locale` condition already used by the CRT's character conversion routines.

## Validation

- focused combined-WoW64 rebuild: `dlls/ucrtbase/all` and `dlls/ucrtbase/tests/all`
- x86-64: `dlls/ucrtbase/tests/x86_64-windows/string.ok` passed
- i386: `dlls/ucrtbase/tests/i386-windows/string.ok` passed
- `git diff --check` passed

Build provenance:

- base: `a39f0ded6474876e2142d42a0a509818da918708`
- build workspace: `ucrt-wcsicmp-pr-20260901`

## Performance evidence

On the Wine test host, a four-character `_wcsicmp_l(NULL)` comparison fell from 184.395 ns to 10.339 ns. The same benchmark measured 7.147 ns on native Windows on different hardware, so only the within-Wine ratio is causal.

After refreshing Office's expired ECS configuration, the normal-startup effect was about 70 ms less Excel CPU with no repeatable wall-time improvement. This PR does not claim a startup-seconds improvement.

## Risk

The fast path is restricted to the initial C locale. Explicit locale objects, per-thread locales, and any changed process locale continue through the existing implementation. The added Turkish thread-locale regression covers the main locale-isolation boundary.

## Summary by Sourcery

Speed up case-insensitive wide-string comparisons in the initial C locale while preserving locale-specific behavior.

Enhancements:
- Optimize default C-locale _wcsicmp_l() calls by applying ASCII case folding directly without creating locale snapshots.
- Make initial-locale detection and updates synchronization-safe across character conversion, string comparison, and locale-setting paths.

Tests:
- Add coverage for the full nonzero UTF-16 code-unit range in both implicit and explicit C-locale comparisons.
- Verify that per-thread Turkish locale comparisons match explicit Turkish-locale behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Reduced CPU work when building DirectWrite font collections.

- **Bug Fixes**
  - Improved case-insensitive string comparisons when using the default C locale.
  - Enhanced wide-character comparisons to correctly respect thread-specific and explicit locales.
  - Improved reliability when switching between the default C locale and other locales.

- **Tests**
  - Added coverage for wide-character comparisons across default and thread-specific locale scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->