### PR TITLE
wined3d: use allocation serials for presentation buffer identities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Track graphics buffer allocations reliably when drivers reuse resource identifiers.
+
 - Prevent Office licensing repair from crashing while querying installed product keys.
 - Add X11/Wayland and OpenGL/Vulkan controls to the Manager's environment page.
 - Restore Outlook account setup after Office repairs its Click-to-Run registry data.

--- a/dlls/dxgi/dxgi.spec
+++ b/dlls/dxgi/dxgi.spec
@@ -6,3 +6,4 @@
 @ stdcall DXGIGetDebugInterface1(long ptr ptr)
 @ stdcall __wine_dxgi_bind_composition_window(long long)
 @ stdcall __wine_dxgi_set_composition_description(ptr ptr)
+@ stdcall -private __wine_dxgi_get_test_present_result(ptr ptr)

--- a/dlls/dxgi/swapchain.c
+++ b/dlls/dxgi/swapchain.c
@@ -291,6 +291,32 @@ HRESULT WINAPI __wine_dxgi_set_composition_description(IDXGISwapChain1 *iface,
 }
 
 
+/* Wine-only observation of the real backend completion, including diagnostic
+ * identities on backends that do not advertise sparse preservation. */
+HRESULT WINAPI __wine_dxgi_get_test_present_result(IDXGISwapChain1 *iface,
+        struct wined3d_swapchain_present_result *result)
+{
+    struct d3d11_swapchain *swapchain;
+    IDXGISwapChain4 *swapchain4;
+    HRESULT hr;
+
+    if (result)
+        memset(result, 0, sizeof(*result));
+    if (!iface || !result)
+        return E_INVALIDARG;
+    if (FAILED(hr = IDXGISwapChain1_QueryInterface(iface, &IID_IDXGISwapChain4, (void **)&swapchain4)))
+        return hr;
+    if (swapchain4->lpVtbl != &d3d11_swapchain_vtbl)
+    {
+        IDXGISwapChain4_Release(swapchain4);
+        return E_NOINTERFACE;
+    }
+    swapchain = d3d11_swapchain_from_IDXGISwapChain4(swapchain4);
+    hr = wined3d_swapchain_wait_present_result(swapchain->wined3d_swapchain, swapchain->last_present_id, result);
+    IDXGISwapChain4_Release(swapchain4);
+    return hr;
+}
+
 /* IUnknown methods */
 
 static HRESULT STDMETHODCALLTYPE d3d11_swapchain_QueryInterface(IDXGISwapChain4 *iface, REFIID riid, void **object)

--- a/dlls/dxgi/tests/dxgi.c
+++ b/dlls/dxgi/tests/dxgi.c
@@ -29,6 +29,7 @@
 #include "winternl.h"
 #include "ddk/d3dkmthk.h"
 #include "wine/test.h"
+#include "wine/wined3d.h"
 
 enum frame_latency
 {
@@ -6893,6 +6894,143 @@ static BOOL wait_present1_benchmark_query(ID3D11DeviceContext *context, ID3D11Qu
     return hr == S_OK;
 }
 
+static void test_swapchain_present_storage(void)
+{
+    HRESULT (WINAPI *get_result)(IDXGISwapChain1 *, struct wined3d_swapchain_present_result *);
+    struct wined3d_swapchain_present_result previous, result;
+    struct present1_lifetime_swapchain state;
+    ID3D11DeviceContext *context;
+    IDXGIFactory2 *factory2;
+    IDXGIFactory *factory;
+    IDXGIDevice *dxgi_device;
+    ID3D11Device *device;
+    ID3D11Texture2D *texture;
+    DWORD pixels[16 * 16];
+    unsigned int count, round, frame, i, j, k;
+    uint64_t retired[4] = {0};
+    uint64_t retired_generation = 0;
+    HRESULT hr;
+
+    get_result = (void *)GetProcAddress(GetModuleHandleA("dxgi.dll"), "__wine_dxgi_get_test_present_result");
+    if (!get_result)
+    {
+        win_skip("Wine backend completion observation is unavailable.\n");
+        return;
+    }
+    if (!(dxgi_device = create_d3d11_device()))
+    {
+        skip("D3D11 device is unavailable for storage rotation tests.\n");
+        return;
+    }
+    hr = IDXGIDevice_QueryInterface(dxgi_device, &IID_ID3D11Device, (void **)&device);
+    ok(hr == S_OK, "Failed to get device, hr %#lx.\n", hr);
+    if (FAILED(hr))
+        goto done_dxgi;
+    ID3D11Device_GetImmediateContext(device, &context);
+    get_factory((IUnknown *)dxgi_device, FALSE, &factory);
+    hr = IDXGIFactory_QueryInterface(factory, &IID_IDXGIFactory2, (void **)&factory2);
+    IDXGIFactory_Release(factory);
+    if (FAILED(hr))
+        goto done_device;
+
+    for (count = 2; count <= 4; ++count)
+    {
+        memset(&state, 0, sizeof(state));
+        state.width = state.height = 16;
+        state.buffer_count = count;
+        state.format = DXGI_FORMAT_R8G8B8A8_UNORM;
+        state.name = "physical-storage";
+        if (!init_present1_lifetime_swapchain(device, factory2, &state))
+        {
+            cleanup_present1_lifetime_swapchain(&state);
+            break;
+        }
+
+        for (round = 0; round < 2; ++round)
+        {
+            memset(&previous, 0, sizeof(previous));
+            for (i = 0; i < count; ++i)
+            {
+                for (j = 0; j < ARRAY_SIZE(pixels); ++j)
+                    pixels[j] = 0xff000000 | ((i + 1) * 0x10203);
+                hr = IDXGISwapChain1_GetBuffer(state.swapchain, 0, &IID_ID3D11Texture2D, (void **)&texture);
+                ok(hr == S_OK, "GetBuffer(%u) failed, hr %#lx.\n", i, hr);
+                if (FAILED(hr))
+                    goto done_state;
+                ID3D11DeviceContext_UpdateSubresource(context, (ID3D11Resource *)texture, 0, NULL,
+                        pixels, 16 * sizeof(*pixels), 0);
+                ID3D11Texture2D_Release(texture);
+                hr = IDXGISwapChain1_Present(state.swapchain, 0, 0);
+                ok(hr == S_OK, "Seeding Present failed, hr %#lx.\n", hr);
+            }
+            for (frame = 0; frame < 2 * count; ++frame)
+            {
+                winetest_push_context("buffers %u, round %u, frame %u", count, round, frame);
+                hr = IDXGISwapChain1_Present(state.swapchain, 0, 0);
+                ok(hr == S_OK, "Present failed, hr %#lx.\n", hr);
+                hr = get_result(state.swapchain, &result);
+                ok(hr == S_OK, "Completion query failed, hr %#lx.\n", hr);
+                if (FAILED(hr))
+                {
+                    winetest_pop_context();
+                    goto done_state;
+                }
+                ok(result.result == S_OK, "Backend failed, hr %#lx.\n", result.result);
+                ok(!!result.identity_generation, "Completion has no generation.\n");
+                if (round)
+                    ok(result.identity_generation != retired_generation, "Recreation kept the old generation.\n");
+                ok(result.physical_identity_count == count, "Got %u identities.\n", result.physical_identity_count);
+                for (i = 0; i < count; ++i)
+                {
+                    ok(!!result.physical_identities[i], "Buffer %u has no storage serial.\n", i);
+                    for (j = 0; j < i; ++j)
+                        ok(result.physical_identities[i] != result.physical_identities[j], "Aliased buffers %u/%u.\n", i, j);
+                    if (round)
+                        for (j = 0; j < count; ++j)
+                            ok(result.physical_identities[i] != retired[j], "Recreated buffer %u reused serial.\n", i);
+                    if (frame)
+                        ok(result.physical_identities[i] == previous.physical_identities[(i + 1) % count],
+                                "Serial for buffer %u did not follow storage rotation.\n", i);
+                    hr = IDXGISwapChain1_GetBuffer(state.swapchain, i, &IID_ID3D11Texture2D, (void **)&texture);
+                    ok(hr == S_OK, "GetBuffer(%u) failed, hr %#lx.\n", i, hr);
+                    if (SUCCEEDED(hr))
+                    {
+                        for (k = 0; k < ARRAY_SIZE(pixels); ++k)
+                            pixels[k] = 0xff000000 | ((((frame + 1 + i) % count) + 1) * 0x10203);
+                        check_present1_d3d11_frame_size(context, texture, state.staging, pixels, 16, 16, "rotation");
+                        ID3D11Texture2D_Release(texture);
+                    }
+                }
+                ok(result.presented_physical_identity == result.physical_identities[count - 1],
+                        "Presented serial does not identify the last buffer.\n");
+                ok(result.current_physical_identity == result.physical_identities[0], "Current serial mismatch.\n");
+                if (frame)
+                    ok(result.identity_generation == previous.identity_generation, "Rotation changed generation.\n");
+                previous = result;
+                winetest_pop_context();
+            }
+            memcpy(retired, result.physical_identities, count * sizeof(*retired));
+            retired_generation = result.identity_generation;
+            /* Change dimensions to require a new storage set. */
+            hr = IDXGISwapChain1_ResizeBuffers(state.swapchain, count, round ? 16 : 17, 16, state.format, 0);
+            ok(hr == S_OK, "ResizeBuffers failed, hr %#lx.\n", hr);
+            if (!round)
+            {
+                hr = IDXGISwapChain1_ResizeBuffers(state.swapchain, count, 16, 16, state.format, 0);
+                ok(hr == S_OK, "Restoring dimensions failed, hr %#lx.\n", hr);
+            }
+        }
+done_state:
+        cleanup_present1_lifetime_swapchain(&state);
+    }
+    IDXGIFactory2_Release(factory2);
+done_device:
+    ID3D11DeviceContext_Release(context);
+    ID3D11Device_Release(device);
+done_dxgi:
+    IDXGIDevice_Release(dxgi_device);
+}
+
 static void test_swapchain_present1_benchmark(void)
 {
     enum
@@ -11249,6 +11387,7 @@ START_TEST(dxgi)
         run_on_d3d10(test_swapchain_present1_history);
         test_swapchain_present1_scroll();
         test_swapchain_present1_lifetime();
+        test_swapchain_present_storage();
         return;
     }
 

--- a/dlls/dxgi/tests/dxgi.c
+++ b/dlls/dxgi/tests/dxgi.c
@@ -11431,6 +11431,7 @@ START_TEST(dxgi)
     run_on_d3d10(test_swapchain_present1_history);
     test_swapchain_present1_scroll();
     test_swapchain_present1_lifetime();
+    test_swapchain_present_storage();
     run_on_d3d10(test_swapchain_backbuffer_index);
     run_on_d3d10(test_swapchain_formats);
     run_on_d3d10(test_output_ownership);

--- a/dlls/wined3d/context_vk.c
+++ b/dlls/wined3d/context_vk.c
@@ -680,6 +680,7 @@ bool wined3d_context_vk_create_image(struct wined3d_context_vk *context_vk,
 
     create_info = *desc;
     image->vk_image = VK_NULL_HANDLE;
+    image->storage_serial = 0;
     image->vk_memory = VK_NULL_HANDLE;
     image->memory = NULL;
     image->command_buffer_id = 0;
@@ -840,6 +841,9 @@ bool wined3d_context_vk_create_image(struct wined3d_context_vk *context_vk,
         }
     }
 
+    image->storage_serial = wined3d_allocate_storage_serial();
+    TRACE("Created image %s, storage serial %s.\n", wine_dbgstr_longlong(image->vk_image),
+            wine_dbgstr_longlong(image->storage_serial));
     return true;
 }
 
@@ -1322,6 +1326,7 @@ void wined3d_context_vk_destroy_va_decoder(struct wined3d_context_vk *context_vk
 
 void wined3d_context_vk_destroy_image(struct wined3d_context_vk *context_vk, struct wined3d_image_vk *image)
 {
+    image->storage_serial = 0;
     wined3d_context_vk_destroy_vk_image(context_vk, image->vk_image, image->command_buffer_id);
     if (image->memory)
         wined3d_context_vk_destroy_allocator_block(context_vk, image->memory,

--- a/dlls/wined3d/resource.c
+++ b/dlls/wined3d/resource.c
@@ -28,6 +28,27 @@
 WINE_DEFAULT_DEBUG_CHANNEL(d3d);
 WINE_DECLARE_DEBUG_CHANNEL(d3d_perf);
 
+uint64_t wined3d_allocate_storage_serial(void)
+{
+    static DECLSPEC_ALIGN(8) LONG64 counter;
+    uint64_t previous;
+
+    /* Resource wrappers and backend object names may both be reused. Never
+     * recycle a serial, including on exhaustion; zero disables history. */
+    previous = InterlockedCompareExchange64(&counter, 0, 0);
+    for (;;)
+    {
+        uint64_t observed;
+
+        if (previous == UINT64_MAX)
+            return 0;
+        observed = InterlockedCompareExchange64(&counter, previous + 1, previous);
+        if (observed == previous)
+            return previous + 1;
+        previous = observed;
+    }
+}
+
 static void resource_check_usage(uint32_t usage, unsigned int access)
 {
     static const uint32_t handled = WINED3DUSAGE_DYNAMIC

--- a/dlls/wined3d/swapchain.c
+++ b/dlls/wined3d/swapchain.c
@@ -759,6 +759,7 @@ static void wined3d_swapchain_gl_rotate(struct wined3d_swapchain *swapchain, str
     struct wined3d_texture_sub_resource *sub_resource;
     struct wined3d_texture_gl *texture, *texture_prev;
     struct gl_texture tex0;
+    uint64_t rb_serial0;
     GLuint rb0;
     DWORD locations0;
     unsigned int i;
@@ -772,6 +773,7 @@ static void wined3d_swapchain_gl_rotate(struct wined3d_swapchain *swapchain, str
     /* Back buffer 0 is already in the draw binding. */
     tex0 = texture_prev->texture_rgb;
     rb0 = texture_prev->rb_multisample;
+    rb_serial0 = texture_prev->rb_multisample_serial;
     locations0 = texture_prev->t.sub_resources[0].locations;
 
     for (i = 1; i < swapchain->state.desc.backbuffer_count; ++i)
@@ -784,6 +786,7 @@ static void wined3d_swapchain_gl_rotate(struct wined3d_swapchain *swapchain, str
 
         texture_prev->texture_rgb = texture->texture_rgb;
         texture_prev->rb_multisample = texture->rb_multisample;
+        texture_prev->rb_multisample_serial = texture->rb_multisample_serial;
 
         wined3d_texture_validate_location(&texture_prev->t, 0, sub_resource->locations & supported_locations);
         wined3d_texture_invalidate_location(&texture_prev->t, 0, ~(sub_resource->locations & supported_locations));
@@ -793,6 +796,7 @@ static void wined3d_swapchain_gl_rotate(struct wined3d_swapchain *swapchain, str
 
     texture_prev->texture_rgb = tex0;
     texture_prev->rb_multisample = rb0;
+    texture_prev->rb_multisample_serial = rb_serial0;
 
     wined3d_texture_validate_location(&texture_prev->t, 0, locations0 & supported_locations);
     wined3d_texture_invalidate_location(&texture_prev->t, 0, ~(locations0 & supported_locations));
@@ -837,9 +841,9 @@ static uint64_t wined3d_swapchain_gl_get_physical_identity(struct wined3d_swapch
             wined3d_texture_gl(swapchain->back_buffers[backbuffer_idx]);
 
     if (texture_gl->texture_rgb.name)
-        return texture_gl->texture_rgb.name;
+        return texture_gl->texture_rgb.storage_serial;
     if (texture_gl->rb_multisample)
-        return (1ULL << 32) | texture_gl->rb_multisample;
+        return texture_gl->rb_multisample_serial;
     return 0;
 }
 
@@ -1893,7 +1897,7 @@ static HRESULT swapchain_vk_present(struct wined3d_swapchain *swapchain, const R
     else
     {
         wined3d_texture_load_location(back_buffer, 0, &context_vk->c, back_buffer->resource.draw_binding);
-        presented_identity = (uint64_t)wined3d_texture_vk(back_buffer)->image.vk_image;
+        presented_identity = wined3d_texture_vk(back_buffer)->image.storage_serial;
 
         vr = wined3d_swapchain_vk_blit(swapchain_vk, context_vk, src_rect, dst_rect, swap_interval,
                 &presentation_identity, &presentation_generation);
@@ -1949,8 +1953,8 @@ static HRESULT swapchain_vk_present(struct wined3d_swapchain *swapchain, const R
         {
             for (i = 0; i < swapchain->state.desc.backbuffer_count; ++i)
             {
-                if (!(result->physical_identities[i] = (uint64_t)
-                        wined3d_texture_vk(swapchain->back_buffers[i])->image.vk_image))
+                if (!(result->physical_identities[i] =
+                        wined3d_texture_vk(swapchain->back_buffers[i])->image.storage_serial))
                     break;
             }
             if (i != swapchain->state.desc.backbuffer_count)

--- a/dlls/wined3d/texture_gl.c
+++ b/dlls/wined3d/texture_gl.c
@@ -1267,6 +1267,7 @@ static void gltexture_delete(struct wined3d_device *device, const struct wined3d
     context_gl_resource_released(device, tex->name, FALSE);
     gl_info->gl_ops.gl.p_glDeleteTextures(1, &tex->name);
     tex->name = 0;
+    tex->storage_serial = 0;
 }
 
 /* The caller is responsible for binding the correct texture. */
@@ -2381,6 +2382,14 @@ void wined3d_texture_gl_prepare_texture(struct wined3d_texture_gl *texture_gl,
         wined3d_texture_gl_allocate_immutable_storage(texture_gl, internal, gl_info);
     else
         wined3d_texture_gl_allocate_mutable_storage(texture_gl, internal, format_gl, gl_info);
+    /* Refresh on every storage specification, even if the GL name is kept.
+     * A serial alone does not certify allocation or preservation success. */
+    if (!needs_separate_srgb_gl_texture(&context_gl->c, &texture_gl->t))
+        srgb = false;
+    wined3d_texture_gl_get_gl_texture(texture_gl, srgb)->storage_serial = wined3d_allocate_storage_serial();
+    TRACE("Specified texture %u storage, serial %s.\n",
+            wined3d_texture_gl_get_gl_texture(texture_gl, srgb)->name,
+            wine_dbgstr_longlong(wined3d_texture_gl_get_gl_texture(texture_gl, srgb)->storage_serial));
     texture_gl->t.flags |= alloc_flag;
 }
 
@@ -2401,6 +2410,7 @@ static void wined3d_texture_gl_prepare_rb(struct wined3d_texture_gl *texture_gl,
                 wined3d_resource_get_sample_count(&texture_gl->t.resource),
                 format_gl->internal, texture_gl->t.resource.width, texture_gl->t.resource.height);
         checkGLcall("glRenderbufferStorageMultisample()");
+        texture_gl->rb_multisample_serial = wined3d_allocate_storage_serial();
         TRACE("Created multisample rb %u.\n", texture_gl->rb_multisample);
     }
     else
@@ -2659,6 +2669,7 @@ static void wined3d_texture_gl_unload_location(struct wined3d_texture *texture,
                 context_gl_resource_released(texture_gl->t.resource.device, texture_gl->rb_multisample, TRUE);
                 context_gl->gl_info->fbo_ops.glDeleteRenderbuffers(1, &texture_gl->rb_multisample);
                 texture_gl->rb_multisample = 0;
+                texture_gl->rb_multisample_serial = 0;
             }
             break;
 

--- a/dlls/wined3d/texture_gl.c
+++ b/dlls/wined3d/texture_gl.c
@@ -2345,7 +2345,7 @@ static bool wined3d_texture_use_immutable_storage(const struct wined3d_texture *
 void wined3d_texture_gl_prepare_texture(struct wined3d_texture_gl *texture_gl,
         struct wined3d_context_gl *context_gl, bool srgb)
 {
-    uint32_t alloc_flag = srgb ? WINED3D_TEXTURE_SRGB_ALLOCATED : WINED3D_TEXTURE_RGB_ALLOCATED;
+    uint32_t alloc_flag;
     const struct wined3d_gl_info *gl_info = context_gl->gl_info;
     struct wined3d_resource *resource = &texture_gl->t.resource;
     const struct wined3d_format *format = resource->format;
@@ -2355,6 +2355,9 @@ void wined3d_texture_gl_prepare_texture(struct wined3d_texture_gl *texture_gl,
     TRACE("texture_gl %p, context_gl %p, srgb %d, format %s.\n",
             texture_gl, context_gl, srgb, debug_d3dformat(format->id));
 
+    if (!needs_separate_srgb_gl_texture(&context_gl->c, &texture_gl->t))
+        srgb = false;
+    alloc_flag = srgb ? WINED3D_TEXTURE_SRGB_ALLOCATED : WINED3D_TEXTURE_RGB_ALLOCATED;
     if (texture_gl->t.flags & alloc_flag)
         return;
 
@@ -2384,8 +2387,6 @@ void wined3d_texture_gl_prepare_texture(struct wined3d_texture_gl *texture_gl,
         wined3d_texture_gl_allocate_mutable_storage(texture_gl, internal, format_gl, gl_info);
     /* Refresh on every storage specification, even if the GL name is kept.
      * A serial alone does not certify allocation or preservation success. */
-    if (!needs_separate_srgb_gl_texture(&context_gl->c, &texture_gl->t))
-        srgb = false;
     wined3d_texture_gl_get_gl_texture(texture_gl, srgb)->storage_serial = wined3d_allocate_storage_serial();
     TRACE("Specified texture %u storage, serial %s.\n",
             wined3d_texture_gl_get_gl_texture(texture_gl, srgb)->name,

--- a/dlls/wined3d/wined3d_gl.h
+++ b/dlls/wined3d/wined3d_gl.h
@@ -946,6 +946,7 @@ struct gl_texture
 {
     struct wined3d_sampler_desc sampler_desc;
     GLuint name;
+    uint64_t storage_serial;
 };
 
 struct wined3d_renderbuffer_entry
@@ -964,6 +965,7 @@ struct wined3d_texture_gl
     GLenum target;
 
     GLuint rb_multisample;
+    uint64_t rb_multisample_serial;
     GLuint rb_resolved;
 
     struct list renderbuffers;

--- a/dlls/wined3d/wined3d_private.h
+++ b/dlls/wined3d/wined3d_private.h
@@ -3358,6 +3358,7 @@ HRESULT resource_init(struct wined3d_resource *resource, struct wined3d_device *
 void *resource_offset_map_pointer(struct wined3d_resource *resource, unsigned int sub_resource_idx,
         uint8_t *base_memory, const struct wined3d_box *box);
 void resource_unload(struct wined3d_resource *resource);
+uint64_t wined3d_allocate_storage_serial(void);
 HRESULT wined3d_resource_check_box_dimensions(struct wined3d_resource *resource,
         unsigned int sub_resource_idx, const struct wined3d_box *box);
 void wined3d_resource_free_sysmem(struct wined3d_resource *resource);

--- a/dlls/wined3d/wined3d_vk.h
+++ b/dlls/wined3d/wined3d_vk.h
@@ -405,6 +405,7 @@ void wined3d_bo_slab_vk_unmap(struct wined3d_bo_slab_vk *slab_vk,
 struct wined3d_image_vk
 {
     VkImage vk_image;
+    uint64_t storage_serial;
     struct wined3d_allocator_block *memory;
     VkDeviceMemory vk_memory;
     uint64_t command_buffer_id;


### PR DESCRIPTION
Driver handles and OpenGL texture names can be reused after storage is destroyed. Use backend-owned allocation serials for WineD3D presentation identities so a later allocation cannot inherit an earlier buffer identity. Serials follow back-buffer rotations and refresh when OpenGL storage is specified. Normalize shared sRGB storage selection before the allocation check to avoid respecifying an existing RGB allocation.

This is the isolated allocation-identity prerequisite from Plan 10 and issue #60. OpenGL sparse capabilities remain disabled; a serial alone does not certify successful GL allocation, preservation, or reset detection. The remaining lifecycle and reset work continues separately.

Validation: focused combined-WoW64 builds, affected consumers and canonical installation passed. Ten latest history lanes each executed 1,511 assertions with zero failures and zero skips: OpenGL normal/forced-full on x64/i386 under Wine Wayland and Xwayland, plus Vulkan x64 controls under both. Tests verify exact pixels and identity mapping across two rotations for 2/3/4 buffers and fresh identities after resize, and are registered in both focused and default suites. The full default suite was not rerun. The sRGB normalization fix additionally has source-path verification; no dedicated runtime regression for that path is claimed. GL remained fallback-only, with no performance improvement claimed.

Latest source: 094667fc5fa634c8a2a1e7c83143ef8f64878f2f on origin/main 8c75d686875be390185fced0565c50b17a5153b3. Existing unchanged surface.c void-pointer-arithmetic warnings remain. Raw evidence: /home/ttv20/Projects/wine-365/artifacts/plan10-gl-present1-20260907/serial-srgb/ and serial-srgb build/install logs in its parent. Earlier skipped-prefix attempts are excluded from passing evidence.

Independent fresh-context Astra/high review is satisfied on the latest source: https://github.com/ttv20/wine4office/pull/90#issuecomment-5576916438 . Both findings are FIXED: default test registration and sRGB allocation-state normalization. CodeRabbit confirmed the latter fix and resolved its thread. No findings were accepted as risks or deferred.

The configured automated-review gate remains blocked: Qodo reports reviews paused and Sourcery reports its weekly review budget exhausted. Greptile completed without findings on the latest head. CodeRabbit confirmed and resolved its finding through a scoped re-review, but its full-review status reports rate limiting. This PR is non-draft at the user's explicit request. No merge has been performed.
