### PR TITLE
crypt32: serialize default certificate chain engine initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Prevent Office startup crashes when certificate chains are built concurrently.
 - Speed up case-insensitive string comparisons in the default C locale.
 - Reduce CPU work while building DirectWrite font collections.
 - Reduce repeated directory scans during case-insensitive file lookup.

--- a/dlls/crypt32/chain.c
+++ b/dlls/crypt32/chain.c
@@ -161,40 +161,47 @@ HCERTCHAINENGINE CRYPT_CreateChainEngine(HCERTSTORE root, DWORD system_store, co
 }
 
 static CertificateChainEngine *default_cu_engine, *default_lm_engine;
+static INIT_ONCE default_cu_engine_once = INIT_ONCE_STATIC_INIT;
+static INIT_ONCE default_lm_engine_once = INIT_ONCE_STATIC_INIT;
+
+static BOOL CALLBACK create_default_chain_engine(INIT_ONCE *once, void *param, void **context)
+{
+    const CERT_CHAIN_ENGINE_CONFIG config = { sizeof(config) };
+
+    *context = CRYPT_CreateChainEngine(NULL, PtrToUlong(param), &config);
+    return *context != NULL;
+}
 
 static CertificateChainEngine *get_chain_engine(HCERTCHAINENGINE handle, BOOL allow_default)
 {
-    const CERT_CHAIN_ENGINE_CONFIG config = { sizeof(config) };
+    INIT_ONCE *once;
+    CertificateChainEngine **default_engine;
+    DWORD system_store;
 
     if(handle == HCCE_CURRENT_USER) {
         if(!allow_default)
             return NULL;
 
-        if(!default_cu_engine) {
-            handle = CRYPT_CreateChainEngine(NULL, CERT_SYSTEM_STORE_CURRENT_USER, &config);
-            InterlockedCompareExchangePointer((void**)&default_cu_engine, handle, NULL);
-            if(default_cu_engine != handle)
-                CertFreeCertificateChainEngine(handle);
-        }
-        CertControlStore(default_cu_engine->hWorld, 0, CERT_STORE_CTRL_RESYNC, NULL);
-        return default_cu_engine;
+        once = &default_cu_engine_once;
+        default_engine = &default_cu_engine;
+        system_store = CERT_SYSTEM_STORE_CURRENT_USER;
     }
-
-    if(handle == HCCE_LOCAL_MACHINE) {
+    else if(handle == HCCE_LOCAL_MACHINE) {
         if(!allow_default)
             return NULL;
 
-        if(!default_lm_engine) {
-            handle = CRYPT_CreateChainEngine(NULL, CERT_SYSTEM_STORE_LOCAL_MACHINE, &config);
-            InterlockedCompareExchangePointer((void**)&default_lm_engine, handle, NULL);
-            if(default_lm_engine != handle)
-                CertFreeCertificateChainEngine(handle);
-        }
-        CertControlStore(default_lm_engine->hWorld, 0, CERT_STORE_CTRL_RESYNC, NULL);
-        return default_lm_engine;
+        once = &default_lm_engine_once;
+        default_engine = &default_lm_engine;
+        system_store = CERT_SYSTEM_STORE_LOCAL_MACHINE;
     }
+    else
+        return (CertificateChainEngine*)handle;
 
-    return (CertificateChainEngine*)handle;
+    if (!InitOnceExecuteOnce(once, create_default_chain_engine, UlongToPtr(system_store),
+                             (void **)default_engine))
+        return NULL;
+    CertControlStore((*default_engine)->hWorld, 0, CERT_STORE_CTRL_RESYNC, NULL);
+    return *default_engine;
 }
 
 static void free_chain_engine(CertificateChainEngine *engine)

--- a/dlls/crypt32/tests/chain.c
+++ b/dlls/crypt32/tests/chain.c
@@ -150,11 +150,10 @@ static DWORD WINAPI default_chain_engine_thread(void *arg)
     return 0;
 }
 
-static void test_default_chain_engine_threads(void)
+static void run_default_chain_engine_threads(void)
 {
     struct default_chain_engine_thread contexts[16];
     HANDLE threads[ARRAY_SIZE(contexts)], start;
-    DWORD ret;
     unsigned int i;
 
     start = CreateEventW(NULL, TRUE, FALSE, NULL);
@@ -175,15 +174,44 @@ static void test_default_chain_engine_threads(void)
         CloseHandle(start);
         return;
     }
-    ret = WaitForMultipleObjects(i, threads, TRUE, 30000);
-    ok(ret == WAIT_OBJECT_0, "WaitForMultipleObjects returned %#lx\n", ret);
-    if (ret != WAIT_OBJECT_0) WaitForMultipleObjects(i, threads, TRUE, INFINITE);
+    WaitForMultipleObjects(i, threads, TRUE, INFINITE);
     while (i--)
     {
         ok(contexts[i].ret, "thread %u failed: %#lx\n", i, contexts[i].error);
         CloseHandle(threads[i]);
     }
     CloseHandle(start);
+}
+
+static void test_default_chain_engine_threads(void)
+{
+    STARTUPINFOA startup = { sizeof(startup) };
+    PROCESS_INFORMATION info;
+    char command[MAX_PATH + 64], **argv;
+    DWORD ret, exit_code;
+
+    winetest_get_mainargs(&argv);
+    snprintf(command, sizeof(command), "\"%s\" %s default_chain_engine_threads", argv[0], argv[1]);
+    if (!CreateProcessA(NULL, command, NULL, NULL, FALSE, 0, NULL, NULL, &startup, &info))
+    {
+        ok(0, "CreateProcess failed: %lu\n", GetLastError());
+        return;
+    }
+
+    ret = WaitForSingleObject(info.hProcess, 30000);
+    ok(ret == WAIT_OBJECT_0, "WaitForSingleObject returned %#lx\n", ret);
+    if (ret == WAIT_TIMEOUT)
+    {
+        TerminateProcess(info.hProcess, WAIT_TIMEOUT);
+        WaitForSingleObject(info.hProcess, 5000);
+    }
+    else if (ret == WAIT_OBJECT_0)
+    {
+        GetExitCodeProcess(info.hProcess, &exit_code);
+        ok(!exit_code, "child process exited with code %#lx\n", exit_code);
+    }
+    CloseHandle(info.hThread);
+    CloseHandle(info.hProcess);
 }
 
 static const BYTE bigCert[] = { 0x30, 0x7a, 0x02, 0x01, 0x01, 0x30, 0x02, 0x06,
@@ -5634,6 +5662,16 @@ static void test_chain_engine_cache_update(void)
 
 START_TEST(chain)
 {
+    char **argv;
+    int argc;
+
+    argc = winetest_get_mainargs(&argv);
+    if (argc >= 3 && !strcmp(argv[2], "default_chain_engine_threads"))
+    {
+        run_default_chain_engine_threads();
+        return;
+    }
+
     testCreateCertChainEngine();
     test_default_chain_engine_threads();
     testVerifyCertChainPolicy();

--- a/dlls/crypt32/tests/chain.c
+++ b/dlls/crypt32/tests/chain.c
@@ -121,6 +121,71 @@ static void testCreateCertChainEngine(void)
     CertCloseStore(store, 0);
 }
 
+struct default_chain_engine_thread
+{
+    HANDLE start;
+    BOOL ret;
+    DWORD error;
+};
+
+static DWORD WINAPI default_chain_engine_thread(void *arg)
+{
+    struct default_chain_engine_thread *thread = arg;
+    CERT_CHAIN_PARA para = { sizeof(para) };
+    PCCERT_CHAIN_CONTEXT chain = NULL;
+    PCCERT_CONTEXT cert;
+
+    cert = CertCreateCertificateContext(X509_ASN_ENCODING, selfSignedCert, sizeof(selfSignedCert));
+    if (!cert)
+    {
+        thread->error = GetLastError();
+        return 0;
+    }
+    WaitForSingleObject(thread->start, INFINITE);
+    thread->ret = CertGetCertificateChain(HCCE_CURRENT_USER, cert, NULL, NULL, &para,
+                                          CERT_CHAIN_REVOCATION_CHECK_CACHE_ONLY, NULL, &chain);
+    thread->error = GetLastError();
+    if (chain) CertFreeCertificateChain(chain);
+    CertFreeCertificateContext(cert);
+    return 0;
+}
+
+static void test_default_chain_engine_threads(void)
+{
+    struct default_chain_engine_thread contexts[16];
+    HANDLE threads[ARRAY_SIZE(contexts)], start;
+    DWORD ret;
+    unsigned int i;
+
+    start = CreateEventW(NULL, TRUE, FALSE, NULL);
+    ok(start != NULL, "CreateEventW failed: %lu\n", GetLastError());
+    if (!start) return;
+
+    memset(contexts, 0, sizeof(contexts));
+    for (i = 0; i < ARRAY_SIZE(contexts); ++i)
+    {
+        contexts[i].start = start;
+        threads[i] = CreateThread(NULL, 0, default_chain_engine_thread, &contexts[i], 0, NULL);
+        ok(threads[i] != NULL, "CreateThread %u failed: %lu\n", i, GetLastError());
+        if (!threads[i]) break;
+    }
+    SetEvent(start);
+    if (!i)
+    {
+        CloseHandle(start);
+        return;
+    }
+    ret = WaitForMultipleObjects(i, threads, TRUE, 30000);
+    ok(ret == WAIT_OBJECT_0, "WaitForMultipleObjects returned %#lx\n", ret);
+    if (ret != WAIT_OBJECT_0) WaitForMultipleObjects(i, threads, TRUE, INFINITE);
+    while (i--)
+    {
+        ok(contexts[i].ret, "thread %u failed: %#lx\n", i, contexts[i].error);
+        CloseHandle(threads[i]);
+    }
+    CloseHandle(start);
+}
+
 static const BYTE bigCert[] = { 0x30, 0x7a, 0x02, 0x01, 0x01, 0x30, 0x02, 0x06,
  0x00, 0x30, 0x15, 0x31, 0x13, 0x30, 0x11, 0x06, 0x03, 0x55, 0x04, 0x03, 0x13,
  0x0a, 0x4a, 0x75, 0x61, 0x6e, 0x20, 0x4c, 0x61, 0x6e, 0x67, 0x00, 0x30, 0x22,
@@ -5570,6 +5635,7 @@ static void test_chain_engine_cache_update(void)
 START_TEST(chain)
 {
     testCreateCertChainEngine();
+    test_default_chain_engine_threads();
     testVerifyCertChainPolicy();
     testGetCertChain();
     test_CERT_CHAIN_PARA_cbSize();


### PR DESCRIPTION
## Summary

- initialize the current-user and local-machine default certificate chain engines exactly once
- prevent concurrent `CertGetCertificateChain()` callers from constructing and tearing down competing default engines
- add a 16-thread regression test for concurrent default-engine use
- document the Office startup fix in the changelog

## Root cause

The existing compare-exchange protected only publication of the default engine pointer. Concurrent first callers could still construct multiple engines, after which every losing engine was immediately freed. During parallel Office TLS startup this overlapped certificate-store construction and teardown and produced a deterministic crash in `Collection_release()`.

`InitOnceExecuteOnce()` now serializes construction while preserving retry behavior if engine creation fails. Store resynchronization still runs for every call as before.

This race predates PR #80 and the change is based directly on `main`; it does not include the registry-store changes from #80.

## Validation

- focused dry run: 6 compile/link commands for the two DLLs and two test executables
- rebuilt `crypt32.dll` and `crypt32_test.exe` without warnings for i386 and x86-64
- new 16-thread `CertGetCertificateChain(HCCE_CURRENT_USER, ...)` regression passes on both architectures
- the complete `crypt32:chain` run reaches the new test and reports no failures from it; the hermetic builder still reports five unrelated trust-store-dependent failures in older cases
- combined Office runner (`PR #80` plus this fix): Excel opened to the full workbook UI, accepted cell input, and switched to the Data ribbon; PowerPoint opened to the full slide UI, accepted title input, and switched to the Insert ribbon

## Risk

Low and localized to lazy initialization of the two process-global default chain engines. Explicit custom chain-engine handles retain their existing path.

## Summary by Sourcery

Serialize lazy initialization of default certificate chain engines to make concurrent certificate-chain requests safe.

Bug Fixes:
- Prevent crashes during concurrent certificate-chain initialization by serializing creation of the current-user and local-machine default chain engines.

Documentation:
- Document the Office startup crash fix in the changelog.

Tests:
- Add a concurrent 16-thread regression test covering default certificate-chain engine use.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented Office startup crashes when certificate chains are built concurrently.
  * Improved reliability when multiple operations initialize the default certificate chain engine simultaneously.

* **Tests**
  * Added coverage to verify successful concurrent certificate-chain building using the default engine.

* **Documentation**
  * Added an entry to the unreleased changelog describing the concurrency fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->