### PR TITLE
crypt32: fix Excel startup crash from CRYPT_RegOpenStore handle duplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix Excel startup crashes caused by certificate-store registry handling.
 - Speed up case-insensitive string comparisons in the default C locale.
 - Reduce CPU work while building DirectWrite font collections.
 - Reduce repeated directory scans during case-insensitive file lookup.

--- a/dlls/crypt32/regstore.c
+++ b/dlls/crypt32/regstore.c
@@ -17,8 +17,12 @@
  */
 #include <assert.h>
 #include <stdarg.h>
+#include <string.h>
+
+#include "ntstatus.h"
 #include "windef.h"
 #include "winbase.h"
+#include "winternl.h"
 #include "wincrypt.h"
 #include "winreg.h"
 #include "winuser.h"
@@ -515,6 +519,79 @@ static void *regProvFuncs[] = {
     CRYPT_RegControl,
 };
 
+/* Open our own copy of a registry key through the registry API, as the
+ * native provider does, so registry-layer hooks observe a balanced
+ * open/close pair for a real key path.  A DuplicateHandle copy would
+ * bypass those hooks: it is never seen as opened, yet it is closed with
+ * RegCloseKey.  The input key is not closed; the caller keeps ownership
+ * of it.  Returns ERROR_SUCCESS on success, otherwise a Win32 error code. */
+static LONG reg_open_key_copy( HKEY src, REGSAM access, HKEY *dst )
+{
+    static const WCHAR machine_path[] = L"\\REGISTRY\\Machine\\";
+    static const WCHAR user_path[] = L"\\REGISTRY\\User\\";
+    KEY_NAME_INFORMATION *info;
+    DWORD len = 256, needed;
+    NTSTATUS status;
+    HKEY root;
+    LPCWSTR subkey;
+    LPWSTR path;
+    DWORD count;
+
+    /* Predefined roots need no copy: opening them returns the same
+     * pseudo-handle, and closing them is a no-op. */
+    if (HandleToULong( src ) >= HandleToULong( HKEY_CLASSES_ROOT ) &&
+        HandleToULong( src ) <= HandleToULong( HKEY_DYN_DATA ))
+    {
+        *dst = src;
+        return ERROR_SUCCESS;
+    }
+
+    if (!(info = CryptMemAlloc( len ))) return ERROR_NOT_ENOUGH_MEMORY;
+    status = NtQueryKey( src, KeyNameInformation, info, len, &needed );
+    while (status == STATUS_BUFFER_OVERFLOW)
+    {
+        CryptMemFree( info );
+        len = needed;
+        if (!(info = CryptMemAlloc( len ))) return ERROR_NOT_ENOUGH_MEMORY;
+        status = NtQueryKey( src, KeyNameInformation, info, len, &needed );
+    }
+    if (status)
+    {
+        CryptMemFree( info );
+        return RtlNtStatusToDosError( status );
+    }
+    /* Reopen the key from its predefined root using its full path, so the
+     * open is indistinguishable from any other registry open. */
+    if (!wcsnicmp( info->Name, machine_path, ARRAY_SIZE( machine_path ) - 1 ))
+    {
+        root = HKEY_LOCAL_MACHINE;
+        subkey = info->Name + ARRAY_SIZE( machine_path ) - 1;
+    }
+    else if (!wcsnicmp( info->Name, user_path, ARRAY_SIZE( user_path ) - 1 ))
+    {
+        root = HKEY_USERS;
+        subkey = info->Name + ARRAY_SIZE( user_path ) - 1;
+    }
+    else
+    {
+        CryptMemFree( info );
+        return ERROR_INVALID_HANDLE;
+    }
+    /* The queried name is not null-terminated, copy it with a terminator. */
+    count = (info->Name + info->NameLength / sizeof(WCHAR)) - subkey;
+    if (!(path = CryptMemAlloc( (count + 1) * sizeof(WCHAR) )))
+    {
+        CryptMemFree( info );
+        return ERROR_NOT_ENOUGH_MEMORY;
+    }
+    memcpy( path, subkey, count * sizeof(WCHAR) );
+    path[count] = 0;
+    CryptMemFree( info );
+    status = RegOpenKeyExW( root, path, 0, access, dst );
+    CryptMemFree( path );
+    return status;
+}
+
 WINECRYPT_CERTSTORE *CRYPT_RegOpenStore(HCRYPTPROV hCryptProv, DWORD dwFlags,
  const void *pvPara)
 {
@@ -537,11 +614,11 @@ WINECRYPT_CERTSTORE *CRYPT_RegOpenStore(HCRYPTPROV hCryptProv, DWORD dwFlags,
     else
     {
         HKEY key;
+        REGSAM sam = dwFlags & CERT_STORE_READONLY_FLAG ? KEY_READ : KEY_ALL_ACCESS;
+        LONG rc;
 
-        if (DuplicateHandle(GetCurrentProcess(), (HANDLE)pvPara,
-         GetCurrentProcess(), (LPHANDLE)&key,
-         dwFlags & CERT_STORE_READONLY_FLAG ? KEY_READ : KEY_ALL_ACCESS,
-         TRUE, 0))
+        rc = reg_open_key_copy((HKEY)pvPara, sam, &key);
+        if (!rc)
         {
             WINECRYPT_CERTSTORE *memStore;
 
@@ -582,6 +659,8 @@ WINECRYPT_CERTSTORE *CRYPT_RegOpenStore(HCRYPTPROV hCryptProv, DWORD dwFlags,
                 }
             }
         }
+        else
+            SetLastError(rc);
     }
     TRACE("returning %p\n", store);
     return store;

--- a/dlls/crypt32/regstore.c
+++ b/dlls/crypt32/regstore.c
@@ -527,15 +527,17 @@ static void *regProvFuncs[] = {
  * of it.  Returns ERROR_SUCCESS on success, otherwise a Win32 error code. */
 static LONG reg_open_key_copy( HKEY src, REGSAM access, HKEY *dst )
 {
-    static const WCHAR machine_path[] = L"\\REGISTRY\\Machine\\";
-    static const WCHAR user_path[] = L"\\REGISTRY\\User\\";
+    static const WCHAR machine_path[] = L"\\REGISTRY\\Machine";
+    static const WCHAR user_path[] = L"\\REGISTRY\\User";
     KEY_NAME_INFORMATION *info;
     DWORD len = 256, needed;
     NTSTATUS status;
     HKEY root;
     LPCWSTR subkey;
     LPWSTR path;
-    DWORD count;
+    DWORD count, name_len, prefix_len;
+
+    *dst = NULL;
 
     /* Predefined roots need no copy: opening them returns the same
      * pseudo-handle, and closing them is a no-op. */
@@ -560,25 +562,39 @@ static LONG reg_open_key_copy( HKEY src, REGSAM access, HKEY *dst )
         CryptMemFree( info );
         return RtlNtStatusToDosError( status );
     }
-    /* Reopen the key from its predefined root using its full path, so the
-     * open is indistinguishable from any other registry open. */
-    if (!wcsnicmp( info->Name, machine_path, ARRAY_SIZE( machine_path ) - 1 ))
-    {
-        root = HKEY_LOCAL_MACHINE;
-        subkey = info->Name + ARRAY_SIZE( machine_path ) - 1;
-    }
-    else if (!wcsnicmp( info->Name, user_path, ARRAY_SIZE( user_path ) - 1 ))
-    {
-        root = HKEY_USERS;
-        subkey = info->Name + ARRAY_SIZE( user_path ) - 1;
-    }
-    else
+    if (info->NameLength % sizeof(WCHAR))
     {
         CryptMemFree( info );
         return ERROR_INVALID_HANDLE;
     }
+
+    /* Reopen the key from its predefined root using its full path, so the
+     * open is indistinguishable from any other registry open. */
+    name_len = info->NameLength / sizeof(WCHAR);
+    prefix_len = ARRAY_SIZE( machine_path ) - 1;
+    if (name_len >= prefix_len && !wcsnicmp( info->Name, machine_path, prefix_len ) &&
+        (name_len == prefix_len || info->Name[prefix_len] == '\\'))
+    {
+        root = HKEY_LOCAL_MACHINE;
+        subkey = info->Name + prefix_len + (name_len != prefix_len);
+    }
+    else
+    {
+        prefix_len = ARRAY_SIZE( user_path ) - 1;
+        if (name_len >= prefix_len && !wcsnicmp( info->Name, user_path, prefix_len ) &&
+            (name_len == prefix_len || info->Name[prefix_len] == '\\'))
+        {
+            root = HKEY_USERS;
+            subkey = info->Name + prefix_len + (name_len != prefix_len);
+        }
+        else
+        {
+            CryptMemFree( info );
+            return ERROR_INVALID_HANDLE;
+        }
+    }
     /* The queried name is not null-terminated, copy it with a terminator. */
-    count = (info->Name + info->NameLength / sizeof(WCHAR)) - subkey;
+    count = info->Name + name_len - subkey;
     if (!(path = CryptMemAlloc( (count + 1) * sizeof(WCHAR) )))
     {
         CryptMemFree( info );
@@ -587,7 +603,10 @@ static LONG reg_open_key_copy( HKEY src, REGSAM access, HKEY *dst )
     memcpy( path, subkey, count * sizeof(WCHAR) );
     path[count] = 0;
     CryptMemFree( info );
-    status = RegOpenKeyExW( root, path, 0, access, dst );
+    /* KeyNameInformation returns the physical path.  Force the 64-bit view
+     * so a 32-bit caller's default redirection does not reinterpret it;
+     * physical 32-bit paths already contain Wow6432Node. */
+    status = RegOpenKeyExW( root, path, 0, access | KEY_WOW64_64KEY, dst );
     CryptMemFree( path );
     return status;
 }
@@ -613,55 +632,88 @@ WINECRYPT_CERTSTORE *CRYPT_RegOpenStore(HCRYPTPROV hCryptProv, DWORD dwFlags,
     }
     else
     {
-        HKEY key;
+        HKEY key = NULL;
         REGSAM sam = dwFlags & CERT_STORE_READONLY_FLAG ? KEY_READ : KEY_ALL_ACCESS;
         LONG rc;
 
         rc = reg_open_key_copy((HKEY)pvPara, sam, &key);
         if (!rc)
         {
-            WINECRYPT_CERTSTORE *memStore;
+            WINECRYPT_CERTSTORE *memStore = NULL;
+            WINE_REGSTOREINFO *regInfo = NULL;
+            BOOL cs_initialized = FALSE;
+            DWORD err;
 
             memStore = CertOpenStore(CERT_STORE_PROV_MEMORY, 0, hCryptProv,
              CERT_STORE_CREATE_NEW_FLAG, NULL);
-            if (memStore)
+            if (!memStore)
             {
-                WINE_REGSTOREINFO *regInfo = CryptMemAlloc(
-                 sizeof(WINE_REGSTOREINFO));
-
-                if (regInfo)
-                {
-                    CERT_STORE_PROV_INFO provInfo = { 0 };
-
-                    regInfo->dwOpenFlags = dwFlags;
-                    regInfo->memStore = memStore;
-                    regInfo->key = key;
-                    InitializeCriticalSectionEx(&regInfo->cs, 0, RTL_CRITICAL_SECTION_FLAG_FORCE_DEBUG_INFO);
-                    regInfo->cs.DebugInfo->Spare[0] = (DWORD_PTR)(__FILE__ ": PWINE_REGSTOREINFO->cs");
-                    list_init(&regInfo->certsToDelete);
-                    list_init(&regInfo->crlsToDelete);
-                    list_init(&regInfo->ctlsToDelete);
-                    regInfo->key_modified_event = CreateEventW(NULL, FALSE, FALSE, NULL);
-                    if (RegNotifyChangeKeyValue(regInfo->key, TRUE, REG_NOTIFY_CHANGE_NAME | REG_NOTIFY_CHANGE_LAST_SET,
-                        regInfo->key_modified_event, TRUE))
-                        ERR("RegNotifyChangeKeyValue failed.\n");
-                    CRYPT_RegReadFromReg(regInfo->key, regInfo->memStore, CERT_STORE_ADD_ALWAYS);
-                    regInfo->dirty = FALSE;
-                    provInfo.cbSize = sizeof(provInfo);
-                    provInfo.cStoreProvFunc = ARRAY_SIZE(regProvFuncs);
-                    provInfo.rgpvStoreProvFunc = regProvFuncs;
-                    provInfo.hStoreProv = regInfo;
-                    store = CRYPT_ProvCreateStore(dwFlags, memStore, &provInfo);
-                    /* Reg store doesn't need crypto provider, so close it */
-                    if (hCryptProv &&
-                     !(dwFlags & CERT_STORE_NO_CRYPT_RELEASE_FLAG))
-                        CryptReleaseContext(hCryptProv, 0);
-                }
+                SetLastError(ERROR_NOT_ENOUGH_MEMORY);
+                goto failed;
             }
+
+            if (!(regInfo = CryptMemAlloc(sizeof(*regInfo))))
+            {
+                SetLastError(ERROR_NOT_ENOUGH_MEMORY);
+                goto failed;
+            }
+            regInfo->dwOpenFlags = dwFlags;
+            regInfo->memStore = memStore;
+            regInfo->key = key;
+            regInfo->key_modified_event = NULL;
+            if (!InitializeCriticalSectionEx(&regInfo->cs, 0, RTL_CRITICAL_SECTION_FLAG_FORCE_DEBUG_INFO))
+            {
+                SetLastError(ERROR_NOT_ENOUGH_MEMORY);
+                goto failed;
+            }
+            cs_initialized = TRUE;
+            regInfo->cs.DebugInfo->Spare[0] = (DWORD_PTR)(__FILE__ ": PWINE_REGSTOREINFO->cs");
+            list_init(&regInfo->certsToDelete);
+            list_init(&regInfo->crlsToDelete);
+            list_init(&regInfo->ctlsToDelete);
+            if (!(regInfo->key_modified_event = CreateEventW(NULL, FALSE, FALSE, NULL)))
+                goto failed;
+            if (RegNotifyChangeKeyValue(regInfo->key, TRUE, REG_NOTIFY_CHANGE_NAME | REG_NOTIFY_CHANGE_LAST_SET,
+                regInfo->key_modified_event, TRUE))
+                ERR("RegNotifyChangeKeyValue failed.\n");
+            CRYPT_RegReadFromReg(regInfo->key, regInfo->memStore, CERT_STORE_ADD_ALWAYS);
+            regInfo->dirty = FALSE;
+            {
+                CERT_STORE_PROV_INFO provInfo = { 0 };
+
+                provInfo.cbSize = sizeof(provInfo);
+                provInfo.cStoreProvFunc = ARRAY_SIZE(regProvFuncs);
+                provInfo.rgpvStoreProvFunc = regProvFuncs;
+                provInfo.hStoreProv = regInfo;
+                store = CRYPT_ProvCreateStore(dwFlags, memStore, &provInfo);
+            }
+            /* Reg store doesn't need crypto provider, so close it */
+            if (hCryptProv && !(dwFlags & CERT_STORE_NO_CRYPT_RELEASE_FLAG))
+                CryptReleaseContext(hCryptProv, 0);
+            if (store)
+                goto done;
+            SetLastError(ERROR_NOT_ENOUGH_MEMORY);
+
+failed:
+            err = GetLastError();
+            if (regInfo)
+            {
+                if (regInfo->key_modified_event) CloseHandle(regInfo->key_modified_event);
+                if (cs_initialized)
+                {
+                    regInfo->cs.DebugInfo->Spare[0] = 0;
+                    DeleteCriticalSection(&regInfo->cs);
+                }
+                CryptMemFree(regInfo);
+            }
+            if (memStore) CertCloseStore(memStore, 0);
+            RegCloseKey(key);
+            SetLastError(err);
         }
         else
             SetLastError(rc);
     }
+done:
     TRACE("returning %p\n", store);
     return store;
 }

--- a/dlls/crypt32/tests/store.c
+++ b/dlls/crypt32/tests/store.c
@@ -29,6 +29,7 @@
 #include <winreg.h>
 #include <winerror.h>
 #include <wincrypt.h>
+#include <winternl.h>
 
 #include "wine/test.h"
 
@@ -1082,6 +1083,97 @@ static const struct CertPropIDHeader *findPropID(const BYTE *buf, DWORD size,
     return ret;
 }
 
+static BOOL has_wow64_registry(void)
+{
+    BOOL (WINAPI *pIsWow64Process)(HANDLE, BOOL *);
+    BOOL is_wow64;
+
+    if (sizeof(void *) == 8) return TRUE;
+    pIsWow64Process = (void *)GetProcAddress(GetModuleHandleA("kernel32.dll"), "IsWow64Process");
+    return pIsWow64Process && pIsWow64Process(GetCurrentProcess(), &is_wow64) && is_wow64;
+}
+
+static void delete_wow64_reg_store_key(REGSAM view)
+{
+    HKEY parent;
+
+    if (!RegOpenKeyExA(HKEY_LOCAL_MACHINE, "Software\\Wine", 0, KEY_ALL_ACCESS | view, &parent))
+    {
+        SHDeleteKeyA(parent, "CryptRegWow64");
+        RegCloseKey(parent);
+    }
+}
+
+static void testRegStoreWow64(void)
+{
+    static const char path[] = "Software\\Wine\\CryptRegWow64";
+    HKEY key32 = NULL, key64 = NULL, selected, other, subkey;
+    DWORD value, size, type;
+    HCERTSTORE store;
+    LONG rc;
+
+    if (!has_wow64_registry())
+    {
+        skip("WOW64 registry views are unavailable\n");
+        return;
+    }
+
+    delete_wow64_reg_store_key(KEY_WOW64_32KEY);
+    delete_wow64_reg_store_key(KEY_WOW64_64KEY);
+    rc = RegCreateKeyExA(HKEY_LOCAL_MACHINE, path, 0, NULL, 0,
+                         KEY_ALL_ACCESS | KEY_WOW64_32KEY, NULL, &key32, NULL);
+    if (rc == ERROR_ACCESS_DENIED)
+    {
+        skip("Not authorized to test WOW64 registry stores\n");
+        return;
+    }
+    ok(!rc, "RegCreateKeyExA failed for 32-bit view: %ld\n", rc);
+    rc = RegCreateKeyExA(HKEY_LOCAL_MACHINE, path, 0, NULL, 0,
+                         KEY_ALL_ACCESS | KEY_WOW64_64KEY, NULL, &key64, NULL);
+    ok(!rc, "RegCreateKeyExA failed for 64-bit view: %ld\n", rc);
+    if (!key32 || !key64) goto cleanup;
+
+    value = 32;
+    rc = RegSetValueExA(key32, "View", 0, REG_DWORD, (BYTE *)&value, sizeof(value));
+    ok(!rc, "RegSetValueExA failed for 32-bit view: %ld\n", rc);
+    value = 64;
+    rc = RegSetValueExA(key64, "View", 0, REG_DWORD, (BYTE *)&value, sizeof(value));
+    ok(!rc, "RegSetValueExA failed for 64-bit view: %ld\n", rc);
+
+    selected = sizeof(void *) == 8 ? key32 : key64;
+    other = sizeof(void *) == 8 ? key64 : key32;
+    value = 0;
+    size = sizeof(value);
+    rc = RegQueryValueExA(selected, "View", NULL, &type, (BYTE *)&value, &size);
+    ok(!rc && value == (sizeof(void *) == 8 ? 32 : 64),
+       "Wrong selected registry view, rc %ld, value %lu\n", rc, value);
+    value = 0;
+    size = sizeof(value);
+    rc = RegQueryValueExA(other, "View", NULL, &type, (BYTE *)&value, &size);
+    ok(!rc && value == (sizeof(void *) == 8 ? 64 : 32),
+       "Wrong other registry view, rc %ld, value %lu\n", rc, value);
+
+    store = CertOpenStore(CERT_STORE_PROV_REG, 0, 0, 0, selected);
+    ok(store != NULL, "CertOpenStore failed for alternate WOW64 view: %08lx\n", GetLastError());
+    if (store) CertCloseStore(store, 0);
+
+    rc = RegOpenKeyExA(selected, "Certificates", 0, KEY_READ, &subkey);
+    ok(!rc, "Certificates not created in selected WOW64 view: %ld\n", rc);
+    if (!rc) RegCloseKey(subkey);
+    rc = RegOpenKeyExA(other, "Certificates", 0, KEY_READ, &subkey);
+    ok(rc == ERROR_FILE_NOT_FOUND, "Certificates unexpectedly created in other WOW64 view: %ld\n", rc);
+    if (!rc) RegCloseKey(subkey);
+
+    rc = RegQueryInfoKeyA(selected, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+    ok(!rc, "Input key was invalidated by CertCloseStore: %ld\n", rc);
+
+cleanup:
+    if (key32) RegCloseKey(key32);
+    if (key64) RegCloseKey(key64);
+    delete_wow64_reg_store_key(KEY_WOW64_32KEY);
+    delete_wow64_reg_store_key(KEY_WOW64_64KEY);
+}
+
 static void testRegStore(void)
 {
     static const char tempKey[] = "Software\\Wine\\CryptTemp";
@@ -1104,6 +1196,37 @@ static void testRegStore(void)
     store = CertOpenStore(CERT_STORE_PROV_REG, 0, 0, 0, key);
     ok(store != 0, "CertOpenStore failed: %08lx\n", GetLastError());
     CertCloseStore(store, 0);
+
+    {
+        static const WCHAR *root_paths[] = { L"\\Registry\\Machine", L"\\Registry\\User" };
+        NTSTATUS (WINAPI *pNtOpenKey)(HANDLE *, ACCESS_MASK, OBJECT_ATTRIBUTES *);
+        unsigned int i;
+
+        pNtOpenKey = (void *)GetProcAddress(GetModuleHandleA("ntdll.dll"), "NtOpenKey");
+        ok(pNtOpenKey != NULL, "NtOpenKey is unavailable\n");
+        for (i = 0; pNtOpenKey && i < ARRAY_SIZE(root_paths); i++)
+        {
+            UNICODE_STRING name;
+            OBJECT_ATTRIBUTES attr;
+            NTSTATUS status;
+
+            name.Buffer = (WCHAR *)root_paths[i];
+            name.Length = wcslen(root_paths[i]) * sizeof(WCHAR);
+            name.MaximumLength = name.Length + sizeof(WCHAR);
+            InitializeObjectAttributes(&attr, &name, OBJ_CASE_INSENSITIVE, NULL, NULL);
+            status = pNtOpenKey((HANDLE *)&key, KEY_READ, &attr);
+            ok(!status, "NtOpenKey failed for %s: %#lx\n", wine_dbgstr_w(root_paths[i]), status);
+            if (status) continue;
+
+            store = CertOpenStore(CERT_STORE_PROV_REG, 0, 0, CERT_STORE_READONLY_FLAG, key);
+            ok(store != NULL, "CertOpenStore failed for real root %s: %08lx\n",
+               wine_dbgstr_w(root_paths[i]), GetLastError());
+            if (store) CertCloseStore(store, 0);
+            rc = RegQueryInfoKeyW(key, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+            ok(!rc, "Input root key was invalidated by CertCloseStore: %ld\n", rc);
+            RegCloseKey(key);
+        }
+    }
 
     rc = RegCreateKeyExA(HKEY_CURRENT_USER, tempKey, 0, NULL, 0, KEY_ALL_ACCESS,
      NULL, &key, NULL);
@@ -3867,6 +3990,7 @@ START_TEST(store)
     testStoresInCollection();
 
     testRegStore();
+    testRegStoreWow64();
     testRegStoreSavedCerts();
 
     testSystemRegStore();

--- a/dlls/crypt32/tests/store.c
+++ b/dlls/crypt32/tests/store.c
@@ -1102,9 +1102,7 @@ static void testRegStore(void)
     /* Opening up any old key works.. */
     key = HKEY_CURRENT_USER;
     store = CertOpenStore(CERT_STORE_PROV_REG, 0, 0, 0, key);
-    /* Not sure if this is a bug in DuplicateHandle, marking todo_wine for now
-     */
-    todo_wine ok(store != 0, "CertOpenStore failed: %08lx\n", GetLastError());
+    ok(store != 0, "CertOpenStore failed: %08lx\n", GetLastError());
     CertCloseStore(store, 0);
 
     rc = RegCreateKeyExA(HKEY_CURRENT_USER, tempKey, 0, NULL, 0, KEY_ALL_ACCESS,


### PR DESCRIPTION
Fixes #79.

CRYPT_RegOpenStore duplicated the provider registry key with DuplicateHandle, which bypasses registry-layer hooks: the copy is never seen as opened, yet is closed with RegCloseKey. Office's AppV hook did not recognize the handle and crashed intermittently on close during Excel COM startup.

The fix queries the key's NT path via NtQueryKey and reopens it from its predefined root through the registry API, so hooks observe a balanced open/close pair for a real key path. Predefined roots pass through (open/close is a no-op for them) and failures propagate Win32 errors.

Validation:
- Excel COM-startup loop 16/16 clean on final bits, Wine crypt32/store suite 0 failures, Word control 4/4 clean, native probes on Windows all pass.

## Summary by Sourcery

Fix certificate-store registry handle handling to prevent Office startup crashes and maintain compatibility with registry-layer hooks.

Bug Fixes:
- Fix Excel startup crashes caused by certificate-store registry key handle duplication and unbalanced registry hook notifications.

Enhancements:
- Preserve registry key ownership while reopening handles through the registry API, including predefined roots and WOW64 registry views.

Tests:
- Add coverage for real registry roots, alternate WOW64 views, key validity after store closure, and registry-store creation behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Excel startup crashes related to certificate-store handling in the Windows registry.
  * Improved reliability when opening registry-backed certificate stores, including current-user and machine stores.
  * Corrected registry access behavior across 32-bit and 64-bit views, with improved cleanup and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->