### PR TITLE
ntdll: Restore Click-to-Run registry repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add X11/Wayland and OpenGL/Vulkan controls to the Manager's environment page.
+- Restore Outlook account setup after Office repairs its Click-to-Run registry data.
 - Restore Excel worksheets and formula bars when using Vulkan on Wayland.
 - Prevent a Wayland window-restacking deadlock when resizing Excel.
 - Fix distorted rounded selection borders around PowerPoint slide thumbnails.

--- a/dlls/ntdll/sec.c
+++ b/dlls/ntdll/sec.c
@@ -555,14 +555,66 @@ BOOLEAN WINAPI RtlValidSecurityDescriptor(PSECURITY_DESCRIPTOR descriptor)
     return sd && sd->Revision == SECURITY_DESCRIPTOR_REVISION;
 }
 
+static BOOLEAN valid_relative_sid( const SECURITY_DESCRIPTOR_RELATIVE *sd, ULONG length, ULONG offset )
+{
+    const SID *sid;
+
+    if ((offset & 3) || offset < sizeof(*sd) || offset > length ||
+        length - offset < offsetof(SID, SubAuthority)) return FALSE;
+    sid = (const SID *)((const char *)sd + offset);
+    return sid->Revision == SID_REVISION && sid->SubAuthorityCount <= SID_MAX_SUB_AUTHORITIES &&
+           offsetof(SID, SubAuthority[sid->SubAuthorityCount]) <= length - offset;
+}
+
+static BOOLEAN valid_relative_acl( const SECURITY_DESCRIPTOR_RELATIVE *sd, ULONG length, ULONG offset )
+{
+    const ACL *acl;
+    const ACE_HEADER *ace;
+    ULONG pos, i;
+
+    if ((offset & 3) || offset < sizeof(*sd) || offset > length || length - offset < sizeof(*acl))
+        return FALSE;
+    acl = (const ACL *)((const char *)sd + offset);
+    if (acl->AclSize < sizeof(*acl) || acl->AclSize > length - offset) return FALSE;
+
+    /* Check every header before passing the ACL to the unbounded validator. */
+    for (i = 0, pos = sizeof(*acl); i < acl->AceCount; ++i)
+    {
+        if (acl->AclSize - pos < sizeof(*ace)) return FALSE;
+        ace = (const ACE_HEADER *)((const char *)acl + pos);
+        if (ace->AceSize < sizeof(*ace) || (ace->AceSize & 3) || ace->AceSize > acl->AclSize - pos)
+            return FALSE;
+        pos += ace->AceSize;
+    }
+    return RtlValidAcl( (ACL *)acl );
+}
+
 /**************************************************************************
  * RtlValidRelativeSecurityDescriptor		[NTDLL.@]
  */
 BOOLEAN WINAPI RtlValidRelativeSecurityDescriptor(PSECURITY_DESCRIPTOR descriptor,
     ULONG length, SECURITY_INFORMATION info)
 {
-    FIXME("%p,%lu,%ld: semi-stub\n", descriptor, length, info);
-    return RtlValidSecurityDescriptor(descriptor) == STATUS_SUCCESS;
+    const SECURITY_DESCRIPTOR_RELATIVE *sd = descriptor;
+
+    TRACE("%p,%lu,%ld\n", descriptor, length, info);
+    if (!sd || length < sizeof(*sd) || sd->Revision != SECURITY_DESCRIPTOR_REVISION ||
+        !(sd->Control & SE_SELF_RELATIVE)) return FALSE;
+    if (sd->Owner)
+    {
+        if (!valid_relative_sid( sd, length, sd->Owner )) return FALSE;
+    }
+    else if (info & OWNER_SECURITY_INFORMATION) return FALSE;
+    if (sd->Group)
+    {
+        if (!valid_relative_sid( sd, length, sd->Group )) return FALSE;
+    }
+    else if (info & GROUP_SECURITY_INFORMATION) return FALSE;
+    if ((sd->Control & SE_SACL_PRESENT) && sd->Sacl && !valid_relative_acl( sd, length, sd->Sacl ))
+        return FALSE;
+    if ((sd->Control & SE_DACL_PRESENT) && sd->Dacl && !valid_relative_acl( sd, length, sd->Dacl ))
+        return FALSE;
+    return TRUE;
 }
 
 /**************************************************************************

--- a/dlls/ntdll/tests/file.c
+++ b/dlls/ntdll/tests/file.c
@@ -296,8 +296,8 @@ static void create_file_test(void)
         "open %s failed %lx\n", wine_dbgstr_w(nameW.Buffer), status );
 
     status = pNtQueryFullAttributesFile( &attr, &info );
-    todo_wine ok( status == STATUS_OBJECT_NAME_INVALID,
-                  "query %s failed %lx\n", wine_dbgstr_w(nameW.Buffer), status );
+    ok( status == STATUS_OBJECT_NAME_INVALID,
+        "query %s failed %lx\n", wine_dbgstr_w(nameW.Buffer), status );
 
     pRtlInitUnicodeString( &nameW, pathInvalidNt2W );
     status = pNtCreateFile( &dir, GENERIC_READ|SYNCHRONIZE, &attr, &io, NULL, 0,
@@ -320,6 +320,46 @@ static void create_file_test(void)
     status = pNtQueryFullAttributesFile( &attr, &info );
     ok( status == STATUS_OBJECT_NAME_INVALID,
         "query %s failed %lx\n", wine_dbgstr_w(nameW.Buffer), status );
+}
+
+static void test_query_missing_object_attributes(void)
+{
+    static const struct
+    {
+        const WCHAR *path;
+        NTSTATUS status;
+    } tests[] =
+    {
+        { L"\\??\\wine-test-missing-device", STATUS_OBJECT_NAME_NOT_FOUND },
+        { L"\\Device\\wine-test-missing-device", STATUS_OBJECT_NAME_NOT_FOUND },
+        { L"\\??\\wine-test-missing-device\\child", STATUS_OBJECT_PATH_NOT_FOUND },
+    };
+    FILE_NETWORK_OPEN_INFORMATION full;
+    FILE_BASIC_INFORMATION basic;
+    WIN32_FILE_ATTRIBUTE_DATA data;
+    OBJECT_ATTRIBUTES attr;
+    UNICODE_STRING name;
+    NTSTATUS status;
+    BOOL ret;
+    unsigned int i;
+
+    for (i = 0; i < ARRAY_SIZE(tests); ++i)
+    {
+        pRtlInitUnicodeString( &name, tests[i].path );
+        InitializeObjectAttributes( &attr, &name, OBJ_CASE_INSENSITIVE, NULL, NULL );
+        status = pNtQueryFullAttributesFile( &attr, &full );
+        ok( status == tests[i].status, "%s: full attributes returned %#lx\n",
+            wine_dbgstr_w(tests[i].path), status );
+        status = pNtQueryAttributesFile( &attr, &basic );
+        ok( status == tests[i].status, "%s: basic attributes returned %#lx\n",
+            wine_dbgstr_w(tests[i].path), status );
+    }
+    SetLastError( 0xdeadbeef );
+    ret = GetFileAttributesExW( L"\\\\?\\wine-test-missing-device", GetFileExInfoStandard, &data );
+    ok( !ret && GetLastError() == ERROR_FILE_NOT_FOUND, "got %d, error %lu\n", ret, GetLastError() );
+    SetLastError( 0xdeadbeef );
+    ret = GetFileAttributesExW( L"\\\\?\\NUL", GetFileExInfoStandard, &data );
+    ok( !ret && GetLastError() == ERROR_INVALID_PARAMETER, "got %d, error %lu\n", ret, GetLastError() );
 }
 
 static void open_file_test(void)
@@ -7570,6 +7610,7 @@ START_TEST(file)
     test_read_write();
     test_NtCreateFile();
     create_file_test();
+    test_query_missing_object_attributes();
     open_file_test();
     delete_file_test();
     read_file_test();

--- a/dlls/ntdll/tests/rtl.c
+++ b/dlls/ntdll/tests/rtl.c
@@ -3811,6 +3811,103 @@ static void test_RtlValidSecurityDescriptor(void)
     free(sd);
 }
 
+static void test_RtlValidRelativeSecurityDescriptor(void)
+{
+    union { SECURITY_DESCRIPTOR_RELATIVE sd; BYTE bytes[256]; } buffer;
+    SECURITY_DESCRIPTOR_RELATIVE *sd = &buffer.sd;
+    SID *sid = (SID *)(buffer.bytes + 32);
+    ACL *acl = (ACL *)(buffer.bytes + 128);
+    ACE_HEADER *ace = (ACE_HEADER *)(acl + 1);
+    ULONG i, field;
+    BOOLEAN ret;
+
+    memset( &buffer, 0, sizeof(buffer) );
+    sd->Revision = SECURITY_DESCRIPTOR_REVISION;
+    sd->Control = SE_SELF_RELATIVE;
+    for (i = 0; i <= sizeof(*sd); ++i)
+    {
+        ret = RtlValidRelativeSecurityDescriptor( sd, i, 0 );
+        ok( ret == (i == sizeof(*sd)), "length %lu: got %u\n", i, ret );
+    }
+    for (i = 1; i <= 0x100; i <<= 1)
+    {
+        ret = RtlValidRelativeSecurityDescriptor( sd, sizeof(buffer), i );
+        ok( ret == (i != OWNER_SECURITY_INFORMATION && i != GROUP_SECURITY_INFORMATION),
+            "required information %#lx: got %u\n", i, ret );
+    }
+    sd->Control = 0;
+    ok( !RtlValidRelativeSecurityDescriptor( sd, sizeof(buffer), 0 ), "accepted absolute descriptor\n" );
+    sd->Control = SE_SELF_RELATIVE;
+    sd->Revision = 2;
+    ok( !RtlValidRelativeSecurityDescriptor( sd, sizeof(buffer), 0 ), "accepted invalid revision\n" );
+    sd->Revision = 1;
+
+    for (field = 0; field < 2; ++field)
+    {
+        DWORD *offset = field ? &sd->Group : &sd->Owner;
+        *offset = 32;
+        sid->Revision = SID_REVISION;
+        for (i = 0; i <= SID_MAX_SUB_AUTHORITIES + 1; ++i)
+        {
+            sid->SubAuthorityCount = i;
+            ret = RtlValidRelativeSecurityDescriptor( sd, sizeof(buffer), 0 );
+            ok( ret == (i <= SID_MAX_SUB_AUTHORITIES), "field %lu SID count %lu: got %u\n", field, i, ret );
+        }
+        sid->SubAuthorityCount = 1;
+        ok( RtlValidRelativeSecurityDescriptor( sd, 44, field ? GROUP_SECURITY_INFORMATION : OWNER_SECURITY_INFORMATION ),
+            "rejected complete SID\n" );
+        ok( !RtlValidRelativeSecurityDescriptor( sd, 43, 0 ), "accepted truncated SID\n" );
+        ok( !RtlValidRelativeSecurityDescriptor( sd, 39, 0 ), "accepted truncated SID header\n" );
+        sid->Revision = 2;
+        ok( !RtlValidRelativeSecurityDescriptor( sd, sizeof(buffer), 0 ), "accepted invalid SID revision\n" );
+        sid->Revision = 1;
+        *offset = 0xfffffff0;
+        ok( !RtlValidRelativeSecurityDescriptor( sd, sizeof(buffer), 0 ), "accepted overflowing offset\n" );
+        *offset = 4;
+        ok( !RtlValidRelativeSecurityDescriptor( sd, sizeof(buffer), 0 ), "accepted header offset\n" );
+        *offset = 33;
+        buffer.bytes[33] = 1;
+        buffer.bytes[34] = 1;
+        ok( !RtlValidRelativeSecurityDescriptor( sd, sizeof(buffer), 0 ), "accepted unaligned SID\n" );
+        *offset = 0;
+    }
+    for (field = 0; field < 2; ++field)
+    {
+        DWORD *offset = field ? &sd->Sacl : &sd->Dacl;
+        sd->Control = SE_SELF_RELATIVE | (field ? SE_SACL_PRESENT : SE_DACL_PRESENT);
+        ok( RtlValidRelativeSecurityDescriptor( sd, sizeof(*sd), DACL_SECURITY_INFORMATION | SACL_SECURITY_INFORMATION ),
+            "rejected null ACL\n" );
+        *offset = 128;
+        acl->AclRevision = ACL_REVISION;
+        acl->AclSize = sizeof(*acl);
+        acl->AceCount = 0;
+        ok( RtlValidRelativeSecurityDescriptor( sd, 136, 0 ), "rejected empty ACL\n" );
+        ok( !RtlValidRelativeSecurityDescriptor( sd, 135, 0 ), "accepted truncated ACL\n" );
+        acl->AclSize = 7;
+        ok( !RtlValidRelativeSecurityDescriptor( sd, sizeof(buffer), 0 ), "accepted short ACL\n" );
+        acl->AclSize = 0xffff;
+        ok( !RtlValidRelativeSecurityDescriptor( sd, sizeof(buffer), 0 ), "accepted oversized ACL\n" );
+        acl->AclSize = sizeof(*acl);
+        for (i = 0; i <= 5; ++i)
+        {
+            acl->AclRevision = i;
+            ret = RtlValidRelativeSecurityDescriptor( sd, sizeof(buffer), 0 );
+            ok( ret == (i >= 2 && i <= 4), "ACL revision %lu: got %u\n", i, ret );
+        }
+        acl->AclRevision = ACL_REVISION;
+        acl->AceCount = 1;
+        ok( !RtlValidRelativeSecurityDescriptor( sd, sizeof(buffer), 0 ), "accepted missing ACE\n" );
+        acl->AclSize = sizeof(*acl) + sizeof(*ace);
+        ace->AceSize = 0;
+        ok( !RtlValidRelativeSecurityDescriptor( sd, sizeof(buffer), 0 ), "accepted zero-size ACE\n" );
+        ace->AceSize = 8;
+        ok( !RtlValidRelativeSecurityDescriptor( sd, sizeof(buffer), 0 ), "accepted oversized ACE\n" );
+        sd->Control = SE_SELF_RELATIVE;
+        ok( RtlValidRelativeSecurityDescriptor( sd, sizeof(buffer), 0 ), "checked non-present ACL\n" );
+        *offset = 0;
+    }
+}
+
 static void test_RtlFindExportedRoutineByName(void)
 {
     void *proc;
@@ -5590,6 +5687,7 @@ START_TEST(rtl)
     test_RtlFirstFreeAce();
     test_RtlInitializeSid();
     test_RtlValidSecurityDescriptor();
+    test_RtlValidRelativeSecurityDescriptor();
     test_RtlFindExportedRoutineByName();
     test_RtlGetDeviceFamilyInfoEnum();
     test_RtlConvertDeviceFamilyInfoToString();

--- a/dlls/ntdll/unix/file.c
+++ b/dlls/ntdll/unix/file.c
@@ -5035,6 +5035,37 @@ NTSTATUS WINAPI NtDeleteFile( OBJECT_ATTRIBUTES *attr )
 }
 
 
+static NTSTATUS query_object_attributes( OBJECT_ATTRIBUTES *attr, void *info, FILE_INFORMATION_CLASS class )
+{
+    int fd, needs_close;
+    unsigned int options;
+    struct stat st;
+    ULONG attributes;
+    HANDLE handle;
+    NTSTATUS status;
+
+    status = server_open_file_object( &handle, FILE_READ_ATTRIBUTES, attr,
+                                     FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                                     FILE_OPEN_REPARSE_POINT );
+    if (!status)
+    {
+        status = server_get_unix_fd( handle, 0, &fd, &needs_close, NULL, &options );
+        if (!status)
+        {
+            if (fd_get_file_info( handle, fd, options, &st, &attributes, NULL ) == -1)
+                status = errno_to_status( errno );
+            else if (!S_ISREG(st.st_mode) && !S_ISDIR(st.st_mode))
+                status = STATUS_INVALID_PARAMETER;
+            else
+                status = fill_file_info( &st, attributes, info, class );
+            if (needs_close) close( fd );
+        }
+        else if (status == STATUS_BAD_DEVICE_TYPE) status = STATUS_INVALID_PARAMETER;
+        NtClose( handle );
+    }
+    return status;
+}
+
 /******************************************************************************
  *              NtQueryFullAttributesFile   (NTDLL.@)
  */
@@ -5068,6 +5099,8 @@ NTSTATUS WINAPI NtQueryFullAttributesFile( const OBJECT_ATTRIBUTES *attr,
         else
             fill_file_info( &st, attributes, info, FileNetworkOpenInformation );
     }
+    else if (status == STATUS_BAD_DEVICE_TYPE)
+        status = query_object_attributes( &new_attr, info, FileNetworkOpenInformation );
     else WARN( "%s not found (%x)\n", debugstr_us(attr->ObjectName), status );
     free( unix_name );
     free( nt_name.Buffer );
@@ -5104,6 +5137,8 @@ NTSTATUS WINAPI NtQueryAttributesFile( const OBJECT_ATTRIBUTES *attr, FILE_BASIC
         else
             status = fill_file_info( &st, attributes, info, FileBasicInformation );
     }
+    else if (status == STATUS_BAD_DEVICE_TYPE)
+        status = query_object_attributes( &new_attr, info, FileBasicInformation );
     else WARN( "%s not found (%x)\n", debugstr_us(attr->ObjectName), status );
     free( unix_name );
     free( nt_name.Buffer );


### PR DESCRIPTION
## Summary

- validate self-relative security descriptors within the caller-supplied buffer before inspecting SIDs, ACLs, or ACEs
- query NT object-manager paths through the Wine server when they cannot be translated directly to Unix paths
- add native-compatible NTDLL regression coverage and document the Outlook repair result

## Cause

`RtlValidRelativeSecurityDescriptor` compared a BOOLEAN result with `STATUS_SUCCESS`, so it rejected every valid descriptor and ignored the supplied length and required fields. Microsoft OffReg consequently rejected valid Click-to-Run registry hives.

After fixing that validator, Office Full Repair reached a second incompatibility. Attribute queries for missing NT device paths returned `STATUS_BAD_DEVICE_TYPE` before consulting the object namespace. Click-to-Run interpreted the resulting Win32 error as a fatal uninstall failure.

## Validation

- focused combined WoW64 builds rebuilt both x86-64 and i386 NTDLL binaries and tests without warnings
- Wine `rtl` tests passed on x86-64 and i386; the i386 run executed 600,183 checks with zero failures
- native Windows `rtl` tests passed on x86-64 and i386 with zero failures
- native Windows `file` tests passed: 2,949 x86-64 checks and 2,959 i386 checks, both with zero failures
- the new Wine file-attribute cases return the native statuses on x86-64 and i386; the broader headless `file` suite still reports its existing unrelated reparse/directory failures
- Microsoft OffReg opens the original Outlook VREG hive and recursively enumerates all 3,985 descendant keys
- Office Full Repair restored all 32 Click-to-Run VREG hives from their empty 8 KiB placeholders; all 32 now contain data, totalling 11,681,792 bytes
- Classic Outlook opens its real account setup wizard and advances into the Microsoft identity provider instead of showing the `Not implemented` dialog

## Risk

The object-namespace fallback runs only after normal Unix path translation returns `STATUS_BAD_DEVICE_TYPE`, so ordinary filesystem paths keep the existing fast path. ACL validation reuses Wine's existing `RtlValidAcl` semantics after verifying every referenced structure and ACE header fits inside the supplied buffer.

## Evidence

The isolated Office environment and its logs, native comparison binaries, OffReg probes, and screenshots are retained under `artifacts/outlook-account-notimpl-20260906` and the task workspace on `keremreim-bardugonet`.

## Summary by Sourcery

Restore Click-to-Run registry repair and Outlook account setup by correcting relative security descriptor validation and NT object path attribute handling.

Bug Fixes:
- Restore validation of caller-supplied self-relative security descriptors so valid Click-to-Run registry hives are accepted.
- Resolve NT object-manager paths through the Wine server when direct Unix path translation cannot provide file attributes, restoring native-compatible status behavior.

Documentation:
- Document the restoration of Outlook account setup after Click-to-Run registry repair.

Tests:
- Add native-compatible NTDLL regression coverage for relative security descriptor validation and missing NT-object attribute queries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Restored Outlook account setup after Office repairs its Click-to-Run registry data.
  - Improved file attribute queries for device-backed paths, including more accurate handling of missing files and paths.
  - Improved validation of relative security descriptors, including embedded security identifiers, access control lists, and access control entries.
  - Corrected status reporting for invalid, missing, and unsupported file objects to improve application compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->