### PR TITLE
d2d1: Fix distorted PowerPoint thumbnail selection corners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix distorted rounded selection borders around PowerPoint slide thumbnails.
 - Report failed XML transformation checks without crashing the test suite.
 - Handle empty XML downloads safely and report stalled transformation output as an error.
 - Handle XML allocation failures safely and release shared XML memory reliably across threads.

--- a/dlls/d2d1/geometry.c
+++ b/dlls/d2d1/geometry.c
@@ -6423,25 +6423,25 @@ static HRESULT STDMETHODCALLTYPE d2d_rounded_rectangle_geometry_Simplify(ID2D1Ro
 
     d2d_ellipse_to_segments(&ellipse, &start_point, segments);
 
-    d2d_point_set(&p, r->rect.left + r->radiusX, r->rect.bottom + r->radiusY);
+    d2d_point_set(&p, r->rect.left + r->radiusX, r->rect.top + r->radiusY);
     d2d_point_translate(&start_point, p.x, p.y);
     d2d_bezier_segment_translate(&segments[0], p.x, p.y);
-    d2d_point_set(&p, r->rect.right - r->radiusX, r->rect.bottom + r->radiusY);
+    d2d_point_set(&p, r->rect.right - r->radiusX, r->rect.top + r->radiusY);
     d2d_bezier_segment_translate(&segments[1], p.x, p.y);
-    d2d_point_set(&p, r->rect.right - r->radiusX, r->rect.top - r->radiusY);
+    d2d_point_set(&p, r->rect.right - r->radiusX, r->rect.bottom - r->radiusY);
     d2d_bezier_segment_translate(&segments[2], p.x, p.y);
-    d2d_point_set(&p, r->rect.left + r->radiusX, r->rect.top - r->radiusY);
+    d2d_point_set(&p, r->rect.left + r->radiusX, r->rect.bottom - r->radiusY);
     d2d_bezier_segment_translate(&segments[3], p.x, p.y);
 
     ret = d2d_figure_begin(&figure, start_point, D2D1_FIGURE_BEGIN_FILLED);
     ret = ret && d2d_figure_add_beziers(&figure, &segments[0], 1);
-    d2d_point_set(&p, r->rect.right - r->radiusX, r->rect.bottom);
+    d2d_point_set(&p, r->rect.right - r->radiusX, r->rect.top);
     ret = ret && d2d_figure_add_lines(&figure, &p, 1);
     ret = ret && d2d_figure_add_beziers(&figure, &segments[1], 1);
-    d2d_point_set(&p, r->rect.right, r->rect.top - r->radiusY);
+    d2d_point_set(&p, r->rect.right, r->rect.bottom - r->radiusY);
     ret = ret && d2d_figure_add_lines(&figure, &p, 1);
     ret = ret && d2d_figure_add_beziers(&figure, &segments[2], 1);
-    d2d_point_set(&p, r->rect.left + r->radiusX, r->rect.top);
+    d2d_point_set(&p, r->rect.left + r->radiusX, r->rect.bottom);
     ret = ret && d2d_figure_add_lines(&figure, &p, 1);
     ret = ret && d2d_figure_add_beziers(&figure, &segments[3], 1);
     if (!ret)
@@ -6568,18 +6568,18 @@ static void d2d_rounded_rectangle_geometry_stream(struct d2d_geometry *geometry,
 
     arcs[0].size.width = r->radiusX;
     arcs[0].size.height = r->radiusY;
-    arcs[0].rotationAngle = 90.0f;
+    arcs[0].rotationAngle = 0.0f;
     arcs[0].sweepDirection = D2D1_SWEEP_DIRECTION_CLOCKWISE;
     arcs[0].arcSize = D2D1_ARC_SIZE_SMALL;
     arcs[1] = arcs[2] = arcs[3] = arcs[0];
 
-    d2d_point_set(&points[0], r->rect.left, r->rect.top - r->radiusY);
+    d2d_point_set(&points[0], r->rect.left, r->rect.top + r->radiusY);
     d2d_point_set(&points[1], r->rect.right - r->radiusX, r->rect.top);
     d2d_point_set(&points[2], r->rect.right, r->rect.bottom - r->radiusY);
-    d2d_point_set(&points[3], r->rect.left - r->radiusX, r->rect.bottom);
+    d2d_point_set(&points[3], r->rect.left + r->radiusX, r->rect.bottom);
 
-    d2d_point_set(&arcs[0].point, r->rect.left - r->radiusX, r->rect.top);
-    d2d_point_set(&arcs[1].point, r->rect.right, r->rect.top - r->radiusY);
+    d2d_point_set(&arcs[0].point, r->rect.left + r->radiusX, r->rect.top);
+    d2d_point_set(&arcs[1].point, r->rect.right, r->rect.top + r->radiusY);
     d2d_point_set(&arcs[2].point, r->rect.right - r->radiusX, r->rect.bottom);
     d2d_point_set(&arcs[3].point, r->rect.left, r->rect.bottom - r->radiusY);
 

--- a/dlls/d2d1/geometry.c
+++ b/dlls/d2d1/geometry.c
@@ -6402,12 +6402,22 @@ static inline void d2d_bezier_segment_translate(D2D1_BEZIER_SEGMENT *segment, fl
     d2d_point_translate(&segment->point3, x, y);
 }
 
+static void d2d_rounded_rectangle_normalize(const D2D1_ROUNDED_RECT *src, D2D1_ROUNDED_RECT *dst)
+{
+    dst->rect.left = min(src->rect.left, src->rect.right);
+    dst->rect.right = max(src->rect.left, src->rect.right);
+    dst->rect.top = min(src->rect.top, src->rect.bottom);
+    dst->rect.bottom = max(src->rect.top, src->rect.bottom);
+    dst->radiusX = min(src->radiusX, 0.5f * (dst->rect.right - dst->rect.left));
+    dst->radiusY = min(src->radiusY, 0.5f * (dst->rect.bottom - dst->rect.top));
+}
+
 static HRESULT STDMETHODCALLTYPE d2d_rounded_rectangle_geometry_Simplify(ID2D1RoundedRectangleGeometry *iface,
         D2D1_GEOMETRY_SIMPLIFICATION_OPTION option, const D2D1_MATRIX_3X2_F *transform, float tolerance,
         ID2D1SimplifiedGeometrySink *sink)
 {
     struct d2d_geometry *geometry = impl_from_ID2D1RoundedRectangleGeometry(iface);
-    const D2D1_ROUNDED_RECT *r = &geometry->u.rounded_rectangle.rounded_rect;
+    D2D1_ROUNDED_RECT normalized, *r = &normalized;
     struct d2d_figure figure = { 0 };
     D2D1_BEZIER_SEGMENT segments[4];
     D2D1_POINT_2F start_point, p;
@@ -6417,6 +6427,7 @@ static HRESULT STDMETHODCALLTYPE d2d_rounded_rectangle_geometry_Simplify(ID2D1Ro
     TRACE("iface %p, option %#x, transform %p, tolerance %.8e, sink %p.\n",
             iface, option, transform, tolerance, sink);
 
+    d2d_rounded_rectangle_normalize(&geometry->u.rounded_rectangle.rounded_rect, &normalized);
     d2d_point_set(&ellipse.point, 0.0f, 0.0f);
     ellipse.radiusX = r->radiusX;
     ellipse.radiusY = r->radiusY;
@@ -6559,10 +6570,11 @@ static const struct ID2D1RoundedRectangleGeometryVtbl d2d_rounded_rectangle_geom
 static void d2d_rounded_rectangle_geometry_stream(struct d2d_geometry *geometry,
         const D2D_MATRIX_3X2_F *transform, ID2D1GeometrySink *sink)
 {
-    const D2D1_ROUNDED_RECT *r = &geometry->u.rounded_rectangle.rounded_rect;
+    D2D1_ROUNDED_RECT normalized, *r = &normalized;
     D2D1_ARC_SEGMENT arcs[4];
     D2D1_POINT_2F points[4];
 
+    d2d_rounded_rectangle_normalize(&geometry->u.rounded_rectangle.rounded_rect, &normalized);
     if (r->radiusX == 0.0f || r->radiusY == 0.0f)
         return d2d_rectangle_stream(&r->rect, transform, sink);
 

--- a/dlls/d2d1/tests/d2d1.c
+++ b/dlls/d2d1/tests/d2d1.c
@@ -5235,13 +5235,23 @@ static void test_rectangle_geometry(BOOL d3d11)
 static void test_rounded_rectangle_geometry(BOOL d3d11)
 {
     ID2D1RoundedRectangleGeometry *geometry;
+    ID2D1GeometryGroup *group;
     D2D1_ROUNDED_RECT rect, rect2;
     struct d2d1_test_context ctx;
     ID2D1PathGeometry *path;
     ID2D1GeometrySink *sink;
     D2D1_RECT_F bounds;
+    unsigned int i;
     BOOL match;
     HRESULT hr;
+
+    static const D2D1_ROUNDED_RECT oversized[] =
+    {
+        {{0.0f, 0.0f, 10.0f, 10.0f}, 20.0f, 20.0f},
+        {{0.0f, 0.0f, 10.0f, 10.0f}, 20.0f,  2.0f},
+        {{0.0f, 0.0f, 10.0f, 10.0f},  2.0f, 20.0f},
+        {{10.0f, 10.0f, 0.0f, 0.0f}, 20.0f, 20.0f},
+    };
 
     if (!init_test_context(&ctx, d3d11))
         return;
@@ -5302,6 +5312,47 @@ static void test_rounded_rectangle_geometry(BOOL d3d11)
             bounds.left, bounds.top, bounds.right, bounds.bottom);
     ID2D1PathGeometry_Release(path);
     ID2D1RoundedRectangleGeometry_Release(geometry);
+
+    for (i = 0; i < ARRAY_SIZE(oversized); ++i)
+    {
+        hr = ID2D1Factory_CreateRoundedRectangleGeometry(ctx.factory, &oversized[i], &geometry);
+        ok(hr == S_OK, "Case %u: got unexpected hr %#lx.\n", i, hr);
+        ID2D1RoundedRectangleGeometry_GetRoundedRect(geometry, &rect2);
+        ok(!memcmp(&oversized[i], &rect2, sizeof(rect2)), "Case %u: original rectangle changed.\n", i);
+
+        hr = ID2D1Factory_CreatePathGeometry(ctx.factory, &path);
+        ok(hr == S_OK, "Got unexpected hr %#lx.\n", hr);
+        hr = ID2D1PathGeometry_Open(path, &sink);
+        ok(hr == S_OK, "Got unexpected hr %#lx.\n", hr);
+        hr = ID2D1RoundedRectangleGeometry_Simplify(geometry,
+                D2D1_GEOMETRY_SIMPLIFICATION_OPTION_CUBICS_AND_LINES, NULL, 0.0f,
+                (ID2D1SimplifiedGeometrySink *)sink);
+        ok(hr == S_OK, "Got unexpected hr %#lx.\n", hr);
+        hr = ID2D1GeometrySink_Close(sink);
+        ok(hr == S_OK, "Got unexpected hr %#lx.\n", hr);
+        ID2D1GeometrySink_Release(sink);
+        hr = ID2D1PathGeometry_GetBounds(path, NULL, &bounds);
+        ok(hr == S_OK, "Got unexpected hr %#lx.\n", hr);
+        ok(fabsf(bounds.left) < 0.001f && fabsf(bounds.top) < 0.001f
+                && fabsf(bounds.right - 10.0f) < 0.001f && fabsf(bounds.bottom - 10.0f) < 0.001f,
+                "Case %u: unexpected simplified bounds {%.8e, %.8e, %.8e, %.8e}.\n",
+                i, bounds.left, bounds.top, bounds.right, bounds.bottom);
+        ID2D1PathGeometry_Release(path);
+
+        hr = ID2D1Factory_CreateGeometryGroup(ctx.factory, D2D1_FILL_MODE_ALTERNATE,
+                (ID2D1Geometry **)&geometry, 1, &group);
+        ok(hr == S_OK, "Got unexpected hr %#lx.\n", hr);
+        hr = ID2D1GeometryGroup_GetBounds(group, NULL, &bounds);
+        ok(hr == S_OK, "Got unexpected hr %#lx.\n", hr);
+        ok(fabsf(bounds.left) < 0.001f && fabsf(bounds.top) < 0.001f
+                && fabsf(bounds.right - 10.0f) < 0.001f && fabsf(bounds.bottom - 10.0f) < 0.001f,
+                "Case %u: unexpected group bounds {%.8e, %.8e, %.8e, %.8e}.\n",
+                i, bounds.left, bounds.top, bounds.right, bounds.bottom);
+        ID2D1GeometryGroup_Release(group);
+        ID2D1RoundedRectangleGeometry_GetRoundedRect(geometry, &rect2);
+        ok(!memcmp(&oversized[i], &rect2, sizeof(rect2)), "Case %u: original rectangle changed.\n", i);
+        ID2D1RoundedRectangleGeometry_Release(geometry);
+    }
 
     release_test_context(&ctx);
 }

--- a/dlls/d2d1/tests/d2d1.c
+++ b/dlls/d2d1/tests/d2d1.c
@@ -5237,6 +5237,10 @@ static void test_rounded_rectangle_geometry(BOOL d3d11)
     ID2D1RoundedRectangleGeometry *geometry;
     D2D1_ROUNDED_RECT rect, rect2;
     struct d2d1_test_context ctx;
+    ID2D1PathGeometry *path;
+    ID2D1GeometrySink *sink;
+    D2D1_RECT_F bounds;
+    BOOL match;
     HRESULT hr;
 
     if (!init_test_context(&ctx, d3d11))
@@ -5273,6 +5277,30 @@ static void test_rounded_rectangle_geometry(BOOL d3d11)
     ID2D1RoundedRectangleGeometry_GetRoundedRect(geometry, &rect2);
     ok(!memcmp(&rect, &rect2, sizeof(rect)), "Got unexpected rectangle {%.8e, %.8e, %.8e, %.8e, %.8e, %.8e}.\n",
             rect2.rect.left, rect2.rect.top, rect2.rect.right, rect2.rect.bottom, rect2.radiusX, rect2.radiusY);
+    ID2D1RoundedRectangleGeometry_Release(geometry);
+
+    /* PowerPoint uses rounded rectangle geometry groups for thumbnail selection frames. */
+    set_rounded_rect(&rect, 4.0f, 4.0f, 198.0f, 116.0f, 7.0f, 7.0f);
+    hr = ID2D1Factory_CreateRoundedRectangleGeometry(ctx.factory, &rect, &geometry);
+    ok(hr == S_OK, "Got unexpected hr %#lx.\n", hr);
+
+    hr = ID2D1Factory_CreatePathGeometry(ctx.factory, &path);
+    ok(hr == S_OK, "Got unexpected hr %#lx.\n", hr);
+    hr = ID2D1PathGeometry_Open(path, &sink);
+    ok(hr == S_OK, "Got unexpected hr %#lx.\n", hr);
+    hr = ID2D1RoundedRectangleGeometry_Simplify(geometry,
+            D2D1_GEOMETRY_SIMPLIFICATION_OPTION_CUBICS_AND_LINES, NULL, 0.0f,
+            (ID2D1SimplifiedGeometrySink *)sink);
+    ok(hr == S_OK, "Got unexpected hr %#lx.\n", hr);
+    hr = ID2D1GeometrySink_Close(sink);
+    ok(hr == S_OK, "Got unexpected hr %#lx.\n", hr);
+    ID2D1GeometrySink_Release(sink);
+    hr = ID2D1PathGeometry_GetBounds(path, NULL, &bounds);
+    ok(hr == S_OK, "Got unexpected hr %#lx.\n", hr);
+    match = compare_rect(&bounds, 4.0f, 4.0f, 198.0f, 116.0f, 1);
+    ok(match, "Got unexpected simplified bounds {%.8e, %.8e, %.8e, %.8e}.\n",
+            bounds.left, bounds.top, bounds.right, bounds.bottom);
+    ID2D1PathGeometry_Release(path);
     ID2D1RoundedRectangleGeometry_Release(geometry);
 
     release_test_context(&ctx);
@@ -12027,12 +12055,17 @@ static void test_colour_space(BOOL d3d11)
 static void test_geometry_group(BOOL d3d11)
 {
     ID2D1TransformedGeometry *transformed_geometry;
+    ID2D1SolidColorBrush *brush;
+    struct resource_readback rb;
+    D2D1_COLOR_F color;
+    unsigned int mode, x, y, outside;
     struct d2d1_test_context ctx;
     ID2D1Geometry *geometries[2];
     ID2D1GeometryGroup *group;
     D2D1_MATRIX_3X2_F matrix;
     ID2D1PathGeometry *path;
     ID2D1GeometrySink *sink;
+    D2D1_ROUNDED_RECT rounded_rect;
     D2D1_POINT_2F point;
     D2D1_RECT_F rect;
     HRESULT hr;
@@ -12072,6 +12105,62 @@ static void test_geometry_group(BOOL d3d11)
 
     ID2D1Geometry_Release(geometries[0]);
     ID2D1Geometry_Release(geometries[1]);
+
+    set_rounded_rect(&rounded_rect, 4.0f, 4.0f, 198.0f, 116.0f, 7.0f, 7.0f);
+    hr = ID2D1Factory_CreateRoundedRectangleGeometry(ctx.factory, &rounded_rect,
+            (ID2D1RoundedRectangleGeometry **)&geometries[0]);
+    ok(hr == S_OK, "Got unexpected hr %#lx.\n", hr);
+    hr = ID2D1Factory_CreateGeometryGroup(ctx.factory, D2D1_FILL_MODE_ALTERNATE, geometries, 1, &group);
+    ok(hr == S_OK, "Got unexpected hr %#lx.\n", hr);
+    hr = ID2D1GeometryGroup_GetBounds(group, NULL, &rect);
+    ok(hr == S_OK, "Got unexpected hr %#lx.\n", hr);
+    match = compare_rect(&rect, 4.0f, 4.0f, 198.0f, 116.0f, 0);
+    ok(match, "Got unexpected rounded rectangle group bounds {%.8e, %.8e, %.8e, %.8e}.\n",
+            rect.left, rect.top, rect.right, rect.bottom);
+    ID2D1GeometryGroup_Release(group);
+
+    set_rounded_rect(&rounded_rect, 7.0f, 7.0f, 195.0f, 113.0f, 4.0f, 4.0f);
+    hr = ID2D1Factory_CreateRoundedRectangleGeometry(ctx.factory, &rounded_rect,
+            (ID2D1RoundedRectangleGeometry **)&geometries[1]);
+    ok(hr == S_OK, "Got unexpected hr %#lx.\n", hr);
+    hr = ID2D1Factory_CreateGeometryGroup(ctx.factory, D2D1_FILL_MODE_ALTERNATE, geometries, 2, &group);
+    ok(hr == S_OK, "Got unexpected hr %#lx.\n", hr);
+    set_color(&color, 1.0f, 0.0f, 0.0f, 1.0f);
+    hr = ID2D1RenderTarget_CreateSolidColorBrush(ctx.rt, &color, NULL, &brush);
+    ok(hr == S_OK, "Got unexpected hr %#lx.\n", hr);
+    ID2D1RenderTarget_SetDpi(ctx.rt, 96.0f, 96.0f);
+    for (mode = D2D1_ANTIALIAS_MODE_PER_PRIMITIVE; mode <= D2D1_ANTIALIAS_MODE_ALIASED; ++mode)
+    {
+        ID2D1RenderTarget_SetAntialiasMode(ctx.rt, mode);
+        ID2D1RenderTarget_BeginDraw(ctx.rt);
+        ID2D1RenderTarget_Clear(ctx.rt, NULL);
+        ID2D1RenderTarget_FillGeometry(ctx.rt, (ID2D1Geometry *)group, (ID2D1Brush *)brush, NULL);
+        hr = ID2D1RenderTarget_EndDraw(ctx.rt, NULL, NULL);
+        ok(hr == S_OK, "Mode %u: got unexpected hr %#lx.\n", mode, hr);
+        get_surface_readback(&ctx, &rb);
+        outside = 0;
+        for (y = 0; y < 120; ++y)
+            for (x = 0; x < 202; ++x)
+                if ((x < 4 || x >= 198 || y < 4 || y >= 116)
+                        && (get_readback_colour(&rb, x, y) & 0x00ffffff))
+                    ++outside;
+        ok(!outside, "Mode %u: %u coloured pixels outside the frame.\n", mode, outside);
+        ok((get_readback_colour(&rb, 100, 5) & 0x00ffffff) == 0x00ff0000,
+                "Mode %u: missing top edge.\n", mode);
+        ok((get_readback_colour(&rb, 100, 114) & 0x00ffffff) == 0x00ff0000,
+                "Mode %u: missing bottom edge.\n", mode);
+        ok((get_readback_colour(&rb, 5, 60) & 0x00ffffff) == 0x00ff0000,
+                "Mode %u: missing left edge.\n", mode);
+        ok((get_readback_colour(&rb, 196, 60) & 0x00ffffff) == 0x00ff0000,
+                "Mode %u: missing right edge.\n", mode);
+        ok(!(get_readback_colour(&rb, 100, 60) & 0x00ffffff),
+                "Mode %u: the frame interior was filled.\n", mode);
+        release_resource_readback(&rb);
+    }
+    ID2D1SolidColorBrush_Release(brush);
+    ID2D1GeometryGroup_Release(group);
+    ID2D1Geometry_Release(geometries[1]);
+    ID2D1Geometry_Release(geometries[0]);
 
     /* Empty path. */
     hr = ID2D1Factory_CreatePathGeometry(ctx.factory, &path);
@@ -20956,6 +21045,12 @@ START_TEST(d2d1)
     {
         test_draw_geometry(FALSE);
         test_draw_geometry(TRUE);
+        return;
+    }
+    if (getenv("WINE_D2D1_ROUNDED_RECTANGLE_ONLY"))
+    {
+        test_rounded_rectangle_geometry(FALSE);
+        test_geometry_group(FALSE);
         return;
     }
 


### PR DESCRIPTION
PowerPoint's selected slide thumbnail had protruding, disconnected corners. Its alternate-fill group contains two rounded rectangles, but Wine emitted tangent points outside their bounds and gave the corner arcs a 90-degree ellipse rotation.

Correct the corner coordinates in rounded-rectangle streaming and simplification, and keep the streamed ellipse axes aligned with the rectangle. Antialiasing and shared Direct3D state handling remain enabled.

Normalize the rectangle bounds and clamp corner radii in local copies before emitting paths, matching cached geometry. Preserve the original input for GetRoundedRect.

Validation:

- Canonical focused builds of `d2d1.dll` and `d2d1_test.exe` for i386 and x86_64.
- Public-API regressions for simplified path bounds, rounded geometry-group bounds, and the PowerPoint frame's four sides, empty interior, and out-of-bounds pixels in both antialias modes. A focused test entry avoids running unrelated graphics tests concurrently.
- The same regression executable fails against the original runner and passes against the patched runner.
- Final focused suite: 139 tests on each of i386 and x86_64, zero failures/skips. New oversized-radius and reversed-bounds cases produce eight failures against the preceding PR commit and pass after normalization; getter values remain unchanged.
- PowerPoint visual check at 1440x900 and 81% slide zoom: the thumbnail frame now has continuous rounded corners. Evidence is preserved in `artifacts/ppt-thumbnail-regression-20260906/`, including `26cb-start.png` and `powerpoint-fixed-v2.png`.
- Native Windows was unavailable (SSH timeout). Full-suite attempts exceeded the Office container's memory limit; only the completed focused tests are counted as validation.

The change is based on `d2b3f25e1fc637681fbdb9e6400bd9617ef06144`. The defect predates PR #72 and the recent antialiasing changes.

## Summary by Sourcery

Fix rounded-rectangle geometry so PowerPoint thumbnail selection frames render as continuous, correctly bounded corners.

Bug Fixes:
- Fix distorted rounded selection borders around PowerPoint slide thumbnails by keeping corner geometry within rectangle bounds.

Enhancements:
- Normalize rounded rectangles and preserve aligned ellipse axes during geometry streaming and simplification.

Tests:
- Add regression coverage for rounded-rectangle normalization, simplified and geometry-group bounds, and alternate-fill thumbnail frame rendering in both antialiasing modes.