### PR TITLE
winewayland: Restore Excel Vulkan worksheet presentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Restore Excel worksheets and formula bars when using Vulkan on Wayland.
+- Prevent a Wayland window-restacking deadlock when resizing Excel.
 - Fix distorted rounded selection borders around PowerPoint slide thumbnails.
 - Report failed XML transformation checks without crashing the test suite.
 - Handle empty XML downloads safely and report stalled transformation output as an error.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Restore Excel worksheets and formula bars when using Vulkan on Wayland.
 - Report failed XML transformation checks without crashing the test suite.
 - Handle empty XML downloads safely and report stalled transformation output as an error.
 - Handle XML allocation failures safely and release shared XML memory reliably across threads.

--- a/dlls/opengl32/tests/Makefile.in
+++ b/dlls/opengl32/tests/Makefile.in
@@ -2,4 +2,5 @@ TESTDLL   = opengl32.dll
 IMPORTS   = opengl32 user32 gdi32
 
 SOURCES = \
-	opengl.c
+	opengl.c \
+	surface.c

--- a/dlls/opengl32/tests/surface.c
+++ b/dlls/opengl32/tests/surface.c
@@ -1,0 +1,230 @@
+/*
+ * Concurrent window surface lifetime tests
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+#include "windef.h"
+#include "winbase.h"
+#include "wingdi.h"
+#include "winuser.h"
+#include "wine/test.h"
+#include "wine/wgl.h"
+
+struct render_state
+{
+    HDC dc;
+    HGLRC context;
+    HANDLE ready, frame;
+    LONG stop, frames;
+    BOOL current;
+};
+
+/* The window owner must dispatch messages while waiting for the rendering
+ * thread: a WGL implementation may synchronously message that window. */
+static DWORD wait_with_messages(HANDLE event, DWORD timeout)
+{
+    ULONGLONG end = GetTickCount64() + timeout, now;
+    DWORD ret;
+    MSG msg;
+
+    for (;;)
+    {
+        now = GetTickCount64();
+        ret = MsgWaitForMultipleObjects(1, &event, FALSE, now < end ? end - now : 0, QS_ALLINPUT);
+        if (ret != WAIT_OBJECT_0 + 1) return ret;
+        while (PeekMessageW(&msg, NULL, 0, 0, PM_REMOVE))
+        {
+            TranslateMessage(&msg);
+            DispatchMessageW(&msg);
+        }
+    }
+}
+
+static DWORD WINAPI render_thread(void *arg)
+{
+    struct render_state *state = arg;
+    BOOL ret;
+
+    state->current = wglMakeCurrent(state->dc, state->context);
+    ok(state->current, "wglMakeCurrent failed, error %lu.\n", GetLastError());
+    SetEvent(state->ready);
+    if (!state->current) return 0;
+    trace("Renderer: %s.\n", glGetString(GL_RENDERER));
+    while (!InterlockedCompareExchange(&state->stop, 0, 0))
+    {
+        glClearColor(0.25f, 0.5f, 0.75f, 1.0f);
+        glClear(GL_COLOR_BUFFER_BIT);
+        ret = SwapBuffers(state->dc);
+        ok(ret, "SwapBuffers failed, error %lu.\n", GetLastError());
+        if (!ret) break;
+        InterlockedIncrement(&state->frames);
+        SetEvent(state->frame);
+    }
+    ok(wglMakeCurrent(NULL, NULL), "Failed to release the current context.\n");
+    return 0;
+}
+
+static HWND create_surface_window(HWND parent, int x)
+{
+    HWND hwnd = CreateWindowW(L"static", L"surface concurrency", WS_VISIBLE | WS_CLIPSIBLINGS |
+                              WS_CLIPCHILDREN | (parent ? WS_CHILD : WS_OVERLAPPEDWINDOW),
+                              x, 20, 240, 180, parent, NULL, NULL, NULL);
+    ok(!!hwnd, "CreateWindow failed, error %lu.\n", GetLastError());
+    return hwnd;
+}
+
+static void test_surface_child(void)
+{
+    PIXELFORMATDESCRIPTOR pfd = {sizeof(pfd), 1, PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL |
+                                PFD_DOUBLEBUFFER, PFD_TYPE_RGBA, 24};
+    struct render_state state = {0};
+    HWND roots[2] = {0}, branches[2] = {0}, drawable = NULL, previous;
+    HANDLE thread = NULL;
+    DWORD ret;
+    unsigned int i, old = 0, next;
+    int format;
+
+    roots[0] = create_surface_window(NULL, 20);
+    roots[1] = create_surface_window(NULL, 300);
+    if (!roots[0] || !roots[1]) goto done;
+    branches[0] = create_surface_window(roots[0], 0);
+    branches[1] = create_surface_window(roots[1], 0);
+    if (!branches[0] || !branches[1]) goto done;
+    if (!(drawable = create_surface_window(branches[0], 0))) goto done;
+    state.dc = GetDC(drawable);
+    ok(!!state.dc, "GetDC failed.\n");
+    if (!state.dc) goto done;
+    if (!(format = ChoosePixelFormat(state.dc, &pfd)))
+    {
+        win_skip("No window OpenGL pixel format.\n");
+        goto done;
+    }
+    ret = SetPixelFormat(state.dc, format, &pfd);
+    ok(ret, "SetPixelFormat failed, error %lu.\n", GetLastError());
+    if (!ret) goto done;
+    state.context = wglCreateContext(state.dc);
+    ok(!!state.context, "wglCreateContext failed, error %lu.\n", GetLastError());
+    if (!state.context) goto done;
+    state.ready = CreateEventW(NULL, TRUE, FALSE, NULL);
+    state.frame = CreateEventW(NULL, FALSE, FALSE, NULL);
+    ok(state.ready && state.frame, "CreateEvent failed.\n");
+    if (!state.ready || !state.frame) goto done;
+    thread = CreateThread(NULL, 0, render_thread, &state, 0, NULL);
+    ok(!!thread, "CreateThread failed.\n");
+    if (!thread) goto done;
+    ret = wait_with_messages(state.ready, 10000);
+    ok(ret == WAIT_OBJECT_0, "Renderer startup timed out: %#lx.\n", ret);
+    if (ret != WAIT_OBJECT_0) ExitProcess(1);
+    if (!state.current) goto done;
+
+    /* Keep the drawable and its DC alive until the renderer joins. Only the
+     * window owner reparents/resizes/destroys HWNDs. Destroy the old ancestor
+     * after moving the drawable out, while presentation continues on the new
+     * hierarchy. This exercises stale driver snapshots without using a dead DC. */
+    for (i = 0; i < 200; ++i)
+    {
+        winetest_push_context("iteration %u", i);
+        next = old ^ 1;
+        previous = SetParent(drawable, branches[next]);
+        ok(previous == branches[old], "Unexpected previous parent %p.\n", previous);
+        if (previous != branches[old])
+        {
+            winetest_pop_context();
+            goto done;
+        }
+        ok(GetParent(drawable) == branches[next], "Wrong new parent.\n");
+        ok(SetWindowPos(roots[next], NULL, 0, 0, 260 + i % 8, 200 + i % 8,
+                        SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE), "Resize failed.\n");
+        if (!(i % 8))
+        {
+            ShowWindow(roots[next], SW_MAXIMIZE);
+            ShowWindow(roots[next], SW_RESTORE);
+        }
+        ok(RedrawWindow(roots[next], NULL, NULL, RDW_INVALIDATE | RDW_ERASE |
+                       RDW_FRAME | RDW_ALLCHILDREN | RDW_UPDATENOW), "RedrawWindow failed.\n");
+        if (previous == branches[old])
+        {
+            ok(DestroyWindow(branches[old]), "DestroyWindow failed.\n");
+            branches[old] = create_surface_window(roots[old], 0);
+            if (!branches[old]) ExitProcess(1);
+        }
+        old = next;
+        ResetEvent(state.frame);
+        ret = wait_with_messages(state.frame, 10000);
+        ok(ret == WAIT_OBJECT_0, "Presentation stopped after hierarchy change: %#lx.\n", ret);
+        if (ret != WAIT_OBJECT_0) ExitProcess(1);
+        winetest_pop_context();
+    }
+    trace("Completed %u hierarchy changes, %ld frames.\n", i,
+          InterlockedCompareExchange(&state.frames, 0, 0));
+
+done:
+    if (thread)
+    {
+        InterlockedExchange(&state.stop, 1);
+        ret = wait_with_messages(thread, 10000);
+        ok(ret == WAIT_OBJECT_0, "Rendering thread failed to stop: %#lx.\n", ret);
+        if (ret != WAIT_OBJECT_0) ExitProcess(1);
+        CloseHandle(thread);
+    }
+    if (state.frame) CloseHandle(state.frame);
+    if (state.ready) CloseHandle(state.ready);
+    if (state.context) ok(wglDeleteContext(state.context), "wglDeleteContext failed.\n");
+    if (state.dc) ReleaseDC(drawable, state.dc);
+    if (drawable) DestroyWindow(drawable);
+    for (i = 0; i < 2; ++i)
+    {
+        if (branches[i]) DestroyWindow(branches[i]);
+        if (roots[i]) DestroyWindow(roots[i]);
+    }
+}
+
+START_TEST(surface)
+{
+    STARTUPINFOA startup = {sizeof(startup)};
+    PROCESS_INFORMATION process;
+    char **argv, command[2 * MAX_PATH];
+    DWORD ret;
+    int argc = winetest_get_mainargs(&argv);
+    BOOL created;
+
+    if (argc > 2 && !strcmp(argv[2], "child"))
+    {
+        test_surface_child();
+        return;
+    }
+
+    /* A deadlock can block the window owner inside SetParent/SetWindowPos.
+     * A separate process bounds that failure without terminating a thread
+     * holding locks in the rest of the test suite. */
+    snprintf(command, sizeof(command), "\"%s\" surface child", argv[0]);
+    created = CreateProcessA(NULL, command, NULL, NULL, FALSE, 0, NULL, NULL, &startup, &process);
+    ok(created, "CreateProcess failed, error %lu.\n", GetLastError());
+    if (!created) return;
+    ret = WaitForSingleObject(process.hProcess, 90000);
+    ok(ret == WAIT_OBJECT_0, "Concurrent presentation/window updates hung: %#lx.\n", ret);
+    if (ret != WAIT_OBJECT_0)
+    {
+        /* The child may exit between the timeout and TerminateProcess. */
+        if (!TerminateProcess(process.hProcess, 1))
+            ok(WaitForSingleObject(process.hProcess, 1000) == WAIT_OBJECT_0,
+               "Failed to terminate hung test child, error %lu.\n", GetLastError());
+    }
+    wait_child_process(&process);
+}

--- a/dlls/winewayland.drv/wayland_surface.c
+++ b/dlls/winewayland.drv/wayland_surface.c
@@ -982,24 +982,6 @@ static RECT wayland_surface_get_presentation_rect(struct wayland_surface *surfac
     return rect;
 }
 
-struct wl_surface *wayland_client_surface_get_parent(struct wayland_surface *surface,
-                                                     struct wayland_client_surface *client)
-{
-    HWND parent = NtUserGetAncestor(client->client.hwnd, GA_PARENT);
-
-    while (parent && parent != client->toplevel && parent != NtUserGetDesktopWindow())
-    {
-        struct wayland_win_data *data = wayland_win_data_get_nolock(parent);
-
-        if (data && data->client_surface && data->client_surface->wl_subsurface &&
-            data->client_surface->toplevel == client->toplevel)
-            return data->client_surface->wl_surface;
-        parent = NtUserGetAncestor(parent, GA_PARENT);
-    }
-
-    return surface->wl_surface;
-}
-
 /**********************************************************************
  *          wayland_surface_reconfigure_client
  *

--- a/dlls/winewayland.drv/wayland_surface.c
+++ b/dlls/winewayland.drv/wayland_surface.c
@@ -1532,7 +1532,9 @@ static void wayland_client_surface_update(struct client_surface *client)
 
     TRACE("%s\n", debugstr_client_surface(client));
     if(toplevel) visible = NtUserIsWindowVisible(hwnd);
-    for (child = NtUserGetWindowRelative(hwnd, GW_CHILD); child;
+    /* Only OpenGL drawables can read back their pixels for GDI composition.
+     * Vulkan clients have format zero and must keep their native surface. */
+    for (child = client->format > 0 ? NtUserGetWindowRelative(hwnd, GW_CHILD) : NULL; child;
          child = NtUserGetWindowRelative(child, GW_HWNDNEXT))
     {
         if ((offscreen = NtUserIsWindowVisible(child))) break;

--- a/dlls/winewayland.drv/waylanddrv.h
+++ b/dlls/winewayland.drv/waylanddrv.h
@@ -383,8 +383,6 @@ POINT map_point_to_surface(struct wayland_surface *surface, POINT point);
 RECT map_rect_from_surface(struct wayland_surface *surface, RECT rect);
 POINT map_point_from_surface(struct wayland_surface *surface, POINT point);
 void wayland_client_surface_attach(struct wayland_client_surface *client, HWND toplevel, const RECT *rect);
-struct wl_surface *wayland_client_surface_get_parent(struct wayland_surface *surface,
-                                                     struct wayland_client_surface *client);
 void wayland_surface_ensure_contents(struct wayland_surface *surface);
 void wayland_surface_set_title(struct wayland_surface *surface, LPCWSTR title);
 void wayland_surface_assign_icon(struct wayland_surface *surface);

--- a/dlls/winewayland.drv/window.c
+++ b/dlls/winewayland.drv/window.c
@@ -158,17 +158,58 @@ void wayland_win_data_release(struct wayland_win_data *data)
 
 static HWND *build_hwnd_list(HWND hwnd, BOOL children);
 
+struct client_stack_entry
+{
+    HWND hwnd;
+    unsigned int parent;
+};
+
+/* Collect both Z-order and ancestry before taking win_data_mutex. Entries
+ * contain handles, not driver pointers, since windows may disappear while
+ * collecting the snapshot. Index zero represents the group root. */
+static struct client_stack_entry *build_client_stack(HWND toplevel)
+{
+    struct client_stack_entry *stack;
+    HWND *list = build_hwnd_list(toplevel, TRUE), parent;
+    unsigned int count, i, j;
+
+    if (!list) return NULL;
+    for (count = 0; list[count] != HWND_BOTTOM; ++count) {}
+    if (!(stack = calloc((size_t)count + 2, sizeof(*stack))))
+    {
+        free(list);
+        return NULL;
+    }
+    stack[0].hwnd = toplevel;
+    for (i = 1; i <= count; ++i)
+    {
+        stack[i].hwnd = list[i - 1];
+        parent = NtUserGetAncestor(stack[i].hwnd, GA_PARENT);
+        /* The server enumerates parents before their descendants. Reject an
+         * entry whose ancestry changed out of this snapshot; a subsequent
+         * window update or presentation will rebuild the group. Requiring a
+         * preceding parent also bounds traversal even during reparenting. */
+        for (j = 0; j < i; ++j)
+            if (stack[j].hwnd == parent) break;
+        stack[i].parent = j;
+    }
+    stack[count + 1].hwnd = HWND_BOTTOM;
+    free(list);
+    return stack;
+}
+
 /* The caller holds win_data_mutex. Rebuild the GPU client hierarchy in
  * Win32 child Z-order. Client surfaces are Wayland siblings regardless of
  * their HWND ancestry, so creation or presentation order cannot determine
  * stacking. */
 static void wayland_win_data_restack_client_surfaces_locked(HWND toplevel,
-                                                            const HWND *list)
+                                                            const struct client_stack_entry *stack)
 {
     struct wayland_win_data *data, *toplevel_data;
     struct wayland_surface *toplevel_surface;
     struct wayland_client_surface *client;
-    UINT i;
+    struct wl_surface *anchor;
+    UINT i, j;
 
     if (!(toplevel_data = wayland_win_data_get_nolock(toplevel)) ||
         !(toplevel_surface = toplevel_data->wayland_surface))
@@ -177,17 +218,28 @@ static void wayland_win_data_restack_client_surfaces_locked(HWND toplevel,
     /* NtUserBuildHwndList returns descendants from top to bottom. Placing
      * each surface immediately above its attached ancestor in that order
      * leaves later (lower) siblings below the earlier (higher) ones. */
-    if (list)
+    if (stack)
     {
-        for (i = 0; list[i] != HWND_BOTTOM; ++i)
+        for (i = 1; stack[i].hwnd != HWND_BOTTOM; ++i)
         {
-            if (!(data = wayland_win_data_get_nolock(list[i])) ||
+            if (!(data = wayland_win_data_get_nolock(stack[i].hwnd)) ||
                 !(client = data->client_surface) || !client->wl_subsurface ||
                 client->toplevel != toplevel ||
                 client->parent_surface != toplevel_surface->wl_surface)
                 continue;
-            wl_subsurface_place_above(client->wl_subsurface,
-                                      wayland_client_surface_get_parent(toplevel_surface, client));
+            anchor = toplevel_surface->wl_surface;
+            for (j = stack[i].parent; j && stack[j].parent < j; j = stack[j].parent)
+            {
+                if (!(data = wayland_win_data_get_nolock(stack[j].hwnd)) ||
+                    !data->client_surface || !data->client_surface->wl_subsurface ||
+                    data->client_surface->toplevel != toplevel ||
+                    data->client_surface->parent_surface != toplevel_surface->wl_surface)
+                    continue;
+                anchor = data->client_surface->wl_surface;
+                break;
+            }
+            if (j && stack[j].parent >= j) continue;
+            wl_subsurface_place_above(client->wl_subsurface, anchor);
         }
     }
 
@@ -207,14 +259,14 @@ static void wayland_win_data_restack_client_surfaces_locked(HWND toplevel,
 static void wayland_win_data_restack_client_surfaces(HWND toplevel)
 {
     struct wayland_win_data *data;
-    HWND *list = build_hwnd_list(toplevel, TRUE);
+    struct client_stack_entry *stack = build_client_stack(toplevel);
 
     if ((data = wayland_win_data_get(toplevel)))
     {
-        wayland_win_data_restack_client_surfaces_locked(toplevel, list);
+        wayland_win_data_restack_client_surfaces_locked(toplevel, stack);
         wayland_win_data_release(data);
     }
-    free(list);
+    free(stack);
 }
 
 /* Keep all visible owner-relative popups
@@ -230,11 +282,11 @@ static void wayland_win_data_restack_owned_popups(HWND toplevel)
     struct wayland_win_data *data, *locked_data, *toplevel_data;
     struct wayland_surface *toplevel_surface, *popup;
     RECT intersection;
-    HWND *list = build_hwnd_list(toplevel, TRUE);
+    struct client_stack_entry *stack = build_client_stack(toplevel);
 
     if (!(locked_data = wayland_win_data_get(toplevel)))
     {
-        free(list);
+        free(stack);
         return;
     }
     if (!(toplevel_data = wayland_win_data_get_nolock(toplevel)) ||
@@ -266,11 +318,11 @@ static void wayland_win_data_restack_owned_popups(HWND toplevel)
 
     /* Rebuild clients even without popups. A newly attached ancestor client
      * must not cover child clients which were attached before it. */
-    wayland_win_data_restack_client_surfaces_locked(toplevel, list);
+    wayland_win_data_restack_client_surfaces_locked(toplevel, stack);
 
 done:
     wayland_win_data_release(locked_data);
-    free(list);
+    free(stack);
 }
 
 /* Called by window_surface_flush_done, after the window-surface mutex has

--- a/dlls/winewayland.drv/window.c
+++ b/dlls/winewayland.drv/window.c
@@ -229,7 +229,6 @@ static void wayland_win_data_restack_owned_popups(HWND toplevel)
 {
     struct wayland_win_data *data, *locked_data, *toplevel_data;
     struct wayland_surface *toplevel_surface, *popup;
-    BOOL popup_found = FALSE;
     RECT intersection;
     HWND *list = build_hwnd_list(toplevel, TRUE);
 
@@ -263,11 +262,10 @@ static void wayland_win_data_restack_owned_popups(HWND toplevel)
             wayland_surface_make_subsurface(popup, toplevel_surface);
         if (!popup->wl_subsurface) continue;
         wl_subsurface_place_above(popup->wl_subsurface, toplevel_surface->wl_surface);
-        popup_found = TRUE;
     }
-    if (!popup_found) goto done;
 
-    /* Rebuild clients in Win32 Z-order below the popup group. */
+    /* Rebuild clients even without popups. A newly attached ancestor client
+     * must not cover child clients which were attached before it. */
     wayland_win_data_restack_client_surfaces_locked(toplevel, list);
 
 done:


### PR DESCRIPTION
## Purpose

Restore Excel worksheet and formula-bar presentation with WineD3D Vulkan on
Wayland. The old visible-child policy detached Vulkan surfaces into a GDI
readback path implemented only for OpenGL. Keeping Vulkan attached also requires
restacking ancestor and child GPU surfaces without waiting for an owned popup.

## Resize regression and follow-up

The initial patch exposed an existing lock inversion in the restacking helper.
Repeated resize froze both OpenGL and Vulkan; diagnostic mutex-owner logs proved
the UI and graphics threads waiting on each other's user/window-data locks.
Earlier startup-only safety statements are superseded.

Commit de40bbb6a08 collects HWND ancestry alongside Z-order before locking
Wayland window data. The locked walk resolves live surfaces without Win32
ancestry calls and requires the anchor to share the current Wayland parent.
Parent-index traversal is bounded and out-of-snapshot ancestry is skipped.
The obsolete lock-taking helper is removed.

## Validation

- Focused canonical build of the affected Unix driver succeeded on the existing
  build server. No new Office environment or full runner copy.
- Same existing Intel Iris Xe / Mesa 26.1.5 / KWin container, workbook, prefix
  snapshot and 1440x900 desktop: two restore/maximize cycles passed with OpenGL;
  five passed with Vulkan, followed by minimize/restore, cell edit and Format
  Cells open/close. Worksheet and formula controls remain visible.
- Final Excel maps the patched runner with `WINE_D3D_CONFIG=renderer=vulkan`.
  Driver SHA-256 `eba988fbb005733afeb1d6737ff4888182061e25e51478a2bfcb59aec42d89aa`.
- `git diff --check` passed. The private Unix driver change is shared by the
  existing combined WoW64 runner; runtime testing used 64-bit Excel.

## Limits and review gate

`opengl32_test.exe surface` now covers concurrent SwapBuffers, reparenting,
ancestor destruction/recreation, resizing, maximize/restore and redraw using
public APIs with event-based progress and a subprocess watchdog. The old driver
times out; the fixed driver passed three final runs on each of x64 and x86,
1,200 hierarchy changes total, with zero failures/skips. See commit d7934c01fe7.

The internal lock schedule is not forced and native Windows has not been run.
The hierarchy snapshot is not an atomic Windows transaction; these tests do not
prove every interleaving. Arbitrary Vulkan-to-GDI child overlap
remains unsupported by the existing readback path. No Vulkan semaphore changes
are included.

Remain draft pending current-SHA CodeRabbit, Greptile and Sourcery review.
No merge requested or performed.

Evidence in the project workspace at `artifacts/plan14-next-steps-20260831/`:
`EXCEL-RESIZE-REGRESSION-20260906.md`, `resize-lockdiag-gl-office.log`,
`restack-fixed-gl-max-settled.png`, `restack-fixed-vk-max-settled.png`,
`restack-fixed-vk-dialog.png`, `restack-fixed-vk-stress-final.png`.

## Summary by Sourcery

Restore reliable Vulkan presentation for Excel on Wayland while making GPU surface restacking safe during window hierarchy changes.

Bug Fixes:
- Restore Excel worksheet and formula-bar visibility for Vulkan-rendered child surfaces on Wayland.
- Prevent window-restacking deadlocks during Excel resize and hierarchy updates.

Enhancements:
- Make Wayland GPU-surface restacking account for descendant ancestry and Z-order without relying on lock-taking Win32 ancestry lookups.

Tests:
- Add concurrent OpenGL surface tests covering rendering, reparenting, resizing, maximize/restore, redraw, ancestor recreation, and watchdog-bounded progress.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Restored Excel worksheet and formula-bar display when running through Vulkan on Wayland.
  - Prevented window-restacking deadlocks that could occur while resizing Excel windows on Wayland.
  - Improved OpenGL window-surface stability during concurrent resizing, reparenting, maximizing, restoring, and recreation.
  - Preserved native presentation behavior for Vulkan applications on Wayland.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->