### PR TITLE
Fix OpenGL presentation storage lifetime and reset invalidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Prevent OpenGL presentation from using released buffers or retaining history after context loss.
+
 - Track graphics buffer allocations reliably when drivers reuse resource identifiers.
 
 - Prevent Office licensing repair from crashing while querying installed product keys.

--- a/dlls/dxgi/dxgi.spec
+++ b/dlls/dxgi/dxgi.spec
@@ -7,3 +7,6 @@
 @ stdcall __wine_dxgi_bind_composition_window(long long)
 @ stdcall __wine_dxgi_set_composition_description(ptr ptr)
 @ stdcall -private __wine_dxgi_get_test_present_result(ptr ptr)
+
+@ stdcall -private __wine_dxgi_test_gl(ptr long long ptr)
+@ stdcall -private __wine_dxgi_peek_test_present_result(ptr ptr)

--- a/dlls/dxgi/swapchain.c
+++ b/dlls/dxgi/swapchain.c
@@ -18,6 +18,7 @@
  */
 
 #include "dxgi_private.h"
+#include "wine/wined3d_test.h"
 #include "wine/dcomp.h"
 
 #define VKD3D_NO_VULKAN_H
@@ -313,6 +314,54 @@ HRESULT WINAPI __wine_dxgi_get_test_present_result(IDXGISwapChain1 *iface,
     }
     swapchain = d3d11_swapchain_from_IDXGISwapChain4(swapchain4);
     hr = wined3d_swapchain_wait_present_result(swapchain->wined3d_swapchain, swapchain->last_present_id, result);
+    IDXGISwapChain4_Release(swapchain4);
+    return hr;
+}
+
+HRESULT WINAPI __wine_dxgi_peek_test_present_result(IDXGISwapChain1 *iface,
+        struct wined3d_swapchain_present_result *result)
+{
+    struct d3d11_swapchain *swapchain;
+    IDXGISwapChain4 *swapchain4;
+    HRESULT hr;
+
+    if (result)
+        memset(result, 0, sizeof(*result));
+    if (!iface || !result)
+        return E_INVALIDARG;
+    if (FAILED(hr = IDXGISwapChain1_QueryInterface(iface, &IID_IDXGISwapChain4, (void **)&swapchain4)))
+        return hr;
+    if (swapchain4->lpVtbl != &d3d11_swapchain_vtbl)
+    {
+        IDXGISwapChain4_Release(swapchain4);
+        return E_NOINTERFACE;
+    }
+    swapchain = d3d11_swapchain_from_IDXGISwapChain4(swapchain4);
+    hr = wined3d_swapchain_get_present_result(swapchain->wined3d_swapchain, swapchain->last_present_id, result);
+    IDXGISwapChain4_Release(swapchain4);
+    return hr;
+}
+
+HRESULT WINAPI __wine_dxgi_test_gl(IDXGISwapChain1 *iface, enum wined3d_gl_present_test action,
+        unsigned int buffer_idx, struct wined3d_gl_storage_test_result *result)
+{
+    struct d3d11_swapchain *swapchain;
+    IDXGISwapChain4 *swapchain4;
+    HRESULT hr;
+
+    if (result) memset(result, 0, sizeof(*result));
+    if (!iface || !result) return E_INVALIDARG;
+    if (FAILED(hr = IDXGISwapChain1_QueryInterface(iface, &IID_IDXGISwapChain4, (void **)&swapchain4)))
+        return hr;
+    if (swapchain4->lpVtbl != &d3d11_swapchain_vtbl)
+    {
+        IDXGISwapChain4_Release(swapchain4);
+        return E_NOINTERFACE;
+    }
+    swapchain = d3d11_swapchain_from_IDXGISwapChain4(swapchain4);
+    wined3d_mutex_lock();
+    hr = wined3d_swapchain_test_gl(swapchain->wined3d_swapchain, action, buffer_idx, result);
+    wined3d_mutex_unlock();
     IDXGISwapChain4_Release(swapchain4);
     return hr;
 }

--- a/dlls/dxgi/tests/dxgi.c
+++ b/dlls/dxgi/tests/dxgi.c
@@ -30,6 +30,8 @@
 #include "ddk/d3dkmthk.h"
 #include "wine/test.h"
 #include "wine/wined3d.h"
+#include "wine/wined3d_test.h"
+#include "wine/dcomp.h"
 
 enum frame_latency
 {
@@ -7031,6 +7033,203 @@ done_dxgi:
     IDXGIDevice_Release(dxgi_device);
 }
 
+static void test_swapchain_present_gl(void)
+{
+    HRESULT (WINAPI *test_gl)(IDXGISwapChain1 *, enum wined3d_gl_present_test,
+            unsigned int, struct wined3d_gl_storage_test_result *);
+    HRESULT (WINAPI *get_result)(IDXGISwapChain1 *, struct wined3d_swapchain_present_result *);
+    HRESULT (WINAPI *peek_result)(IDXGISwapChain1 *, struct wined3d_swapchain_present_result *);
+    HRESULT (WINAPI *set_composition)(IDXGISwapChain1 *, const struct wine_dcomp_visual_desc *);
+    struct wine_dcomp_visual_desc composition = {0};
+    struct wined3d_gl_storage_test_result before, after;
+    struct wined3d_swapchain_present_result result;
+    struct present1_lifetime_swapchain state = {0}, shared_state = {0}, other_state = {0};
+    struct wined3d_gl_storage_test_result shared_before, shared_after;
+    DWORD shared_expected[16 * 16], other_expected[16 * 16];
+    IDXGIDevice *other_dxgi_device = NULL;
+    ID3D11Device *other_device = NULL;
+    ID3D11DeviceContext *other_context = NULL;
+    ID3D11DeviceContext *context;
+    IDXGIFactory2 *factory2;
+    IDXGIFactory *factory;
+    IDXGIDevice *dxgi_device;
+    ID3D11Device *device;
+    DWORD pixels[16 * 16], expected[16 * 16];
+    unsigned int action, i;
+    HRESULT hr;
+
+    test_gl = (void *)GetProcAddress(GetModuleHandleA("dxgi.dll"), "__wine_dxgi_test_gl");
+    get_result = (void *)GetProcAddress(GetModuleHandleA("dxgi.dll"), "__wine_dxgi_get_test_present_result");
+    peek_result = (void *)GetProcAddress(GetModuleHandleA("dxgi.dll"), "__wine_dxgi_peek_test_present_result");
+    set_composition = (void *)GetProcAddress(GetModuleHandleA("dxgi.dll"), "__wine_dxgi_set_composition_description");
+    if (!test_gl || !get_result || !peek_result || !set_composition)
+    {
+        win_skip("Wine GL presentation hooks are unavailable.\n");
+        return;
+    }
+    if (!(dxgi_device = create_d3d11_device())) return;
+    hr = IDXGIDevice_QueryInterface(dxgi_device, &IID_ID3D11Device, (void **)&device);
+    ok(hr == S_OK, "Failed to get D3D11 device, hr %#lx.\n", hr);
+    if (FAILED(hr)) goto done_dxgi;
+    ID3D11Device_GetImmediateContext(device, &context);
+    get_factory((IUnknown *)dxgi_device, FALSE, &factory);
+    hr = IDXGIFactory_QueryInterface(factory, &IID_IDXGIFactory2, (void **)&factory2);
+    IDXGIFactory_Release(factory);
+    if (FAILED(hr)) goto done_device;
+    state.width = state.height = 16;
+    state.buffer_count = 2;
+    state.format = DXGI_FORMAT_R8G8B8A8_UNORM;
+    state.name = "GL-storage-lifecycle";
+    state.expected = expected;
+    if (!init_present1_lifetime_swapchain(device, factory2, &state)) goto done_state;
+    hr = test_gl(state.swapchain, WINED3D_GL_TEST_OBSERVE, 0, &before);
+    if (hr == WINED3DERR_NOTAVAILABLE) goto done_state; /* Other renderer control. */
+    ok(hr == S_OK, "GL observation failed, hr %#lx.\n", hr);
+    if (FAILED(hr)) goto done_state;
+
+    for (i = 0; i < state.buffer_count; ++i)
+    {
+        hr = test_gl(state.swapchain, WINED3D_GL_TEST_MUTABLE_STORAGE, i, &after);
+        ok(hr == S_OK, "Mutable storage setup failed, hr %#lx.\n", hr);
+    }
+    if (!seed_present1_lifetime_swapchain(context, &state, 0xff123456, pixels)) goto done_state;
+    for (action = WINED3D_GL_TEST_REUSE_NAME; action <= WINED3D_GL_TEST_REDEFINE_STORAGE; ++action)
+    {
+        hr = test_gl(state.swapchain, WINED3D_GL_TEST_OBSERVE, 0, &before);
+        ok(hr == S_OK, "Observation failed, hr %#lx.\n", hr);
+        hr = test_gl(state.swapchain, action, 0, &after);
+        ok(hr == S_OK, "Storage action %u failed, hr %#lx.\n", action, hr);
+        ok(after.name == before.name, "Action %u changed numeric name %u to %u.\n", action, before.name, after.name);
+        ok(after.storage_serial && after.storage_serial != before.storage_serial,
+                "Action %u reused allocation serial.\n", action);
+        ok(after.identity_generation == before.identity_generation + 1,
+                "Action %u did not invalidate exactly one generation.\n", action);
+        hr = IDXGISwapChain1_Present(state.swapchain, 0, 0);
+        ok(hr == S_OK, "Post-replacement Present failed, hr %#lx.\n", hr);
+        hr = get_result(state.swapchain, &result);
+        ok(hr == S_OK && result.result == S_OK, "Post-replacement completion failed, hr %#lx / %#lx.\n",
+                hr, result.result);
+        ok(result.presented_physical_identity == after.storage_serial, "Presented allocation mismatch.\n");
+        check_present1_lifetime_swapchain(context, &state, "replacement pixels");
+    }
+    for (action = WINED3D_GL_TEST_SWAP_FAILURE; action <= WINED3D_GL_TEST_STALE_COMPLETION; ++action)
+    {
+        hr = test_gl(state.swapchain, action, 0, &before);
+        ok(hr == S_OK, "Failed to arm action %u, hr %#lx.\n", action, hr);
+        hr = IDXGISwapChain1_Present(state.swapchain, 0, 0);
+        ok(hr == S_OK, "Asynchronous Present returned %#lx.\n", hr);
+        hr = get_result(state.swapchain, &result);
+        if (action == WINED3D_GL_TEST_STALE_COMPLETION)
+            ok(hr == WINED3DERR_NOTAVAILABLE, "Stale completion survived invalidation, hr %#lx.\n", hr);
+        else
+        {
+            ok(hr == S_OK, "Completion query failed, hr %#lx.\n", hr);
+            if (action != WINED3D_GL_TEST_BACKUP_DC)
+                ok(FAILED(result.result), "Action %u published successful completion.\n", action);
+        }
+        ok(!result.capabilities, "Action %u published sparse capabilities %#x.\n", action, result.capabilities);
+        hr = IDXGISwapChain1_Present(state.swapchain, 0, 0);
+        ok(hr == S_OK, "Recovery Present failed, hr %#lx.\n", hr);
+        hr = get_result(state.swapchain, &result);
+        ok(hr == S_OK && result.result == S_OK, "Recovery completion failed, hr %#lx / %#lx.\n", hr, result.result);
+    }
+
+    hr = test_gl(state.swapchain, WINED3D_GL_TEST_PENDING, 0, &after);
+    ok(hr == S_OK && after.completion_gate, "Failed to arm pending completion, hr %#lx.\n", hr);
+    if (SUCCEEDED(hr) && after.completion_gate)
+    {
+        hr = IDXGISwapChain1_Present(state.swapchain, 0, 0);
+        ok(hr == S_OK, "Queued Present failed, hr %#lx.\n", hr);
+        hr = peek_result(state.swapchain, &result);
+        ok(hr == S_FALSE, "Blocked completion returned %#lx.\n", hr);
+        ok(!result.capabilities, "Pending completion exposed capabilities.\n");
+        SetEvent(after.completion_gate);
+        CloseHandle(after.completion_gate);
+        hr = get_result(state.swapchain, &result);
+        ok(hr == S_OK && result.result == S_OK, "Unblocked completion failed, hr %#lx / %#lx.\n", hr, result.result);
+    }
+    composition.version = WINE_DCOMP_VISUAL_DESC_VERSION;
+    composition.flags = WINE_DCOMP_VISUAL_RENDERER_ACTIVE;
+    hr = set_composition(state.swapchain, &composition);
+    ok(hr == S_OK, "Failed to activate composition, hr %#lx.\n", hr);
+    hr = IDXGISwapChain1_Present(state.swapchain, 0, 0);
+    ok(hr == S_OK, "Composition Present failed, hr %#lx.\n", hr);
+    hr = get_result(state.swapchain, &result);
+    ok(hr == S_OK, "Composition completion query failed, hr %#lx.\n", hr);
+    ok(!result.capabilities, "Composition exposed sparse capabilities.\n");
+    hr = set_composition(state.swapchain, NULL);
+    ok(hr == S_OK, "Failed to clear composition, hr %#lx.\n", hr);
+
+    shared_state.width = shared_state.height = 16;
+    shared_state.buffer_count = 2;
+    shared_state.format = state.format;
+    shared_state.expected = shared_expected;
+    shared_state.name = "GL-shared-reset";
+    if (!init_present1_lifetime_swapchain(device, factory2, &shared_state)) goto done_state;
+    if (!seed_present1_lifetime_swapchain(context, &shared_state, 0xff654321, pixels)) goto done_state;
+    hr = test_gl(shared_state.swapchain, WINED3D_GL_TEST_OBSERVE, 0, &shared_before);
+    ok(hr == S_OK, "Shared observation failed, hr %#lx.\n", hr);
+    /* Separate D3D devices still share win32u's native GL storage domain. */
+    if (!(other_dxgi_device = create_d3d11_device())) goto done_state;
+    hr = IDXGIDevice_QueryInterface(other_dxgi_device, &IID_ID3D11Device, (void **)&other_device);
+    ok(hr == S_OK, "Failed to get independent device, hr %#lx.\n", hr);
+    if (FAILED(hr)) goto done_state;
+    ID3D11Device_GetImmediateContext(other_device, &other_context);
+    other_state.width = other_state.height = 16;
+    other_state.buffer_count = 2;
+    other_state.format = state.format;
+    other_state.expected = other_expected;
+    other_state.name = "GL-other-device-reset";
+    if (!init_present1_lifetime_swapchain(other_device, factory2, &other_state)) goto done_state;
+    if (!seed_present1_lifetime_swapchain(other_context, &other_state, 0xff112233, pixels)) goto done_state;
+    hr = test_gl(state.swapchain, WINED3D_GL_TEST_RESET, 0, &before);
+    if (hr != WINED3DERR_NOTAVAILABLE)
+    {
+        ok(hr == S_OK, "Failed to arm reset, hr %#lx.\n", hr);
+        hr = IDXGISwapChain1_Present(state.swapchain, 0, 0);
+        ok(hr == S_OK, "Asynchronous reset Present failed, hr %#lx.\n", hr);
+        hr = get_result(state.swapchain, &result);
+        ok(hr == WINED3DERR_NOTAVAILABLE && !result.capabilities,
+                "Reset completion was published, hr %#lx, caps %#x.\n", hr, result.capabilities);
+        hr = get_result(shared_state.swapchain, &result);
+        ok(hr == WINED3DERR_NOTAVAILABLE, "Shared swapchain retained its old completion, hr %#lx.\n", hr);
+        hr = test_gl(shared_state.swapchain, WINED3D_GL_TEST_OBSERVE, 0, &shared_after);
+        ok(hr == S_OK, "Shared post-reset observation failed, hr %#lx.\n", hr);
+        ok(shared_after.identity_generation == shared_before.identity_generation + 1,
+                "Reset did not invalidate the other swapchain exactly once.\n");
+        hr = IDXGISwapChain1_Present(state.swapchain, 0, 0);
+        ok(hr == S_OK, "Post-reset submission failed, hr %#lx.\n", hr);
+        hr = get_result(state.swapchain, &result);
+        ok(hr == S_OK && FAILED(result.result) && !result.capabilities,
+                "Lost storage became successful again, hr %#lx, result %#lx.\n", hr, result.result);
+        hr = get_result(other_state.swapchain, &result);
+        ok(hr == WINED3DERR_NOTAVAILABLE && !result.capabilities,
+                "Independent device retained old completion, hr %#lx.\n", hr);
+        hr = IDXGISwapChain1_Present(other_state.swapchain, 0, 0);
+        ok(hr == S_OK, "Independent lost-device submission failed, hr %#lx.\n", hr);
+        hr = get_result(other_state.swapchain, &result);
+        ok(hr == S_OK && FAILED(result.result) && !result.capabilities,
+                "Independent device revived lost storage, hr %#lx, result %#lx.\n", hr, result.result);
+        trace("GL reset notification handler exercised across devices.\n");
+    }
+    else
+        trace("GL reset notification unavailable; reset-injection lane not executed.\n");
+
+done_state:
+    cleanup_present1_lifetime_swapchain(&other_state);
+    if (other_context) ID3D11DeviceContext_Release(other_context);
+    if (other_device) ID3D11Device_Release(other_device);
+    if (other_dxgi_device) IDXGIDevice_Release(other_dxgi_device);
+    cleanup_present1_lifetime_swapchain(&shared_state);
+    cleanup_present1_lifetime_swapchain(&state);
+    IDXGIFactory2_Release(factory2);
+done_device:
+    ID3D11DeviceContext_Release(context);
+    ID3D11Device_Release(device);
+done_dxgi:
+    IDXGIDevice_Release(dxgi_device);
+}
+
 static void test_swapchain_present1_benchmark(void)
 {
     enum
@@ -11330,6 +11529,7 @@ START_TEST(dxgi)
     HMODULE dxgi_module, d3d11_module, d3d12_module, gdi32_module, kernelbase_module;
     BOOL enable_debug_layer = FALSE;
     BOOL present1_history_only = FALSE;
+    BOOL present1_gl_only = FALSE;
     BOOL present1_benchmark = FALSE;
     unsigned int argc, i;
     ID3D12Debug *debug;
@@ -11373,6 +11573,8 @@ START_TEST(dxgi)
             use_mt = FALSE;
         else if (!strcmp(argv[i], "--present1-history-only"))
             present1_history_only = TRUE;
+        else if (!strcmp(argv[i], "--present1-gl-only"))
+            present1_gl_only = TRUE;
         else if (!strcmp(argv[i], "--present1-benchmark"))
             present1_benchmark = TRUE;
     }
@@ -11382,12 +11584,19 @@ START_TEST(dxgi)
         test_swapchain_present1_benchmark();
         return;
     }
+    if (present1_gl_only)
+    {
+        test_swapchain_present_gl();
+        return;
+    }
+
     if (present1_history_only)
     {
         run_on_d3d10(test_swapchain_present1_history);
         test_swapchain_present1_scroll();
         test_swapchain_present1_lifetime();
         test_swapchain_present_storage();
+        test_swapchain_present_gl();
         return;
     }
 
@@ -11445,6 +11654,10 @@ START_TEST(dxgi)
     run_on_d3d10(test_resize_target_wndproc);
     run_on_d3d10(test_swapchain_window_messages);
     run_on_d3d10(test_zero_size);
+
+    /* Reset injection permanently loses the native GL share group, so this
+     * must be the last test using WineD3D OpenGL in this process. */
+    test_swapchain_present_gl();
 
     if (!(d3d12_module = LoadLibraryA("d3d12.dll")))
     {

--- a/dlls/opengl32/make_opengl
+++ b/dlls/opengl32/make_opengl
@@ -189,6 +189,7 @@ sub manual_unix_thunks($)
     return "glFlush"                        if $name =~ /^glFlush$/;
     return "glViewport"                     if $name =~ /^glViewport$/;
     return "glGetError"                     if $name =~ /^glGetError$/;
+    return "glGetGraphicsResetStatus"       if $name =~ /^glGetGraphicsResetStatus/;
 
     return "glGetBooleanv"                  if $name =~ /^glGetBooleanv/;
     return "glGetDoublev"                   if $name =~ /^glGetDoublev/;
@@ -1303,6 +1304,7 @@ sub get_integer_call($)
     return 0 if !$pname;
     return 0 if $name !~ /^glGet/;
 
+    $to_val = "!!" if $name =~ /^glGetBoolean/;
     my $hook = "if (get_integer( $pname, $index, $to_int*$params, &integer )) *$params = $to_val" . "integer;";
     return $hook if $name =~ /^glGet(Boolean|Double|Fixed|Float|Integer|Pointer|UnsignedByte)/;
     return $hook if $name =~ /^glGet(Multi)?Tex(ture)?LevelParameter/;

--- a/dlls/opengl32/tests/opengl.c
+++ b/dlls/opengl32/tests/opengl.c
@@ -5292,6 +5292,104 @@ static void test_memory_map( HDC hdc)
     wglMakeCurrent( hdc, old_rc );
 }
 
+static void test_reset_notification( HDC hdc )
+{
+    static const GLint strategies[] = {WGL_NO_RESET_NOTIFICATION_ARB, WGL_LOSE_CONTEXT_ON_RESET_ARB};
+    GLenum (WINAPI *get_reset_status)(void);
+    HGLRC old = wglGetCurrentContext(), context, shared, incompatible;
+    const char *extensions;
+    GLint actual, attribs[] = {WGL_CONTEXT_MAJOR_VERSION_ARB, 2,
+            WGL_CONTEXT_MINOR_VERSION_ARB, 1, WGL_CONTEXT_RESET_NOTIFICATION_STRATEGY_ARB, 0, 0};
+    GLuint texture;
+    unsigned int pixel, expected = 0xff4080c0;
+    GLfloat value_float;
+    GLdouble value_double;
+    GLboolean value_boolean;
+    unsigned int i;
+
+    if (!ext.wglGetExtensionsStringARB || !ext.wglCreateContextAttribsARB
+            || !(extensions = ext.wglGetExtensionsStringARB( hdc ))
+            || !strstr( extensions, "WGL_ARB_create_context_robustness" ))
+    {
+        win_skip( "WGL_ARB_create_context_robustness is unavailable.\n" );
+        return;
+    }
+
+    for (i = 0; i < ARRAY_SIZE(strategies); ++i)
+    {
+        winetest_push_context( "strategy %#x", strategies[i] );
+        attribs[5] = strategies[i];
+        context = ext.wglCreateContextAttribsARB( hdc, NULL, attribs );
+        ok( !!context, "Failed to create context, error %lu.\n", GetLastError() );
+        if (!context)
+        {
+            winetest_pop_context();
+            continue;
+        }
+        ok( wglMakeCurrent( hdc, context ), "Failed to make context current.\n" );
+        actual = 0;
+        glGetIntegerv( GL_RESET_NOTIFICATION_STRATEGY_ARB, &actual );
+        ok( glGetError() == GL_NO_ERROR, "Reset strategy query failed.\n" );
+        ok( actual == strategies[i], "Got strategy %#x, expected %#x.\n", actual, strategies[i] );
+        value_float = value_double = 0;
+        glGetFloatv( GL_RESET_NOTIFICATION_STRATEGY_ARB, &value_float );
+        glGetDoublev( GL_RESET_NOTIFICATION_STRATEGY_ARB, &value_double );
+        ok( value_float == strategies[i], "Float reset strategy %f.\n", value_float );
+        ok( value_double == strategies[i], "Double reset strategy %f.\n", value_double );
+        value_boolean = GL_FALSE;
+        glGetBooleanv( GL_RESET_NOTIFICATION_STRATEGY_ARB, &value_boolean );
+        ok( value_boolean == GL_TRUE, "Boolean reset strategy %#x.\n", value_boolean );
+        glGenTextures( 1, &texture );
+        glBindTexture( GL_TEXTURE_2D, texture );
+        glTexImage2D( GL_TEXTURE_2D, 0, GL_RGBA8, 1, 1, 0, GL_RGBA, GL_UNSIGNED_BYTE, &expected );
+        ok( glGetError() == GL_NO_ERROR, "Texture allocation failed.\n" );
+
+        get_reset_status = (void *)wglGetProcAddress( "glGetGraphicsResetStatusARB" );
+        ok( !!get_reset_status, "Reset status function is unavailable.\n" );
+        if (get_reset_status)
+            ok( get_reset_status() == GL_NO_ERROR, "Fresh context reports a reset.\n" );
+
+        attribs[5] = strategies[!i];
+        incompatible = ext.wglCreateContextAttribsARB( hdc, context, attribs );
+        ok( !incompatible, "Created a context sharing a different reset strategy.\n" );
+        if (incompatible) wglDeleteContext( incompatible );
+        incompatible = ext.wglCreateContextAttribsARB( hdc, NULL, attribs );
+        ok( !!incompatible, "Failed to create independent context with different strategy.\n" );
+        if (incompatible)
+        {
+            ok( !wglShareLists( context, incompatible ), "Shared lists between different reset strategies.\n" );
+            wglDeleteContext( incompatible );
+        }
+        attribs[5] = strategies[i];
+
+        shared = ext.wglCreateContextAttribsARB( hdc, context, attribs );
+        ok( !!shared, "Failed to create a context with the same sharing strategy.\n" );
+        if (shared)
+        {
+            ok( wglMakeCurrent( hdc, shared ), "Failed to make shared context current.\n" );
+            actual = 0;
+            glGetIntegerv( GL_RESET_NOTIFICATION_STRATEGY_ARB, &actual );
+            ok( actual == strategies[i], "Shared context has strategy %#x.\n", actual );
+            ok( glGetError() == GL_NO_ERROR, "Shared reset query failed.\n" );
+            glBindTexture( GL_TEXTURE_2D, texture );
+            pixel = 0;
+            glGetTexImage( GL_TEXTURE_2D, 0, GL_RGBA, GL_UNSIGNED_BYTE, &pixel );
+            ok( pixel == expected, "Shared texture has pixel %#x, expected %#x.\n", pixel, expected );
+            ok( glGetError() == GL_NO_ERROR, "Shared texture read failed.\n" );
+            glClearColor( 1.0f, 0.0f, 0.0f, 1.0f );
+            glClear( GL_COLOR_BUFFER_BIT );
+            ok( SwapBuffers( hdc ), "Failed to present with reset strategy %#x.\n", strategies[i] );
+            glDeleteTextures( 1, &texture );
+            ok( wglMakeCurrent( hdc, old ), "Failed to restore original context.\n" );
+            ok( wglDeleteContext( shared ), "Failed to delete shared context.\n" );
+        }
+        else
+            wglMakeCurrent( hdc, old );
+        ok( wglDeleteContext( context ), "Failed to delete context.\n" );
+        winetest_pop_context();
+    }
+}
+
 START_TEST(opengl)
 {
     const PIXELFORMATDESCRIPTOR pfd =
@@ -5309,6 +5407,13 @@ START_TEST(opengl)
     HGLRC hglrc;
     HWND hwnd;
     HDC hdc;
+    char **argv;
+    int argc, i;
+    BOOL reset_only = FALSE;
+
+    argc = winetest_get_mainargs( &argv );
+    for (i = 2; i < argc; ++i)
+        if (!strcmp( argv[i], "--reset-notification-only" )) reset_only = TRUE;
 
     pD3DKMTCreateDCFromMemory = (void *)GetProcAddress( gdi32, "D3DKMTCreateDCFromMemory" );
     pD3DKMTDestroyDCFromMemory = (void *)GetProcAddress( gdi32, "D3DKMTDestroyDCFromMemory" );
@@ -5334,6 +5439,21 @@ START_TEST(opengl)
     ok_ptr( glGetString( GL_RENDERER ), ==, NULL );
     ok_ptr( glGetString( GL_VERSION ), ==, NULL );
     ok_ptr( glGetString( GL_VENDOR ), ==, NULL );
+
+    if (reset_only)
+    {
+        hglrc = wglCreateContext( hdc );
+        ok( !!hglrc, "Failed to create initial context.\n" );
+        if (hglrc)
+        {
+            ok( wglMakeCurrent( hdc, hglrc ), "Failed to make initial context current.\n" );
+            init_functions();
+            test_reset_notification( hdc );
+            wglMakeCurrent( NULL, NULL );
+            wglDeleteContext( hglrc );
+        }
+        goto cleanup;
+    }
 
     test_bitmap_rendering( TRUE );
     test_bitmap_rendering( FALSE );
@@ -5405,6 +5525,7 @@ START_TEST(opengl)
     {
         test_wglCreateContextAttribsARB( hdc );
         test_object_creation( hdc );
+        test_reset_notification( hdc );
     }
 
     if (strstr( wgl_extensions, "WGL_ARB_make_current_read" ))

--- a/dlls/opengl32/thunks.c
+++ b/dlls/opengl32/thunks.c
@@ -941,7 +941,7 @@ void WINAPI glGetBooleanv( GLenum pname, GLboolean *data )
     int integer;
     TRACE( "pname %d, data %p\n", pname, data );
     if ((status = UNIX_CALL( glGetBooleanv, &args ))) WARN( "glGetBooleanv returned %#lx\n", status );
-    else if (get_integer( pname, 0, *data, &integer )) *data = integer;
+    else if (get_integer( pname, 0, *data, &integer )) *data = !!integer;
 }
 
 void WINAPI glGetClipPlane( GLenum plane, GLdouble *equation )
@@ -9181,7 +9181,7 @@ static void WINAPI glGetBooleanIndexedvEXT( GLenum target, GLuint index, GLboole
     int integer;
     TRACE( "target %d, index %d, data %p\n", target, index, data );
     if ((status = UNIX_CALL( glGetBooleanIndexedvEXT, &args ))) WARN( "glGetBooleanIndexedvEXT returned %#lx\n", status );
-    else if (get_integer( target, index, *data, &integer )) *data = integer;
+    else if (get_integer( target, index, *data, &integer )) *data = !!integer;
 }
 
 static void WINAPI glGetBooleani_v( GLenum target, GLuint index, GLboolean *data )
@@ -9191,7 +9191,7 @@ static void WINAPI glGetBooleani_v( GLenum target, GLuint index, GLboolean *data
     int integer;
     TRACE( "target %d, index %d, data %p\n", target, index, data );
     if ((status = UNIX_CALL( glGetBooleani_v, &args ))) WARN( "glGetBooleani_v returned %#lx\n", status );
-    else if (get_integer( target, index, *data, &integer )) *data = integer;
+    else if (get_integer( target, index, *data, &integer )) *data = !!integer;
 }
 
 static void WINAPI glGetBufferParameteri64v( GLenum target, GLenum pname, GLint64 *params )

--- a/dlls/opengl32/unix_thunks.c
+++ b/dlls/opengl32/unix_thunks.c
@@ -9613,7 +9613,7 @@ static NTSTATUS ext_glGetGraphicsResetStatus( void *args )
     struct glGetGraphicsResetStatus_params *params = args;
     const struct opengl_funcs *funcs = params->teb->glTable;
     if (!funcs->p_glGetGraphicsResetStatus) return STATUS_NOT_IMPLEMENTED;
-    params->ret = funcs->p_glGetGraphicsResetStatus();
+    params->ret = wrap_glGetGraphicsResetStatus( params->teb, funcs->p_glGetGraphicsResetStatus );
     return STATUS_SUCCESS;
 }
 
@@ -9622,7 +9622,7 @@ static NTSTATUS ext_glGetGraphicsResetStatusARB( void *args )
     struct glGetGraphicsResetStatusARB_params *params = args;
     const struct opengl_funcs *funcs = params->teb->glTable;
     if (!funcs->p_glGetGraphicsResetStatusARB) return STATUS_NOT_IMPLEMENTED;
-    params->ret = funcs->p_glGetGraphicsResetStatusARB();
+    params->ret = wrap_glGetGraphicsResetStatus( params->teb, funcs->p_glGetGraphicsResetStatusARB );
     return STATUS_SUCCESS;
 }
 
@@ -48200,7 +48200,7 @@ static NTSTATUS wow64_ext_glGetGraphicsResetStatus( void *args )
     TEB *teb = get_teb64( params->teb );
     const struct opengl_funcs *funcs = teb->glTable;
     if (!funcs->p_glGetGraphicsResetStatus) return STATUS_NOT_IMPLEMENTED;
-    params->ret = funcs->p_glGetGraphicsResetStatus();
+    params->ret = wrap_glGetGraphicsResetStatus( teb, funcs->p_glGetGraphicsResetStatus );
     return STATUS_SUCCESS;
 }
 
@@ -48214,7 +48214,7 @@ static NTSTATUS wow64_ext_glGetGraphicsResetStatusARB( void *args )
     TEB *teb = get_teb64( params->teb );
     const struct opengl_funcs *funcs = teb->glTable;
     if (!funcs->p_glGetGraphicsResetStatusARB) return STATUS_NOT_IMPLEMENTED;
-    params->ret = funcs->p_glGetGraphicsResetStatusARB();
+    params->ret = wrap_glGetGraphicsResetStatus( teb, funcs->p_glGetGraphicsResetStatusARB );
     return STATUS_SUCCESS;
 }
 

--- a/dlls/opengl32/unix_thunks.h
+++ b/dlls/opengl32/unix_thunks.h
@@ -28,6 +28,7 @@ extern void wrap_glFramebufferDrawBuffersEXT( TEB *teb, GLuint framebuffer, GLsi
 extern void wrap_glFramebufferReadBufferEXT( TEB *teb, GLuint framebuffer, GLenum mode, PFN_glFramebufferReadBufferEXT func );
 extern void wrap_glGetFramebufferParameteriv( TEB *teb, GLenum target, GLenum pname, GLint *params, PFN_glGetFramebufferParameteriv func );
 extern void wrap_glGetFramebufferParameterivEXT( TEB *teb, GLuint framebuffer, GLenum pname, GLint *params, PFN_glGetFramebufferParameterivEXT func );
+extern GLenum wrap_glGetGraphicsResetStatus( TEB *teb, PFN_glGetGraphicsResetStatus func );
 extern void wrap_glGetInteger64v( TEB *teb, GLenum pname, GLint64 *data, PFN_glGetInteger64v func );
 extern void wrap_glGetUnsignedBytevEXT( TEB *teb, GLenum pname, GLubyte *data, PFN_glGetUnsignedBytevEXT func );
 extern GLsync wrap_glImportSyncEXT( TEB *teb, GLenum external_sync_type, GLintptr external_sync, GLbitfield flags, GLsync handle, PFN_glImportSyncEXT func );

--- a/dlls/opengl32/unix_wgl.c
+++ b/dlls/opengl32/unix_wgl.c
@@ -1020,6 +1020,10 @@ HGLRC wrap_wglCreateContextAttribsARB( TEB *teb, HDC hdc, HGLRC client_shared, c
     opengl_client_context_init( client_context, context, funcs );
     context->client_context = client_context;
     client->format = context->format;
+    client->reset_notification = WGL_NO_RESET_NOTIFICATION_ARB;
+    for (const int *attr = attribs; attr && attr[0]; attr += 2)
+        if (attr[0] == WGL_CONTEXT_RESET_NOTIFICATION_STRATEGY_ARB)
+            client->reset_notification = attr[1];
 
     return client_context;
 }
@@ -1420,6 +1424,15 @@ void wrap_glGetFramebufferParameterivEXT( TEB *teb, GLuint fbo, GLenum pname, GL
     }
 
     p_glGetFramebufferParameterivEXT( fbo, pname, params );
+}
+
+GLenum wrap_glGetGraphicsResetStatus( TEB *teb, PFN_glGetGraphicsResetStatus get_status )
+{
+    struct opengl_client_context *client;
+
+    if (!get_current_context( teb, NULL, NULL, &client )) return GL_NO_ERROR;
+    if (client->reset_notification == WGL_NO_RESET_NOTIFICATION_ARB) return GL_NO_ERROR;
+    return get_status();
 }
 
 GLenum wrap_glGetError( TEB *teb, PFN_glGetError p_glGetError )

--- a/dlls/opengl32/wgl.c
+++ b/dlls/opengl32/wgl.c
@@ -978,12 +978,21 @@ HGLRC WINAPI wglCreateContextAttribsARB( HDC hdc, HGLRC share, const int *attrib
 {
     struct wglCreateContextAttribsARB_params args = { .teb = NtCurrentTeb(), .hDC = hdc, .attribList = attribs };
     struct context *share_context = NULL;
+    GLint reset_notification = WGL_NO_RESET_NOTIFICATION_ARB;
+    const int *attr;
     struct handle_entry *ptr;
     NTSTATUS status;
 
     TRACE( "hdc %p, share %p, attribs %p\n", hdc, share, attribs );
 
     if (share && !(share_context = context_from_handle( share )))
+    {
+        SetLastError( ERROR_INVALID_OPERATION );
+        return NULL;
+    }
+    for (attr = attribs; attr && attr[0]; attr += 2)
+        if (attr[0] == WGL_CONTEXT_RESET_NOTIFICATION_STRATEGY_ARB) reset_notification = attr[1];
+    if (share_context && share_context->base.reset_notification != reset_notification)
     {
         SetLastError( ERROR_INVALID_OPERATION );
         return NULL;
@@ -1089,6 +1098,11 @@ BOOL WINAPI wglShareLists( HGLRC src_handle, HGLRC dst_handle )
 
     if (!(src_context = context_from_handle( src_handle ))) return FALSE;
     if (!(dst_context = context_from_handle( dst_handle ))) return FALSE;
+    if (src_context->base.reset_notification != dst_context->base.reset_notification)
+    {
+        SetLastError( ERROR_INVALID_OPERATION );
+        return FALSE;
+    }
     if (ReadNoFence( &dst_context->lists->modified )) return FALSE;
 
     if (src_context->base.broken_sharing || dst_context->base.broken_sharing)
@@ -2909,6 +2923,9 @@ BOOL get_integer( GLenum name, GLuint index, GLint value, GLint *data )
 
     switch (name)
     {
+    case GL_RESET_NOTIFICATION_STRATEGY_ARB:
+        *data = ctx->base.reset_notification;
+        return TRUE;
     case GL_CONTEXT_FLAGS:
         *data = ctx->base.context_flags;
         return TRUE;

--- a/dlls/win32u/opengl.c
+++ b/dlls/win32u/opengl.c
@@ -84,6 +84,8 @@ static struct list devices_egl = LIST_INIT( devices_egl );
 static struct egl_platform display_egl;
 static struct opengl_funcs display_funcs;
 static struct opengl_context *global_context;
+static GLint native_reset_strategy = WGL_NO_RESET_NOTIFICATION_ARB;
+static BOOL native_reset_verified;
 
 static BOOLEAN global_extensions[GL_EXTENSION_COUNT];
 static struct wgl_pixel_format *pixel_formats;
@@ -264,11 +266,15 @@ static BOOL opengl_drawable_swap( struct opengl_drawable *drawable )
 
 static struct opengl_context *internal_context_create(void)
 {
-    static const int attribs[] = { WGL_CONTEXT_PROFILE_MASK_ARB, WGL_CONTEXT_CORE_PROFILE_BIT_ARB, 0 };
+    int attribs[] = { WGL_CONTEXT_PROFILE_MASK_ARB, WGL_CONTEXT_CORE_PROFILE_BIT_ARB,
+            WGL_CONTEXT_RESET_NOTIFICATION_STRATEGY_ARB, native_reset_strategy, 0 };
     struct opengl_context *context, *share = global_context ? global_context->driver_private : NULL;
     BOOL shared = TRUE, doublebuffer;
     int format;
 
+    /* NO_RESET is the native default. Drivers without the robustness
+     * extension may reject the attribute even when it requests that default. */
+    if (native_reset_strategy != WGL_LOSE_CONTEXT_ON_RESET_ARB) attribs[2] = 0;
     if (!(context = calloc( 1, sizeof(*context) ))) return NULL;
 
     for (format = 1; format <= formats_count; format++)
@@ -829,6 +835,8 @@ static BOOL egldrv_describe_pixel_format( int format, struct wgl_pixel_format *d
 
 static void egldrv_init_extensions( struct opengl_funcs *funcs, BOOLEAN extensions[GL_EXTENSION_COUNT] )
 {
+    /* EGL_KHR_create_context is required by init_egl_platform(). */
+    extensions[WGL_ARB_create_context_robustness] = 1;
 }
 
 static BOOL egldrv_surface_create( struct client_surface *client, int format, struct opengl_drawable **drawable )
@@ -928,13 +936,12 @@ static BOOL egldrv_context_create( int format, void *share, const int *attribs, 
 
     for (; attribs && attribs[0] != 0; attribs += 2)
     {
-        EGLint name;
+        EGLint name, value = attribs[1];
 
         TRACE( "%#x %#x\n", attribs[0], attribs[1] );
 
         /* Find the EGL attribute names corresponding to the WGL names.
-         * For all of the attributes below, the values match between the two
-         * systems, so we can use them directly. */
+         * Reset notification values also need translation. */
         switch (attribs[0])
         {
         case WGL_CONTEXT_MAJOR_VERSION_ARB:
@@ -948,6 +955,16 @@ static BOOL egldrv_context_create( int format, void *share, const int *attribs, 
             break;
         case WGL_CONTEXT_OPENGL_NO_ERROR_ARB:
             name = EGL_CONTEXT_OPENGL_NO_ERROR_KHR;
+            break;
+        case WGL_CONTEXT_RESET_NOTIFICATION_STRATEGY_ARB:
+            name = EGL_CONTEXT_OPENGL_RESET_NOTIFICATION_STRATEGY_KHR;
+            if (value == WGL_LOSE_CONTEXT_ON_RESET_ARB) value = EGL_LOSE_CONTEXT_ON_RESET_KHR;
+            else if (value == WGL_NO_RESET_NOTIFICATION_ARB) value = EGL_NO_RESET_NOTIFICATION_KHR;
+            else
+            {
+                RtlSetLastWin32Error( ERROR_INVALID_PARAMETER );
+                return FALSE;
+            }
             break;
         case WGL_CONTEXT_PROFILE_MASK_ARB:
             if (attribs[1] & WGL_CONTEXT_ES2_PROFILE_BIT_EXT)
@@ -971,7 +988,7 @@ static BOOL egldrv_context_create( int format, void *share, const int *attribs, 
              * attributes we support (we merge repetitions), plus EGL_NONE. */
             assert( dst - egl_attribs <= ARRAY_SIZE(egl_attribs) - 3 );
             dst[0] = name;
-            dst[1] = attribs[1];
+            dst[1] = value;
             if (dst == attribs_end) attribs_end += 2;
         }
     }
@@ -2462,9 +2479,55 @@ static struct opengl_context *win32u_context_create( HDC hdc, const int *attribs
 {
     struct opengl_context *context, *share = global_context ? global_context->driver_private : NULL;
     BOOL shared = TRUE, doublebuffer;
-    int format;
+    int format, native_attribs[17], *dst = native_attribs;
+    const int *src;
 
     TRACE( "hdc %p, attribs %p\n", hdc, attribs );
+
+    /* Client reset notification is virtualized by opengl32. All native
+     * contexts, including drawable helpers, must use the same policy. */
+    for (src = attribs; src && src[0]; src += 2)
+    {
+        int *entry;
+        if (src[0] == WGL_CONTEXT_RESET_NOTIFICATION_STRATEGY_ARB)
+        {
+            if (src[1] != WGL_NO_RESET_NOTIFICATION_ARB && src[1] != WGL_LOSE_CONTEXT_ON_RESET_ARB)
+            {
+                RtlSetLastWin32Error( ERROR_INVALID_PARAMETER );
+                return NULL;
+            }
+            if (src[1] == WGL_LOSE_CONTEXT_ON_RESET_ARB
+                    && !native_reset_verified)
+            {
+                RtlSetLastWin32Error( ERROR_NOT_SUPPORTED );
+                return NULL;
+            }
+            continue;
+        }
+        switch (src[0])
+        {
+        case WGL_CONTEXT_MAJOR_VERSION_ARB:
+        case WGL_CONTEXT_MINOR_VERSION_ARB:
+        case WGL_CONTEXT_LAYER_PLANE_ARB:
+        case WGL_CONTEXT_FLAGS_ARB:
+        case WGL_CONTEXT_PROFILE_MASK_ARB:
+        case WGL_CONTEXT_OPENGL_NO_ERROR_ARB:
+            break;
+        default:
+            RtlSetLastWin32Error( ERROR_INVALID_PARAMETER );
+            return NULL;
+        }
+        for (entry = native_attribs; entry != dst && entry[0] != src[0]; entry += 2) continue;
+        entry[0] = src[0];
+        entry[1] = src[1];
+        if (entry == dst) dst += 2;
+    }
+    if (native_reset_strategy == WGL_LOSE_CONTEXT_ON_RESET_ARB)
+    {
+        *dst++ = WGL_CONTEXT_RESET_NOTIFICATION_STRATEGY_ARB;
+        *dst++ = native_reset_strategy;
+    }
+    *dst = 0;
 
     if ((format = get_dc_pixel_format( hdc )) <= 0 &&
         (format = get_window_pixel_format( NtUserWindowFromDC( hdc ) )) <= 0)
@@ -2480,7 +2543,7 @@ static struct opengl_context *win32u_context_create( HDC hdc, const int *attribs
         RtlSetLastWin32Error( ERROR_OUTOFMEMORY );
         return NULL;
     }
-    if (!driver_funcs->p_context_create( format, share, attribs, &context->driver_private, &shared ))
+    if (!driver_funcs->p_context_create( format, share, native_attribs, &context->driver_private, &shared ))
     {
         WARN( "Failed to create driver context for context %p\n", context );
         free( context );
@@ -2968,7 +3031,35 @@ static void display_funcs_init(void)
             init_device_info( egl, &display_funcs );
     }
 
-    global_context = internal_context_create();
+    if (global_extensions[WGL_ARB_create_context_robustness])
+    {
+        native_reset_strategy = WGL_LOSE_CONTEXT_ON_RESET_ARB;
+        global_context = internal_context_create();
+        if (!global_context || !global_context->driver_private)
+        {
+            free( global_context );
+            global_context = NULL;
+            native_reset_strategy = WGL_NO_RESET_NOTIFICATION_ARB;
+            global_extensions[WGL_ARB_create_context_robustness] = 0;
+        }
+    }
+    if (!global_context) global_context = internal_context_create();
+    if (global_context && global_context->driver_private
+            && native_reset_strategy == WGL_LOSE_CONTEXT_ON_RESET_ARB)
+    {
+        struct opengl_drawable *surface = get_null_surface( global_context );
+        GLint actual = 0;
+
+        if (driver_funcs->p_make_current( surface, surface, global_context->driver_private ))
+        {
+            display_funcs.p_glGetIntegerv( GL_RESET_NOTIFICATION_STRATEGY_ARB, &actual );
+            native_reset_verified = actual == GL_LOSE_CONTEXT_ON_RESET_ARB
+                    && display_funcs.p_glGetError() == GL_NO_ERROR;
+            TRACE( "Native reset strategy %#x, verified %u.\n", actual, native_reset_verified );
+            driver_funcs->p_make_current( NULL, NULL, NULL );
+        }
+    }
+    global_extensions[WGL_ARB_create_context_robustness] = native_reset_verified;
 }
 
 /***********************************************************************

--- a/dlls/wined3d/adapter_gl.c
+++ b/dlls/wined3d/adapter_gl.c
@@ -241,6 +241,7 @@ static const struct wined3d_extension_map gl_extension_map[] =
 
 static const struct wined3d_extension_map wgl_extension_map[] =
 {
+    {"WGL_ARB_create_context_robustness",   WGL_ARB_CREATE_CONTEXT_ROBUSTNESS},
     {"WGL_ARB_pixel_format",                WGL_ARB_PIXEL_FORMAT             },
     {"WGL_EXT_swap_control",                WGL_EXT_SWAP_CONTROL             },
     {"WGL_WINE_pixel_format_passthrough",   WGL_WINE_PIXEL_FORMAT_PASSTHROUGH},
@@ -2065,6 +2066,9 @@ static void enumerate_gl_extensions(struct wined3d_gl_info *gl_info,
 static void load_gl_funcs(struct wined3d_gl_info *gl_info)
 {
 #define USE_GL_FUNC(pfn) gl_info->gl_ops.ext.p_##pfn = (void *)wglGetProcAddress(#pfn);
+    /* GL_ARB_robustness / GL_KHR_robustness */
+    USE_GL_FUNC(glGetGraphicsResetStatus)
+    USE_GL_FUNC(glGetGraphicsResetStatusARB)
     /* GL_APPLE_fence */
     USE_GL_FUNC(glDeleteFencesAPPLE)
     USE_GL_FUNC(glFinishFenceAPPLE)
@@ -4094,6 +4098,8 @@ static HRESULT adapter_gl_create_device(struct wined3d *wined3d, const struct wi
         return E_OUTOFMEMORY;
 
     device_gl->current_fence_id = 1;
+    InitializeSRWLock(&device_gl->present_swapchains_lock);
+    list_init(&device_gl->present_swapchains);
 
     if (FAILED(hr = wined3d_device_init(&device_gl->d, wined3d, adapter->ordinal, device_type, focus_window,
             flags, surface_alignment, levels, level_count,
@@ -4105,6 +4111,7 @@ static HRESULT adapter_gl_create_device(struct wined3d *wined3d, const struct wi
     }
 
     wined3d_lock_init(&device_gl->allocator_cs, "wined3d_device_gl.allocator_cs");
+    wined3d_device_gl_register_present(device_gl);
 
     *device = &device_gl->d;
     return WINED3D_OK;
@@ -4115,6 +4122,7 @@ static void adapter_gl_destroy_device(struct wined3d_device *device)
     struct wined3d_device_gl *device_gl = wined3d_device_gl(device);
 
     wined3d_device_cleanup(&device_gl->d);
+    wined3d_device_gl_unregister_present(device_gl);
     wined3d_lock_cleanup(&device_gl->allocator_cs);
 
     free(device_gl->retired_blocks);

--- a/dlls/wined3d/context_gl.c
+++ b/dlls/wined3d/context_gl.c
@@ -1238,6 +1238,8 @@ static BOOL wined3d_context_gl_set_gl_context(struct wined3d_context_gl *context
         WARN("Failed to make GL context %p current on device context %p, last error %#lx.\n",
                 context_gl->gl_ctx, context_gl->dc, GetLastError());
         context_gl->valid = 0;
+        if (context_gl->c.swapchain)
+            wined3d_swapchain_invalidate_present_results(context_gl->c.swapchain);
         WARN("Trying fallback to the backup window.\n");
 
         if (context_gl->c.destroyed)
@@ -1304,6 +1306,7 @@ static void wined3d_context_gl_update_window(struct wined3d_context_gl *context_
      * instead of replacing a valid context DC with NULL on every acquire. */
     if (!(dc = swapchain->dc))
     {
+        wined3d_swapchain_invalidate_present_results(swapchain);
         if (!(dc = wined3d_device_gl_get_backup_dc(wined3d_device_gl(context_gl->c.device))))
         {
             WARN("Failed to retrieve a device context.\n");
@@ -1856,7 +1859,7 @@ HGLRC context_create_wgl_attribs(const struct wined3d_gl_info *gl_info, HDC hdc,
 {
     HGLRC ctx;
     unsigned int ctx_attrib_idx = 0;
-    GLint ctx_attribs[7], ctx_flags = 0;
+    GLint ctx_attribs[9], ctx_flags = 0;
 
     if (context_debug_output_enabled(gl_info))
         ctx_flags = WGL_CONTEXT_DEBUG_BIT_ARB;
@@ -1864,6 +1867,11 @@ HGLRC context_create_wgl_attribs(const struct wined3d_gl_info *gl_info, HDC hdc,
     ctx_attribs[ctx_attrib_idx++] = gl_info->selected_gl_version >> 16;
     ctx_attribs[ctx_attrib_idx++] = WGL_CONTEXT_MINOR_VERSION_ARB;
     ctx_attribs[ctx_attrib_idx++] = gl_info->selected_gl_version & 0xffff;
+    if (gl_info->supported[WGL_ARB_CREATE_CONTEXT_ROBUSTNESS])
+    {
+        ctx_attribs[ctx_attrib_idx++] = WGL_CONTEXT_RESET_NOTIFICATION_STRATEGY_ARB;
+        ctx_attribs[ctx_attrib_idx++] = WGL_LOSE_CONTEXT_ON_RESET_ARB;
+    }
     if (ctx_flags)
     {
         ctx_attribs[ctx_attrib_idx++] = WGL_CONTEXT_FLAGS_ARB;
@@ -2103,6 +2111,17 @@ HRESULT wined3d_context_gl_init(struct wined3d_context_gl *context_gl, struct wi
         goto fail;
     }
 
+    if (gl_info->supported[WGL_ARB_CREATE_CONTEXT_ROBUSTNESS]
+            && (gl_info->gl_ops.ext.p_glGetGraphicsResetStatus
+            || gl_info->gl_ops.ext.p_glGetGraphicsResetStatusARB))
+    {
+        GLint strategy = 0;
+        gl_info->gl_ops.gl.p_glGetIntegerv(GL_RESET_NOTIFICATION_STRATEGY_ARB, &strategy);
+        context_gl->reset_notification = strategy == GL_LOSE_CONTEXT_ON_RESET_ARB
+                && gl_info->gl_ops.gl.p_glGetError() == GL_NO_ERROR;
+        TRACE("Reset notification strategy %#x, verified %u.\n", strategy, context_gl->reset_notification);
+    }
+
     if (context_debug_output_enabled(gl_info))
     {
         GL_EXTCALL(glDebugMessageCallback(wined3d_debug_callback, context));
@@ -2277,6 +2296,55 @@ fail:
     return E_FAIL;
 }
 
+/* win32u shares all native contexts with its process-wide global context.
+ * Keep this registry alive across device recreation; a new device cannot
+ * recover storage while that native share group remains lost. Lock order:
+ * device registry -> device swapchain registry -> swapchain result lock. */
+static SRWLOCK present_devices_lock = SRWLOCK_INIT;
+static struct list present_devices = LIST_INIT(present_devices);
+static LONG present_share_group_lost;
+
+void wined3d_device_gl_register_present(struct wined3d_device_gl *device_gl)
+{
+    AcquireSRWLockExclusive(&present_devices_lock);
+    list_add_tail(&present_devices, &device_gl->present_device_entry);
+    ReleaseSRWLockExclusive(&present_devices_lock);
+}
+
+void wined3d_device_gl_unregister_present(struct wined3d_device_gl *device_gl)
+{
+    AcquireSRWLockExclusive(&present_devices_lock);
+    list_remove(&device_gl->present_device_entry);
+    ReleaseSRWLockExclusive(&present_devices_lock);
+}
+
+bool wined3d_context_gl_check_reset(struct wined3d_context_gl *context_gl)
+{
+    struct wined3d_device_gl *device_gl = wined3d_device_gl(context_gl->c.device);
+    const struct wined3d_gl_info *gl_info = context_gl->gl_info;
+    GLenum status;
+
+    if (InterlockedCompareExchange(&present_share_group_lost, 0, 0)) return false;
+    if (!context_gl->reset_notification) return true;
+    if ((status = context_gl->test_reset_status))
+        context_gl->test_reset_status = 0;
+    else if (gl_info->gl_ops.ext.p_glGetGraphicsResetStatus)
+        status = GL_EXTCALL(glGetGraphicsResetStatus());
+    else
+        status = GL_EXTCALL(glGetGraphicsResetStatusARB());
+    if (status == GL_NO_ERROR) return true;
+
+    WARN("Graphics context reset %#x on device %p.\n", status, device_gl);
+    /* Reset completion does not restore the old objects. Never publish their
+     * contents again, even if a subsequent reset query returns NO_ERROR. */
+    AcquireSRWLockExclusive(&present_devices_lock);
+    if (!InterlockedExchange(&present_share_group_lost, 1))
+        LIST_FOR_EACH_ENTRY(device_gl, &present_devices, struct wined3d_device_gl, present_device_entry)
+            wined3d_device_gl_invalidate_present_results(device_gl);
+    ReleaseSRWLockExclusive(&present_devices_lock);
+    return false;
+}
+
 void wined3d_context_gl_destroy(struct wined3d_context_gl *context_gl)
 {
     struct wined3d_device *device = context_gl->c.device;
@@ -2284,6 +2352,9 @@ void wined3d_context_gl_destroy(struct wined3d_context_gl *context_gl)
     TRACE("Destroying context %p.\n", context_gl);
 
     wined3d_from_cs(device->cs);
+
+    if (device->context_count == 1)
+        wined3d_device_gl_invalidate_present_results(wined3d_device_gl(device));
 
     /* We delay destroying a context when it is active. The context_release()
      * function invokes wined3d_context_gl_destroy() again while leaving the

--- a/dlls/wined3d/cs.c
+++ b/dlls/wined3d/cs.c
@@ -685,7 +685,9 @@ static void wined3d_cs_exec_present(struct wined3d_cs *cs, const void *data)
     result.present_id = op->present_id;
     result.result = E_FAIL;
     AcquireSRWLockShared(&swapchain->present_result_lock);
-    result.identity_generation = swapchain->present_identity_generation;
+    record = &swapchain->present_results[op->present_id % WINED3D_SWAPCHAIN_PRESENT_RESULT_COUNT];
+    if (record->result.present_id == op->present_id)
+        result.identity_generation = record->result.identity_generation;
     ReleaseSRWLockShared(&swapchain->present_result_lock);
     desc = &swapchain->state.desc;
     back_buffer = swapchain->back_buffers[0];
@@ -773,7 +775,10 @@ static void wined3d_cs_exec_present(struct wined3d_cs *cs, const void *data)
 
     AcquireSRWLockExclusive(&swapchain->present_result_lock);
     record = &swapchain->present_results[result.present_id % WINED3D_SWAPCHAIN_PRESENT_RESULT_COUNT];
-    if (record->result.present_id == result.present_id)
+    if (record->result.present_id == result.present_id
+            && result.identity_generation
+            && record->result.identity_generation == result.identity_generation
+            && swapchain->present_identity_generation == result.identity_generation)
     {
         record->result = result;
         record->completed = true;

--- a/dlls/wined3d/swapchain.c
+++ b/dlls/wined3d/swapchain.c
@@ -101,9 +101,55 @@ void wined3d_swapchain_cleanup(struct wined3d_swapchain *swapchain)
     }
 }
 
+static void swapchain_gl_detach_contexts(void *object)
+{
+    struct wined3d_swapchain *swapchain = object;
+    struct wined3d_device *device = swapchain->device;
+    unsigned int i;
+
+    /* Contexts are shared by the device and can outlive an explicit
+     * swapchain. Drop their borrowed pointer on the CS before freeing it. */
+    for (i = 0; i < device->context_count; ++i)
+    {
+        struct wined3d_context_gl *context_gl = wined3d_context_gl(device->contexts[i]);
+
+        if (context_gl->c.swapchain != swapchain) continue;
+        context_gl->c.swapchain = NULL;
+        context_gl->window = NULL;
+        context_gl->dc = wined3d_device_gl_get_backup_dc(wined3d_device_gl(device));
+        context_gl->dc_is_private = TRUE;
+        context_gl->dc_has_format = FALSE;
+        context_gl->internal_format_set = 0;
+        context_gl->needs_set = 1;
+        context_gl->valid = !!context_gl->dc;
+    }
+}
+
 void wined3d_swapchain_gl_cleanup(struct wined3d_swapchain_gl *swapchain_gl)
 {
+    struct wined3d_device_gl *device_gl = wined3d_device_gl(swapchain_gl->s.device);
+
+    /* Removal pins every entry against a concurrent share-group walk without
+     * making the registry own a reference cycle through the device. */
+    AcquireSRWLockExclusive(&device_gl->present_swapchains_lock);
+    list_remove(&swapchain_gl->present_entry);
+    ReleaseSRWLockExclusive(&device_gl->present_swapchains_lock);
+    wined3d_cs_init_object(swapchain_gl->s.device->cs, swapchain_gl_detach_contexts, &swapchain_gl->s);
+    wined3d_cs_finish(swapchain_gl->s.device->cs, WINED3D_CS_QUEUE_DEFAULT);
+    if (swapchain_gl->test_present_gate) CloseHandle(swapchain_gl->test_present_gate);
     wined3d_swapchain_cleanup(&swapchain_gl->s);
+}
+
+void wined3d_device_gl_invalidate_present_results(struct wined3d_device_gl *device_gl)
+{
+    struct wined3d_swapchain_gl *swapchain_gl;
+
+    /* Never acquire the global WineD3D mutex or wait for the CS here. The
+     * only nested lock is the individual swapchain's result lock. */
+    AcquireSRWLockShared(&device_gl->present_swapchains_lock);
+    LIST_FOR_EACH_ENTRY(swapchain_gl, &device_gl->present_swapchains, struct wined3d_swapchain_gl, present_entry)
+        wined3d_swapchain_invalidate_present_results(&swapchain_gl->s);
+    ReleaseSRWLockShared(&device_gl->present_swapchains_lock);
 }
 
 static void wined3d_swapchain_vk_destroy_vulkan_swapchain(struct wined3d_swapchain_vk *swapchain_vk)
@@ -307,6 +353,7 @@ HRESULT CDECL wined3d_swapchain_present_with_token(struct wined3d_swapchain *swa
     AcquireSRWLockExclusive(&swapchain->present_result_lock);
     if (!(id = ++swapchain->next_present_id))
         id = ++swapchain->next_present_id;
+    swapchain->present_storage_invalidated = false;
     record = &swapchain->present_results[id % WINED3D_SWAPCHAIN_PRESENT_RESULT_COUNT];
     memset(record, 0, sizeof(*record));
     record->result.present_id = id;
@@ -465,6 +512,14 @@ void CDECL wined3d_swapchain_invalidate_present_results(struct wined3d_swapchain
     TRACE("swapchain %p.\n", swapchain);
 
     AcquireSRWLockExclusive(&swapchain->present_result_lock);
+    /* Unloading several back buffers and then destroying their share group
+     * is one transition. Coalesce until another submission can own a result. */
+    if (swapchain->present_storage_invalidated)
+    {
+        ReleaseSRWLockExclusive(&swapchain->present_result_lock);
+        return;
+    }
+    swapchain->present_storage_invalidated = true;
     memset(swapchain->present_results, 0, sizeof(swapchain->present_results));
     swapchain->last_submitted_present_id = 0;
     swapchain->last_completed_present_id = 0;
@@ -665,7 +720,8 @@ static HRESULT swapchain_blit_gdi(struct wined3d_swapchain *swapchain,
         return WINED3DERR_NOTAVAILABLE;
     }
 
-    wined3d_texture_load_location(back_buffer, 0, context, WINED3D_LOCATION_SYSMEM);
+    if (!wined3d_texture_load_location(back_buffer, 0, context, WINED3D_LOCATION_SYSMEM))
+        return E_FAIL;
     wined3d_texture_get_pitch(back_buffer, 0, &row_pitch, &slice_pitch);
 
     create_desc.pMemory = back_buffer->resource.heap_memory;
@@ -704,13 +760,13 @@ static HRESULT swapchain_blit_gdi(struct wined3d_swapchain *swapchain,
 }
 
 /* A GL context is provided by the caller */
-static void swapchain_blit(const struct wined3d_swapchain *swapchain,
+static bool swapchain_blit(struct wined3d_swapchain *swapchain,
         struct wined3d_context *context, const RECT *src_rect, const RECT *dst_rect)
 {
     struct wined3d_texture *texture = swapchain->back_buffers[0];
     struct wined3d_device *device = swapchain->device;
     enum wined3d_texture_filter_type filter;
-    DWORD location;
+    DWORD location, copied;
 
     TRACE("swapchain %p, context %p, src_rect %s, dst_rect %s.\n",
             swapchain, context, wine_dbgstr_rect(src_rect), wine_dbgstr_rect(dst_rect));
@@ -727,9 +783,11 @@ static void swapchain_blit(const struct wined3d_swapchain *swapchain,
         location = WINED3D_LOCATION_RB_RESOLVED;
 
     wined3d_texture_validate_location(texture, 0, WINED3D_LOCATION_DRAWABLE);
-    device->blitter->ops->blitter_blit(device->blitter, WINED3D_BLIT_OP_COLOR_BLIT, context, texture, 0,
+    wined3d_swapchain_gl(swapchain)->present_blit_verified = false;
+    copied = device->blitter->ops->blitter_blit(device->blitter, WINED3D_BLIT_OP_COLOR_BLIT, context, texture, 0,
             location, src_rect, texture, 0, WINED3D_LOCATION_DRAWABLE, dst_rect, NULL, filter, NULL);
     wined3d_texture_invalidate_location(texture, 0, WINED3D_LOCATION_DRAWABLE);
+    return !!(copied & WINED3D_LOCATION_DRAWABLE);
 }
 
 static void swapchain_gl_set_swap_interval(struct wined3d_swapchain *swapchain,
@@ -754,7 +812,7 @@ static void swapchain_gl_set_swap_interval(struct wined3d_swapchain *swapchain,
 }
 
 /* Context activation is done by the caller. */
-static void wined3d_swapchain_gl_rotate(struct wined3d_swapchain *swapchain, struct wined3d_context *context)
+static bool wined3d_swapchain_gl_rotate(struct wined3d_swapchain *swapchain, struct wined3d_context *context)
 {
     struct wined3d_texture_sub_resource *sub_resource;
     struct wined3d_texture_gl *texture, *texture_prev;
@@ -766,7 +824,16 @@ static void wined3d_swapchain_gl_rotate(struct wined3d_swapchain *swapchain, str
     static const DWORD supported_locations = WINED3D_LOCATION_TEXTURE_RGB | WINED3D_LOCATION_RB_MULTISAMPLE;
 
     if (swapchain->state.desc.backbuffer_count < 2)
-        return;
+        return true;
+
+    /* Prepare every allocation before changing any wrapper mapping. */
+    for (i = 1; i < swapchain->state.desc.backbuffer_count; ++i)
+    {
+        struct wined3d_texture *buffer = swapchain->back_buffers[i];
+        if (!(buffer->sub_resources[0].locations & supported_locations)
+                && !wined3d_texture_load_location(buffer, 0, context, buffer->resource.draw_binding))
+            return false;
+    }
 
     texture_prev = wined3d_texture_gl(swapchain->back_buffers[0]);
 
@@ -780,9 +847,6 @@ static void wined3d_swapchain_gl_rotate(struct wined3d_swapchain *swapchain, str
     {
         texture = wined3d_texture_gl(swapchain->back_buffers[i]);
         sub_resource = &texture->t.sub_resources[0];
-
-        if (!(sub_resource->locations & supported_locations))
-            wined3d_texture_load_location(&texture->t, 0, context, texture->t.resource.draw_binding);
 
         texture_prev->texture_rgb = texture->texture_rgb;
         texture_prev->rb_multisample = texture->rb_multisample;
@@ -802,6 +866,7 @@ static void wined3d_swapchain_gl_rotate(struct wined3d_swapchain *swapchain, str
     wined3d_texture_invalidate_location(&texture_prev->t, 0, ~(locations0 & supported_locations));
 
     device_invalidate_state(swapchain->device, STATE_FRAMEBUFFER);
+    return true;
 }
 
 static bool swapchain_present_is_partial_copy(struct wined3d_swapchain *swapchain, const RECT *dst_rect)
@@ -847,11 +912,46 @@ static uint64_t wined3d_swapchain_gl_get_physical_identity(struct wined3d_swapch
     return 0;
 }
 
+static const char *swapchain_gl_sparse_fallback(struct wined3d_swapchain *swapchain,
+        const struct wined3d_context_gl *context_gl)
+{
+    unsigned int i;
+
+    if (!context_gl->reset_notification) return "reset-notification-unavailable";
+    if (!wined3d_swapchain_gl(swapchain)->present_blit_verified)
+        return "unproven-presentation-blit";
+    if (swapchain->composition_desc.flags & WINE_DCOMP_VISUAL_RENDERER_ACTIVE) return "dcomp-renderer-active";
+    if (swapchain->state.desc.backbuffer_count < 2 || swapchain->state.desc.backbuffer_count > 4)
+        return "unproven-buffer-count";
+    for (i = 0; i < swapchain->state.desc.backbuffer_count; ++i)
+    {
+        const struct wined3d_texture *texture = swapchain->back_buffers[i];
+        const struct wined3d_texture_gl *texture_gl = wined3d_texture_gl(swapchain->back_buffers[i]);
+
+        if (texture->resource.multisample_type) return "unproven-multisample-storage";
+        if (texture->resource.draw_binding != WINED3D_LOCATION_TEXTURE_RGB
+                || !(texture->sub_resources[0].locations & WINED3D_LOCATION_TEXTURE_RGB))
+            return "unproven-storage-location";
+        if (texture_gl->target != GL_TEXTURE_2D || texture->level_count != 1 || texture->layer_count != 1)
+            return "unproven-texture-layout";
+        if (!(texture->resource.format_caps & WINED3D_FORMAT_CAP_FBO_ATTACHABLE)
+                || (texture->resource.format->id != WINED3DFMT_R8G8B8A8_UNORM
+                && texture->resource.format->id != WINED3DFMT_B8G8R8A8_UNORM))
+            return "unproven-texture-format";
+        if ((texture->flags & WINED3D_TEXTURE_CONVERTED) || !texture_gl->texture_rgb.storage_serial
+                || !(texture->flags & WINED3D_TEXTURE_RGB_ALLOCATED))
+            return "undefined-texture-storage";
+    }
+    return NULL;
+}
+
 static HRESULT swapchain_gl_present(struct wined3d_swapchain *swapchain,
         const RECT *src_rect, const RECT *dst_rect, unsigned int swap_interval, uint32_t flags,
         struct wined3d_swapchain_present_result *result)
 {
     struct wined3d_texture *back_buffer = swapchain->back_buffers[0];
+    struct wined3d_swapchain_gl *swapchain_gl = wined3d_swapchain_gl(swapchain);
+    enum wined3d_gl_present_test test_action = WINED3D_GL_TEST_OBSERVE;
     const struct wined3d_pixel_format *pixel_format;
     const struct wined3d_gl_info *gl_info;
     struct wined3d_context_gl *context_gl;
@@ -862,19 +962,44 @@ static HRESULT swapchain_gl_present(struct wined3d_swapchain *swapchain,
     HRESULT hr = WINED3D_OK;
     unsigned int i;
 
+    swapchain_gl->present_blit_verified = false;
+    AcquireSRWLockShared(&swapchain->present_result_lock);
+    if (swapchain_gl->test_present_generation == swapchain->present_identity_generation)
+        test_action = swapchain_gl->test_present_action;
+    ReleaseSRWLockShared(&swapchain->present_result_lock);
+    swapchain_gl->test_present_action = WINED3D_GL_TEST_OBSERVE;
+    if (swapchain_gl->test_present_gate)
+    {
+        DWORD wait_result = WAIT_OBJECT_0;
+        if (test_action == WINED3D_GL_TEST_PENDING)
+            wait_result = WaitForSingleObject(swapchain_gl->test_present_gate, 10000);
+        CloseHandle(swapchain_gl->test_present_gate);
+        swapchain_gl->test_present_gate = NULL;
+        if (wait_result != WAIT_OBJECT_0) return E_FAIL;
+    }
+
     context = context_acquire(swapchain->device, swapchain->front_buffer, 0);
     context_gl = wined3d_context_gl(context);
-    if (!context_gl->valid)
+    if (!context_gl->valid || test_action == WINED3D_GL_TEST_INVALID_CONTEXT)
     {
         context_release(context);
         WARN("Invalid context, skipping present.\n");
         return E_FAIL;
     }
 
+    if (test_action == WINED3D_GL_TEST_RESET)
+        context_gl->test_reset_status = GL_UNKNOWN_CONTEXT_RESET_ARB;
+    if (!wined3d_context_gl_check_reset(context_gl))
+    {
+        context_release(context);
+        return E_FAIL;
+    }
+
     TRACE("Presenting DC %p.\n", context_gl->dc);
 
     pixel_format = &wined3d_adapter_gl(swapchain->device->adapter)->pixel_formats[context_gl->pixel_format - 1];
-    if (context_gl->dc == wined3d_device_gl(swapchain->device)->backup_dc
+    if (test_action == WINED3D_GL_TEST_BACKUP_DC
+            || context_gl->dc == wined3d_device_gl(swapchain->device)->backup_dc
             || (pixel_format->swap_method != WGL_SWAP_COPY_ARB
             && swapchain_present_is_partial_copy(swapchain, dst_rect)))
     {
@@ -886,10 +1011,18 @@ static HRESULT swapchain_gl_present(struct wined3d_swapchain *swapchain,
 
         swapchain_gl_set_swap_interval(swapchain, context_gl, swap_interval);
 
-        wined3d_texture_load_location(back_buffer, 0, context, back_buffer->resource.draw_binding);
+        if (!wined3d_texture_load_location(back_buffer, 0, context, back_buffer->resource.draw_binding))
+        {
+            hr = E_FAIL;
+            goto done;
+        }
         presented_identity = wined3d_swapchain_gl_get_physical_identity(swapchain, 0);
 
-        swapchain_blit(swapchain, context, src_rect, dst_rect);
+        if (!swapchain_blit(swapchain, context, src_rect, dst_rect))
+        {
+            hr = E_FAIL;
+            goto done;
+        }
 
         if (swapchain->device->context_count > 1)
         {
@@ -898,7 +1031,8 @@ static HRESULT swapchain_gl_present(struct wined3d_swapchain *swapchain,
         }
 
         /* call wglSwapBuffers through the gl table to avoid confusing the Steam overlay */
-        if (!gl_info->gl_ops.wgl.p_wglSwapBuffers(context_gl->dc))
+        if (!gl_info->gl_ops.wgl.p_wglSwapBuffers(
+                test_action == WINED3D_GL_TEST_SWAP_FAILURE ? NULL : context_gl->dc))
         {
             DWORD error = GetLastError();
 
@@ -919,8 +1053,17 @@ static HRESULT swapchain_gl_present(struct wined3d_swapchain *swapchain,
     if (advance_frame && context->d3d_info->fences)
         wined3d_context_gl_submit_command_fence(context_gl);
 
-    if (advance_frame)
-        wined3d_swapchain_gl_rotate(swapchain, context);
+    if (advance_frame && !wined3d_swapchain_gl_rotate(swapchain, context))
+    {
+        hr = E_FAIL;
+        goto done;
+    }
+
+    if (native_swap && !wined3d_context_gl_check_reset(context_gl))
+    {
+        hr = E_FAIL;
+        goto done;
+    }
 
     if (advance_frame)
         TRACE("SwapBuffers called, starting new frame.\n");
@@ -946,13 +1089,19 @@ static HRESULT swapchain_gl_present(struct wined3d_swapchain *swapchain,
             result->physical_identity_count = i;
             result->current_physical_identity = result->physical_identities[0];
             result->presented_physical_identity = presented_identity;
-            /* A GL context-loss generation is not exposed yet. Keep the
-             * identity record diagnostic-only until that lifecycle is wired. */
-            result->capabilities = 0;
+            {
+                const char *reason = swapchain_gl_sparse_fallback(swapchain, context_gl);
+                /* The candidate passes the pixel/lifecycle matrix, but has
+                 * not passed the no-regression Present1 latency gate. */
+                TRACE("GL sparse Present fallback: %s.\n", reason ? reason : "latency-gate-not-met");
+                result->capabilities = 0;
+            }
         }
     }
 
 done:
+    if (test_action == WINED3D_GL_TEST_STALE_COMPLETION)
+        wined3d_swapchain_invalidate_present_results(swapchain);
     context_release(context);
     return hr;
 }
@@ -973,6 +1122,80 @@ static const struct wined3d_swapchain_ops swapchain_gl_ops =
     swapchain_gl_present,
     swapchain_frontbuffer_updated,
 };
+
+struct swapchain_gl_test_data
+{
+    struct wined3d_swapchain *swapchain;
+    enum wined3d_gl_present_test action;
+    unsigned int buffer_idx;
+    struct wined3d_gl_storage_test_result *result;
+    HRESULT hr;
+};
+
+static void swapchain_gl_test_cb(void *object)
+{
+    struct swapchain_gl_test_data *data = object;
+    struct wined3d_swapchain *swapchain = data->swapchain;
+    struct wined3d_swapchain_gl *swapchain_gl = wined3d_swapchain_gl(swapchain);
+    struct wined3d_texture_gl *texture_gl = wined3d_texture_gl(swapchain->back_buffers[data->buffer_idx]);
+    struct wined3d_context *context = context_acquire(swapchain->device, swapchain->front_buffer, 0);
+    struct wined3d_context_gl *context_gl = wined3d_context_gl(context);
+
+    data->hr = E_FAIL;
+    if (!context_gl->valid) goto done;
+    if (data->action == WINED3D_GL_TEST_RESET && !context_gl->reset_notification)
+    {
+        data->hr = WINED3DERR_NOTAVAILABLE;
+        goto done;
+    }
+    if (data->action >= WINED3D_GL_TEST_MUTABLE_STORAGE && data->action <= WINED3D_GL_TEST_REDEFINE_STORAGE)
+    {
+        if (!wined3d_texture_gl_test_storage(texture_gl, context_gl, data->action)) goto done;
+    }
+    else if (!wined3d_texture_load_location(&texture_gl->t, 0, context, WINED3D_LOCATION_TEXTURE_RGB))
+        goto done;
+
+    if (data->action == WINED3D_GL_TEST_PENDING)
+    {
+        HANDLE event = CreateEventW(NULL, TRUE, FALSE, NULL);
+        if (!event) goto done;
+        if (!DuplicateHandle(GetCurrentProcess(), event, GetCurrentProcess(),
+                &data->result->completion_gate, 0, FALSE, DUPLICATE_SAME_ACCESS))
+        {
+            CloseHandle(event);
+            goto done;
+        }
+        if (swapchain_gl->test_present_gate) CloseHandle(swapchain_gl->test_present_gate);
+        swapchain_gl->test_present_gate = event;
+    }
+
+    AcquireSRWLockShared(&swapchain->present_result_lock);
+    data->result->identity_generation = swapchain->present_identity_generation;
+    swapchain_gl->test_present_generation = swapchain->present_identity_generation;
+    ReleaseSRWLockShared(&swapchain->present_result_lock);
+    if (data->action >= WINED3D_GL_TEST_SWAP_FAILURE)
+        swapchain_gl->test_present_action = data->action;
+    data->result->name = texture_gl->texture_rgb.name;
+    data->result->storage_serial = texture_gl->texture_rgb.storage_serial;
+    data->hr = S_OK;
+done:
+    context_release(context);
+}
+
+HRESULT CDECL wined3d_swapchain_test_gl(struct wined3d_swapchain *swapchain,
+        enum wined3d_gl_present_test action, unsigned int buffer_idx, struct wined3d_gl_storage_test_result *result)
+{
+    struct swapchain_gl_test_data data = {swapchain, action, buffer_idx, result, E_FAIL};
+
+    if (result) memset(result, 0, sizeof(*result));
+    if (!swapchain || !result || action > WINED3D_GL_TEST_RESET
+            || buffer_idx >= swapchain->state.desc.backbuffer_count)
+        return E_INVALIDARG;
+    if (swapchain->swapchain_ops != &swapchain_gl_ops) return WINED3DERR_NOTAVAILABLE;
+    wined3d_cs_init_object(swapchain->device->cs, swapchain_gl_test_cb, &data);
+    wined3d_cs_finish(swapchain->device->cs, WINED3D_CS_QUEUE_DEFAULT);
+    return data.hr;
+}
 
 static bool wined3d_swapchain_vk_present_mode_supported(struct wined3d_swapchain_vk *swapchain_vk,
         VkPresentModeKHR vk_present_mode)
@@ -2546,11 +2769,19 @@ HRESULT wined3d_swapchain_gl_init(struct wined3d_swapchain_gl *swapchain_gl, str
         const struct wined3d_swapchain_desc *desc, struct wined3d_swapchain_state_parent *state_parent,
         void *parent, const struct wined3d_parent_ops *parent_ops)
 {
+    struct wined3d_device_gl *device_gl = wined3d_device_gl(device);
+    HRESULT hr;
+
     TRACE("swapchain_gl %p, device %p, desc %p, state_parent %p, parent %p, parent_ops %p.\n",
             swapchain_gl, device, desc, state_parent, parent, parent_ops);
 
-    return wined3d_swapchain_init(&swapchain_gl->s, device, desc, state_parent, parent,
-            parent_ops, &swapchain_gl_ops);
+    if (FAILED(hr = wined3d_swapchain_init(&swapchain_gl->s, device, desc, state_parent, parent,
+            parent_ops, &swapchain_gl_ops)))
+        return hr;
+    AcquireSRWLockExclusive(&device_gl->present_swapchains_lock);
+    list_add_tail(&device_gl->present_swapchains, &swapchain_gl->present_entry);
+    ReleaseSRWLockExclusive(&device_gl->present_swapchains_lock);
+    return hr;
 }
 
 HRESULT wined3d_swapchain_vk_init(struct wined3d_swapchain_vk *swapchain_vk, struct wined3d_device *device,

--- a/dlls/wined3d/swapchain.c
+++ b/dlls/wined3d/swapchain.c
@@ -1189,6 +1189,7 @@ HRESULT CDECL wined3d_swapchain_test_gl(struct wined3d_swapchain *swapchain,
 
     if (result) memset(result, 0, sizeof(*result));
     if (!swapchain || !result || action > WINED3D_GL_TEST_RESET
+            || !swapchain->back_buffers
             || buffer_idx >= swapchain->state.desc.backbuffer_count)
         return E_INVALIDARG;
     if (swapchain->swapchain_ops != &swapchain_gl_ops) return WINED3DERR_NOTAVAILABLE;

--- a/dlls/wined3d/texture_gl.c
+++ b/dlls/wined3d/texture_gl.c
@@ -697,7 +697,7 @@ static bool fbo_blitter_supported(enum wined3d_blit_op blit_op, const struct win
 
 /* Blit between surface locations. Onscreen on different swapchains is not supported.
  * Depth / stencil is not supported. Context activation is done by the caller. */
-static void texture2d_blt_fbo(struct wined3d_device *device, struct wined3d_context *context,
+static bool texture2d_blt_fbo(struct wined3d_device *device, struct wined3d_context *context,
         enum wined3d_blit_op blit_op, enum wined3d_texture_filter_type filter, struct wined3d_texture *src_texture,
         unsigned int src_sub_resource_idx, DWORD src_location, const RECT *src_rect,
         struct wined3d_texture *dst_texture, unsigned int dst_sub_resource_idx, DWORD dst_location,
@@ -705,7 +705,7 @@ static void texture2d_blt_fbo(struct wined3d_device *device, struct wined3d_cont
 {
     struct wined3d_texture *required_texture, *restore_texture, *dst_save_texture = dst_texture;
     unsigned int restore_idx, dst_save_sub_resource_idx = dst_sub_resource_idx;
-    bool resolve, scaled_resolve, restore_context = false;
+    bool resolve, scaled_resolve, restore_context = false, success = false;
     struct wined3d_texture *src_staging_texture = NULL;
     const struct wined3d_gl_info *gl_info;
     struct wined3d_context_gl *context_gl;
@@ -843,11 +843,18 @@ static void texture2d_blt_fbo(struct wined3d_device *device, struct wined3d_cont
      * surface isn't required if the entire surface is overwritten. (And is
      * in fact harmful if we're being called by surface_load_location() with
      * the purpose of loading the destination surface.) */
-    wined3d_texture_load_location(src_texture, src_sub_resource_idx, context, src_location);
+    if (!wined3d_texture_load_location(src_texture, src_sub_resource_idx, context, src_location))
+        goto done;
     if (!wined3d_texture_is_full_rect(dst_texture, dst_sub_resource_idx % dst_texture->level_count, dst_rect))
-        wined3d_texture_load_location(dst_texture, dst_sub_resource_idx, context, dst_location);
+    {
+        if (!wined3d_texture_load_location(dst_texture, dst_sub_resource_idx, context, dst_location))
+            goto done;
+    }
     else
-        wined3d_texture_prepare_location(dst_texture, dst_sub_resource_idx, context, dst_location);
+    {
+        if (!wined3d_texture_prepare_location(dst_texture, dst_sub_resource_idx, context, dst_location))
+            goto done;
+    }
 
     /* Acquire a context for the front-buffer, even though we may be blitting
      * to/from a back-buffer. Since context_acquire() doesn't take the
@@ -871,9 +878,7 @@ static void texture2d_blt_fbo(struct wined3d_device *device, struct wined3d_cont
     context_gl = wined3d_context_gl(context);
     if (!context_gl->valid)
     {
-        context_release(context);
         WARN("Invalid context, skipping blit.\n");
-        restore_context = false;
         goto done;
     }
 
@@ -896,10 +901,13 @@ static void texture2d_blt_fbo(struct wined3d_device *device, struct wined3d_cont
     wined3d_context_gl_apply_fbo_state_explicit(context_gl, GL_READ_FRAMEBUFFER,
             &src_texture->resource, src_sub_resource_idx, NULL, 0, src_location);
     gl_info->gl_ops.gl.p_glReadBuffer(buffer);
-    checkGLcall("glReadBuffer()");
-    wined3d_context_gl_check_fbo_status(context_gl, GL_READ_FRAMEBUFFER);
+    if (gl_info->gl_ops.gl.p_glGetError() != GL_NO_ERROR
+            || gl_info->fbo_ops.glCheckFramebufferStatus(GL_READ_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
+        goto done;
 
     context_gl_apply_texture_draw_state(context_gl, dst_texture, dst_sub_resource_idx, dst_location);
+    if (gl_info->fbo_ops.glCheckFramebufferStatus(GL_DRAW_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
+        goto done;
 
     if (dst_location == WINED3D_LOCATION_DRAWABLE)
     {
@@ -916,7 +924,8 @@ static void texture2d_blt_fbo(struct wined3d_device *device, struct wined3d_cont
 
     gl_info->fbo_ops.glBlitFramebuffer(src_rect->left, src_rect->top, src_rect->right, src_rect->bottom,
             dst_rect->left, dst_rect->top, dst_rect->right, dst_rect->bottom, GL_COLOR_BUFFER_BIT, gl_filter);
-    checkGLcall("glBlitFramebuffer()");
+    if (gl_info->gl_ops.gl.p_glGetError() != GL_NO_ERROR) goto done;
+    success = true;
 
     if (dst_location == WINED3D_LOCATION_DRAWABLE && dst_texture->swapchain->front_buffer == dst_texture)
         gl_info->gl_ops.gl.p_glFlush();
@@ -941,6 +950,7 @@ done:
 
     if (restore_context)
         context_restore(context, restore_texture, restore_idx);
+    return success;
 }
 
 static void texture2d_depth_blt_fbo(const struct wined3d_device *device, struct wined3d_context *context,
@@ -1107,8 +1117,14 @@ static DWORD fbo_blitter_blit(struct wined3d_blitter *blitter, enum wined3d_blit
     if (blit_op == WINED3D_BLIT_OP_COLOR_BLIT || blit_op == WINED3D_BLIT_OP_RAW_BLIT)
     {
         TRACE("Colour blit.\n");
-        texture2d_blt_fbo(device, context, blit_op, filter, src_texture, src_sub_resource_idx, src_location,
-                src_rect, dst_texture, dst_sub_resource_idx, dst_location, dst_rect, resolve_format);
+        if (!texture2d_blt_fbo(device, context, blit_op, filter, src_texture, src_sub_resource_idx, src_location,
+                src_rect, dst_texture, dst_sub_resource_idx, dst_location, dst_rect, resolve_format))
+            return 0;
+        /* Only this path checks storage loads, framebuffer completeness and
+         * the copy's GL error before attesting to a presentation blit. */
+        if (dst_location == WINED3D_LOCATION_DRAWABLE && dst_texture->swapchain
+                && src_texture == dst_texture && !src_sub_resource_idx && !dst_sub_resource_idx)
+            wined3d_swapchain_gl(dst_texture->swapchain)->present_blit_verified = true;
         return dst_location;
     }
 
@@ -1271,7 +1287,7 @@ static void gltexture_delete(struct wined3d_device *device, const struct wined3d
 }
 
 /* The caller is responsible for binding the correct texture. */
-static void wined3d_texture_gl_allocate_mutable_storage(struct wined3d_texture_gl *texture_gl,
+static bool wined3d_texture_gl_allocate_mutable_storage(struct wined3d_texture_gl *texture_gl,
         GLenum gl_internal_format, const struct wined3d_format_gl *format,
         const struct wined3d_gl_info *gl_info)
 {
@@ -1286,7 +1302,7 @@ static void wined3d_texture_gl_allocate_mutable_storage(struct wined3d_texture_g
         layer_count = texture_gl->t.layer_count;
 
     GL_EXTCALL(glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0));
-    checkGLcall("glBindBuffer");
+    if (gl_info->gl_ops.gl.p_glGetError() != GL_NO_ERROR) return false;
 
     for (unsigned int layer = 0; layer < layer_count; ++layer)
     {
@@ -1311,7 +1327,6 @@ static void wined3d_texture_gl_allocate_mutable_storage(struct wined3d_texture_g
                 GL_EXTCALL(glTexImage3D(target, level, gl_internal_format, width, height,
                         target == GL_TEXTURE_2D_ARRAY ? texture_gl->t.layer_count : depth, 0,
                         format->format, format->type, NULL));
-                checkGLcall("glTexImage3D");
             }
             else if (target == GL_TEXTURE_1D)
             {
@@ -1323,14 +1338,15 @@ static void wined3d_texture_gl_allocate_mutable_storage(struct wined3d_texture_g
                 gl_info->gl_ops.gl.p_glTexImage2D(target, level, gl_internal_format, width,
                         target == GL_TEXTURE_1D_ARRAY ? texture_gl->t.layer_count : height, 0,
                         format->format, format->type, NULL);
-                checkGLcall("glTexImage2D");
             }
+            if (gl_info->gl_ops.gl.p_glGetError() != GL_NO_ERROR) return false;
         }
     }
+    return true;
 }
 
 /* The caller is responsible for binding the correct texture. */
-static void wined3d_texture_gl_allocate_immutable_storage(struct wined3d_texture_gl *texture_gl,
+static bool wined3d_texture_gl_allocate_immutable_storage(struct wined3d_texture_gl *texture_gl,
         GLenum gl_internal_format, const struct wined3d_gl_info *gl_info)
 {
     unsigned int samples = wined3d_resource_get_sample_count(&texture_gl->t.resource);
@@ -1370,7 +1386,7 @@ static void wined3d_texture_gl_allocate_immutable_storage(struct wined3d_texture
             break;
     }
 
-    checkGLcall("allocate immutable storage");
+    return gl_info->gl_ops.gl.p_glGetError() == GL_NO_ERROR;
 }
 
 static void wined3d_texture_gl_upload_bo(const struct wined3d_format *src_format, GLenum target,
@@ -2342,10 +2358,11 @@ static bool wined3d_texture_use_immutable_storage(const struct wined3d_texture *
             && !(texture->resource.format_attrs & WINED3D_FORMAT_ATTR_HEIGHT_SCALE);
 }
 
-void wined3d_texture_gl_prepare_texture(struct wined3d_texture_gl *texture_gl,
+bool wined3d_texture_gl_prepare_texture(struct wined3d_texture_gl *texture_gl,
         struct wined3d_context_gl *context_gl, bool srgb)
 {
     uint32_t alloc_flag;
+    bool allocated;
     const struct wined3d_gl_info *gl_info = context_gl->gl_info;
     struct wined3d_resource *resource = &texture_gl->t.resource;
     const struct wined3d_format *format = resource->format;
@@ -2355,11 +2372,11 @@ void wined3d_texture_gl_prepare_texture(struct wined3d_texture_gl *texture_gl,
     TRACE("texture_gl %p, context_gl %p, srgb %d, format %s.\n",
             texture_gl, context_gl, srgb, debug_d3dformat(format->id));
 
-    if (!needs_separate_srgb_gl_texture(&context_gl->c, &texture_gl->t))
-        srgb = false;
+    if (!needs_separate_srgb_gl_texture(&context_gl->c, &texture_gl->t)) srgb = false;
     alloc_flag = srgb ? WINED3D_TEXTURE_SRGB_ALLOCATED : WINED3D_TEXTURE_RGB_ALLOCATED;
     if (texture_gl->t.flags & alloc_flag)
-        return;
+        return true;
+    if (!context_gl->valid) return false;
 
     if (resource->format_caps & WINED3D_FORMAT_CAP_DECOMPRESS)
     {
@@ -2381,17 +2398,30 @@ void wined3d_texture_gl_prepare_texture(struct wined3d_texture_gl *texture_gl,
 
     TRACE("internal %#x, format %#x, type %#x.\n", internal, format_gl->format, format_gl->type);
 
-    if (wined3d_texture_use_immutable_storage(&texture_gl->t, gl_info))
-        wined3d_texture_gl_allocate_immutable_storage(texture_gl, internal, gl_info);
+    /* A mutable texture can retain its name while replacing the allocation.
+     * Initial allocation has no prior history to invalidate. */
+    if (texture_gl->t.swapchain && &texture_gl->t != texture_gl->t.swapchain->front_buffer
+            && wined3d_texture_gl_get_gl_texture(texture_gl,
+            srgb && needs_separate_srgb_gl_texture(&context_gl->c, &texture_gl->t))->storage_serial)
+        wined3d_swapchain_invalidate_present_results(texture_gl->t.swapchain);
+
+    if (!texture_gl->test_mutable_storage && wined3d_texture_use_immutable_storage(&texture_gl->t, gl_info))
+        allocated = wined3d_texture_gl_allocate_immutable_storage(texture_gl, internal, gl_info);
     else
-        wined3d_texture_gl_allocate_mutable_storage(texture_gl, internal, format_gl, gl_info);
-    /* Refresh on every storage specification, even if the GL name is kept.
-     * A serial alone does not certify allocation or preservation success. */
+        allocated = wined3d_texture_gl_allocate_mutable_storage(texture_gl, internal, format_gl, gl_info);
+    if (!allocated)
+    {
+        WARN("Failed to allocate texture %p storage.\n", texture_gl);
+        gltexture_delete(resource->device, gl_info, wined3d_texture_gl_get_gl_texture(texture_gl, srgb));
+        return false;
+    }
+    /* Only a successful storage specification receives an identity. */
     wined3d_texture_gl_get_gl_texture(texture_gl, srgb)->storage_serial = wined3d_allocate_storage_serial();
     TRACE("Specified texture %u storage, serial %s.\n",
             wined3d_texture_gl_get_gl_texture(texture_gl, srgb)->name,
             wine_dbgstr_longlong(wined3d_texture_gl_get_gl_texture(texture_gl, srgb)->storage_serial));
     texture_gl->t.flags |= alloc_flag;
+    return true;
 }
 
 static void wined3d_texture_gl_prepare_rb(struct wined3d_texture_gl *texture_gl,
@@ -2445,12 +2475,10 @@ static BOOL wined3d_texture_gl_prepare_location(struct wined3d_texture *texture,
             return TRUE;
 
         case WINED3D_LOCATION_TEXTURE_RGB:
-            wined3d_texture_gl_prepare_texture(texture_gl, context_gl, false);
-            return TRUE;
+            return wined3d_texture_gl_prepare_texture(texture_gl, context_gl, false);
 
         case WINED3D_LOCATION_TEXTURE_SRGB:
-            wined3d_texture_gl_prepare_texture(texture_gl, context_gl, true);
-            return TRUE;
+            return wined3d_texture_gl_prepare_texture(texture_gl, context_gl, true);
 
         case WINED3D_LOCATION_DRAWABLE:
             if (!texture->swapchain)
@@ -2641,6 +2669,14 @@ static void wined3d_texture_gl_unload_location(struct wined3d_texture *texture,
     unsigned int sub_count;
 
     TRACE("texture %p, context %p, location %s.\n", texture, context, wined3d_debug_location(location));
+
+    /* Invalidate before deleting a back-buffer allocation, including callers
+     * which unload only one GPU location rather than the entire resource. */
+    if (texture->swapchain && texture != texture->swapchain->front_buffer
+            && ((location == WINED3D_LOCATION_TEXTURE_RGB && texture_gl->texture_rgb.name)
+            || (location == WINED3D_LOCATION_TEXTURE_SRGB && texture_gl->texture_srgb.name)
+            || (location == WINED3D_LOCATION_RB_MULTISAMPLE && texture_gl->rb_multisample)))
+        wined3d_swapchain_invalidate_present_results(texture->swapchain);
 
     switch (location)
     {
@@ -2836,7 +2872,13 @@ void wined3d_texture_gl_bind(struct wined3d_texture_gl *texture_gl,
         return;
     }
 
-    gl_info->gl_ops.gl.p_glGenTextures(1, &gl_tex->name);
+    if (texture_gl->test_reuse_name)
+    {
+        gl_tex->name = texture_gl->test_reuse_name;
+        texture_gl->test_reuse_name = 0;
+    }
+    else
+        gl_info->gl_ops.gl.p_glGenTextures(1, &gl_tex->name);
     checkGLcall("glGenTextures");
     TRACE("Generated texture %d.\n", gl_tex->name);
 
@@ -3125,4 +3167,54 @@ void wined3d_texture_gl_set_compatible_renderbuffer(struct wined3d_texture_gl *t
     }
 
     checkGLcall("set compatible renderbuffer");
+}
+
+/* CS-only deterministic storage replacement, used by Wine's DXGI tests. */
+bool wined3d_texture_gl_test_storage(struct wined3d_texture_gl *texture_gl,
+        struct wined3d_context_gl *context_gl, enum wined3d_gl_present_test action)
+{
+    struct wined3d_texture *texture = &texture_gl->t;
+    const struct wined3d_gl_info *gl_info = context_gl->gl_info;
+    GLuint old_name;
+
+    if (texture_gl->target != GL_TEXTURE_2D || texture->level_count != 1 || texture->layer_count != 1)
+        return false;
+    if (!wined3d_texture_load_location(texture, 0, &context_gl->c, WINED3D_LOCATION_TEXTURE_RGB)
+            || !wined3d_texture_load_location(texture, 0, &context_gl->c, WINED3D_LOCATION_SYSMEM))
+        return false;
+    old_name = texture_gl->texture_rgb.name;
+    if (action == WINED3D_GL_TEST_REDEFINE_STORAGE && !texture_gl->test_mutable_storage) return false;
+    texture->flags &= ~(WINED3D_TEXTURE_RGB_ALLOCATED | WINED3D_TEXTURE_RGB_VALID);
+    wined3d_texture_invalidate_location(texture, 0, ~WINED3D_LOCATION_SYSMEM);
+    if (action != WINED3D_GL_TEST_REDEFINE_STORAGE)
+    {
+        wined3d_texture_gl_unload_location(texture, &context_gl->c, WINED3D_LOCATION_TEXTURE_RGB);
+        if (action == WINED3D_GL_TEST_REUSE_NAME)
+        {
+            GLint attribs[] = {WGL_CONTEXT_MAJOR_VERSION_ARB, 2, WGL_CONTEXT_MINOR_VERSION_ARB, 1,
+                    WGL_CONTEXT_RESET_NOTIFICATION_STRATEGY_ARB,
+                    gl_info->supported[WGL_ARB_CREATE_CONTEXT_ROBUSTNESS]
+                    ? WGL_LOSE_CONTEXT_ON_RESET_ARB : WGL_NO_RESET_NOTIFICATION_ARB, 0};
+            HGLRC compat;
+            bool rebound = false;
+
+            /* Core contexts require generated names. A sharing compatibility
+             * context can legally recreate this exact deleted numeric name. */
+            if (!gl_info->p_wglCreateContextAttribsARB
+                    || !(compat = gl_info->p_wglCreateContextAttribsARB(context_gl->dc, context_gl->gl_ctx, attribs)))
+                return false;
+            if (wglMakeCurrent(context_gl->dc, compat))
+            {
+                gl_info->gl_ops.gl.p_glBindTexture(texture_gl->target, old_name);
+                rebound = gl_info->gl_ops.gl.p_glGetError() == GL_NO_ERROR;
+            }
+            if (!wglMakeCurrent(context_gl->dc, context_gl->gl_ctx)) rebound = false;
+            if (!wglDeleteContext(compat)) rebound = false;
+            if (!rebound) return false;
+            texture_gl->test_reuse_name = old_name;
+        }
+        if (action == WINED3D_GL_TEST_MUTABLE_STORAGE) texture_gl->test_mutable_storage = true;
+    }
+    if (!wined3d_texture_gl_prepare_texture(texture_gl, context_gl, false)) return false;
+    return wined3d_texture_load_location(texture, 0, &context_gl->c, WINED3D_LOCATION_TEXTURE_RGB);
 }

--- a/dlls/wined3d/texture_gl.c
+++ b/dlls/wined3d/texture_gl.c
@@ -798,10 +798,11 @@ static bool texture2d_blt_fbo(struct wined3d_device *device, struct wined3d_cont
             if (src_location == WINED3D_LOCATION_DRAWABLE)
                 FIXME("WINED3D_LOCATION_DRAWABLE not supported for the source of a typeless resolve.\n");
 
-            device->blitter->ops->blitter_blit(device->blitter, WINED3D_BLIT_OP_RAW_BLIT, context,
+            if (!(device->blitter->ops->blitter_blit(device->blitter, WINED3D_BLIT_OP_RAW_BLIT, context,
                     src_texture, src_sub_resource_idx, src_location, src_rect,
                     src_staging_texture, 0, src_location, src_rect,
-                    NULL, WINED3D_TEXF_NONE, NULL);
+                    NULL, WINED3D_TEXF_NONE, NULL) & src_location))
+                goto done;
 
             src_texture = src_staging_texture;
             src_sub_resource_idx = 0;
@@ -925,7 +926,6 @@ static bool texture2d_blt_fbo(struct wined3d_device *device, struct wined3d_cont
     gl_info->fbo_ops.glBlitFramebuffer(src_rect->left, src_rect->top, src_rect->right, src_rect->bottom,
             dst_rect->left, dst_rect->top, dst_rect->right, dst_rect->bottom, GL_COLOR_BUFFER_BIT, gl_filter);
     if (gl_info->gl_ops.gl.p_glGetError() != GL_NO_ERROR) goto done;
-    success = true;
 
     if (dst_location == WINED3D_LOCATION_DRAWABLE && dst_texture->swapchain->front_buffer == dst_texture)
         gl_info->gl_ops.gl.p_glFlush();
@@ -935,11 +935,13 @@ static bool texture2d_blt_fbo(struct wined3d_device *device, struct wined3d_cont
         if (dst_location == WINED3D_LOCATION_DRAWABLE)
             FIXME("WINED3D_LOCATION_DRAWABLE not supported for the destination of a typeless resolve.\n");
 
-        device->blitter->ops->blitter_blit(device->blitter, WINED3D_BLIT_OP_RAW_BLIT, context,
+        if (!(device->blitter->ops->blitter_blit(device->blitter, WINED3D_BLIT_OP_RAW_BLIT, context,
                 dst_texture, 0, dst_location, dst_rect,
                 dst_save_texture, dst_save_sub_resource_idx, dst_location, dst_rect,
-                NULL, WINED3D_TEXF_NONE, NULL);
+                NULL, WINED3D_TEXF_NONE, NULL) & dst_location))
+            goto done;
     }
+    success = true;
 
 done:
     if (dst_texture != dst_save_texture)
@@ -2218,10 +2220,8 @@ static BOOL wined3d_texture_load_renderbuffer(struct wined3d_texture *texture,
     else /* texture2d_blt_fbo() will load the source location if necessary. */
         src_location = WINED3D_LOCATION_TEXTURE_RGB;
 
-    texture2d_blt_fbo(texture->resource.device, context, WINED3D_BLIT_OP_COLOR_BLIT, WINED3D_TEXF_POINT, texture,
+    return texture2d_blt_fbo(texture->resource.device, context, WINED3D_BLIT_OP_COLOR_BLIT, WINED3D_TEXF_POINT, texture,
             sub_resource_idx, src_location, &rect, texture, sub_resource_idx, dst_location, &rect, NULL);
-
-    return TRUE;
 }
 
 static BOOL wined3d_texture_gl_load_texture(struct wined3d_texture_gl *texture_gl,
@@ -2252,15 +2252,14 @@ static BOOL wined3d_texture_gl_load_texture(struct wined3d_texture_gl *texture_g
 
         SetRect(&src_rect, src_box.left, src_box.top, src_box.right, src_box.bottom);
         if (srgb)
-            texture2d_blt_fbo(device, &context_gl->c, WINED3D_BLIT_OP_COLOR_BLIT, WINED3D_TEXF_POINT,
+            return texture2d_blt_fbo(device, &context_gl->c, WINED3D_BLIT_OP_COLOR_BLIT, WINED3D_TEXF_POINT,
                     &texture_gl->t, sub_resource_idx, WINED3D_LOCATION_TEXTURE_RGB, &src_rect,
                     &texture_gl->t, sub_resource_idx, WINED3D_LOCATION_TEXTURE_SRGB, &src_rect, NULL);
         else
-            texture2d_blt_fbo(device, &context_gl->c, WINED3D_BLIT_OP_COLOR_BLIT, WINED3D_TEXF_POINT,
+            return texture2d_blt_fbo(device, &context_gl->c, WINED3D_BLIT_OP_COLOR_BLIT, WINED3D_TEXF_POINT,
                     &texture_gl->t, sub_resource_idx, WINED3D_LOCATION_TEXTURE_SRGB, &src_rect,
                     &texture_gl->t, sub_resource_idx, WINED3D_LOCATION_TEXTURE_RGB, &src_rect, NULL);
 
-        return TRUE;
     }
 
     if (!depth && sub_resource->locations & (WINED3D_LOCATION_RB_MULTISAMPLE | WINED3D_LOCATION_RB_RESOLVED)
@@ -2274,11 +2273,11 @@ static BOOL wined3d_texture_gl_load_texture(struct wined3d_texture_gl *texture_g
         dst_location = srgb ? WINED3D_LOCATION_TEXTURE_SRGB : WINED3D_LOCATION_TEXTURE_RGB;
         if (fbo_blitter_supported(WINED3D_BLIT_OP_COLOR_BLIT, gl_info,
                 &texture_gl->t.resource, src_location, &texture_gl->t.resource, dst_location))
-            texture2d_blt_fbo(device, &context_gl->c, WINED3D_BLIT_OP_COLOR_BLIT,
+            return texture2d_blt_fbo(device, &context_gl->c, WINED3D_BLIT_OP_COLOR_BLIT,
                     WINED3D_TEXF_POINT, &texture_gl->t, sub_resource_idx,
                     src_location, &src_rect, &texture_gl->t, sub_resource_idx, dst_location, &src_rect, NULL);
 
-        return TRUE;
+        return FALSE;
     }
 
     /* Upload from system memory */

--- a/dlls/wined3d/view.c
+++ b/dlls/wined3d/view.c
@@ -219,7 +219,11 @@ static void create_texture_view(struct wined3d_gl_view *view, GLenum view_target
         return;
     }
 
-    wined3d_texture_gl_prepare_texture(texture_gl, context_gl, false);
+    if (!wined3d_texture_gl_prepare_texture(texture_gl, context_gl, false))
+    {
+        context_release(context);
+        return;
+    }
     texture_name = wined3d_texture_gl_get_texture_name(texture_gl, context, FALSE);
 
     level_idx = desc->u.texture.level_idx;

--- a/dlls/wined3d/wined3d.spec
+++ b/dlls/wined3d/wined3d.spec
@@ -420,3 +420,5 @@
 @ cdecl vkd3d_shader_scan(ptr ptr)
 @ cdecl vkd3d_shader_serialize_dxbc(long ptr ptr ptr)
 @ cdecl vkd3d_shader_serialize_root_signature(ptr ptr ptr)
+
+@ cdecl wined3d_swapchain_test_gl(ptr long long ptr)

--- a/dlls/wined3d/wined3d_gl.h
+++ b/dlls/wined3d/wined3d_gl.h
@@ -223,6 +223,7 @@ enum wined3d_gl_extension
     NV_VERTEX_PROGRAM3,
     NV_TEXTURE_BARRIER,
     /* WGL extensions */
+    WGL_ARB_CREATE_CONTEXT_ROBUSTNESS,
     WGL_ARB_PIXEL_FORMAT,
     WGL_EXT_SWAP_CONTROL,
     WGL_WINE_PIXEL_FORMAT_PASSTHROUGH,
@@ -619,6 +620,8 @@ struct fbo_entry
 struct wined3d_context_gl
 {
     struct wined3d_context c;
+    bool reset_notification;
+    GLenum test_reset_status;
 
     const struct wined3d_gl_info *gl_info;
 
@@ -868,6 +871,9 @@ struct wined3d_device_gl
     struct wined3d_dummy_textures dummy_textures;
 
     CRITICAL_SECTION allocator_cs;
+    struct list present_device_entry;
+    SRWLOCK present_swapchains_lock;
+    struct list present_swapchains;
     struct wined3d_allocator allocator;
     uint64_t completed_fence_id;
     uint64_t current_fence_id;
@@ -961,6 +967,8 @@ struct wined3d_texture_gl
     struct wined3d_texture t;
 
     struct gl_texture texture_rgb, texture_srgb;
+    GLuint test_reuse_name;
+    bool test_mutable_storage;
 
     GLenum target;
 
@@ -1040,7 +1048,9 @@ void wined3d_texture_gl_bind_and_dirtify(struct wined3d_texture_gl *texture_gl,
 HRESULT wined3d_texture_gl_init(struct wined3d_texture_gl *texture_gl, struct wined3d_device *device,
         const struct wined3d_resource_desc *desc, unsigned int layer_count, unsigned int level_count,
         uint32_t flags, void *parent, const struct wined3d_parent_ops *parent_ops);
-void wined3d_texture_gl_prepare_texture(struct wined3d_texture_gl *texture_gl,
+bool wined3d_texture_gl_test_storage(struct wined3d_texture_gl *texture_gl,
+        struct wined3d_context_gl *context_gl, enum wined3d_gl_present_test action);
+bool wined3d_texture_gl_prepare_texture(struct wined3d_texture_gl *texture_gl,
         struct wined3d_context_gl *context_gl, bool srgb);
 void wined3d_texture_gl_set_compatible_renderbuffer(struct wined3d_texture_gl *texture_gl,
         struct wined3d_context_gl *context_gl, unsigned int level, const struct wined3d_rendertarget_info *rt);
@@ -1145,6 +1155,11 @@ void wined3d_unordered_access_view_gl_update(struct wined3d_unordered_access_vie
 struct wined3d_swapchain_gl
 {
     struct wined3d_swapchain s;
+    struct list present_entry;
+    enum wined3d_gl_present_test test_present_action;
+    uint64_t test_present_generation;
+    HANDLE test_present_gate;
+    bool present_blit_verified;
 };
 
 static inline struct wined3d_swapchain_gl *wined3d_swapchain_gl(struct wined3d_swapchain *swapchain)
@@ -1153,6 +1168,10 @@ static inline struct wined3d_swapchain_gl *wined3d_swapchain_gl(struct wined3d_s
 }
 
 void wined3d_swapchain_gl_cleanup(struct wined3d_swapchain_gl *swapchain_gl);
+void wined3d_device_gl_invalidate_present_results(struct wined3d_device_gl *device_gl);
+bool wined3d_context_gl_check_reset(struct wined3d_context_gl *context_gl);
+void wined3d_device_gl_register_present(struct wined3d_device_gl *device_gl);
+void wined3d_device_gl_unregister_present(struct wined3d_device_gl *device_gl);
 struct wined3d_context_gl *wined3d_swapchain_gl_get_context(struct wined3d_swapchain_gl *swapchain_gl);
 HRESULT wined3d_swapchain_gl_init(struct wined3d_swapchain_gl *swapchain_gl, struct wined3d_device *device,
         const struct wined3d_swapchain_desc *desc, struct wined3d_swapchain_state_parent *state_parent,

--- a/dlls/wined3d/wined3d_private.h
+++ b/dlls/wined3d/wined3d_private.h
@@ -49,6 +49,7 @@
 
 #include "objbase.h"
 #include "wine/wined3d.h"
+#include "wine/wined3d_test.h"
 #include "wine/wined3d_completion.h"
 #include "wine/dcomp.h"
 #include "wine/list.h"
@@ -4191,6 +4192,7 @@ struct wined3d_swapchain
     uint64_t last_submitted_present_id;
     uint64_t last_completed_present_id;
     uint64_t present_identity_generation;
+    bool present_storage_invalidated;
     struct wined3d_swapchain_present_record present_results[WINED3D_SWAPCHAIN_PRESENT_RESULT_COUNT];
 
     /* Performance tracking */

--- a/dlls/winewayland.drv/opengl.c
+++ b/dlls/winewayland.drv/opengl.c
@@ -313,7 +313,10 @@ static BOOL wayland_drawable_swap(struct opengl_drawable *base)
 
     TRACE("drawable %p presenting at interval %u\n", gl, interval);
     if (!funcs->p_eglSwapBuffers(egl->display, gl->base.surface))
+    {
         wayland_drawable_cancel_frame_callback(gl);
+        return FALSE;
+    }
 
     return TRUE;
 }

--- a/dlls/winex11.drv/opengl.c
+++ b/dlls/winex11.drv/opengl.c
@@ -167,6 +167,7 @@ typedef XID GLXPbuffer;
 #define GLX_CONTEXT_OPENGL_NO_ERROR_ARB   0x31B3
 /** GLX_ARB_create_context_profile */
 #define GLX_CONTEXT_PROFILE_MASK_ARB      0x9126
+#define GLX_CONTEXT_RESET_NOTIFICATION_STRATEGY_ARB 0x8256
 /** GLX_ATI_pixel_format_float */
 #define GLX_RGBA_FLOAT_ATI_BIT            0x00000100
 /** GLX_ARB_pixel_format_float */
@@ -1201,7 +1202,7 @@ static void x11drv_surface_flush( struct opengl_drawable *base, UINT flags )
  */
 static BOOL x11drv_context_create( int format, void *share, const int *attribList, void **context, BOOL *shared )
 {
-    int glx_attribs[16] = {0}, *pContextAttribList = glx_attribs;
+    int glx_attribs[16] = {0}, *attribs_end = glx_attribs;
     int err = 0;
 
     TRACE("(%d %p %p)\n", format, share, attribList);
@@ -1211,38 +1212,42 @@ static BOOL x11drv_context_create( int format, void *share, const int *attribLis
         /* attribList consists of pairs {token, value] terminated with 0 */
         while(attribList[0] != 0)
         {
+            int name = 0, *dst;
+
             TRACE("%#x %#x\n", attribList[0], attribList[1]);
             switch(attribList[0])
             {
             case WGL_CONTEXT_MAJOR_VERSION_ARB:
-                pContextAttribList[0] = GLX_CONTEXT_MAJOR_VERSION_ARB;
-                pContextAttribList[1] = attribList[1];
-                pContextAttribList += 2;
+                name = GLX_CONTEXT_MAJOR_VERSION_ARB;
                 break;
             case WGL_CONTEXT_MINOR_VERSION_ARB:
-                pContextAttribList[0] = GLX_CONTEXT_MINOR_VERSION_ARB;
-                pContextAttribList[1] = attribList[1];
-                pContextAttribList += 2;
+                name = GLX_CONTEXT_MINOR_VERSION_ARB;
                 break;
             case WGL_CONTEXT_LAYER_PLANE_ARB:
                 break;
             case WGL_CONTEXT_FLAGS_ARB:
-                pContextAttribList[0] = GLX_CONTEXT_FLAGS_ARB;
-                pContextAttribList[1] = attribList[1];
-                pContextAttribList += 2;
+                name = GLX_CONTEXT_FLAGS_ARB;
                 break;
             case WGL_CONTEXT_OPENGL_NO_ERROR_ARB:
-                pContextAttribList[0] = GLX_CONTEXT_OPENGL_NO_ERROR_ARB;
-                pContextAttribList[1] = attribList[1];
-                pContextAttribList += 2;
+                name = GLX_CONTEXT_OPENGL_NO_ERROR_ARB;
                 break;
             case WGL_CONTEXT_PROFILE_MASK_ARB:
-                pContextAttribList[0] = GLX_CONTEXT_PROFILE_MASK_ARB;
-                pContextAttribList[1] = attribList[1];
-                pContextAttribList += 2;
+                name = GLX_CONTEXT_PROFILE_MASK_ARB;
+                break;
+            case WGL_CONTEXT_RESET_NOTIFICATION_STRATEGY_ARB:
+                name = GLX_CONTEXT_RESET_NOTIFICATION_STRATEGY_ARB;
                 break;
             default:
                 ERR("Unhandled attribList pair: %#x %#x\n", attribList[0], attribList[1]);
+            }
+            if (name)
+            {
+                /* Merge repetitions instead of overflowing the fixed list. */
+                for (dst = glx_attribs; dst != attribs_end && *dst != name; dst += 2) continue;
+                assert( dst - glx_attribs <= ARRAY_SIZE(glx_attribs) - 3 );
+                dst[0] = name;
+                dst[1] = attribList[1];
+                if (dst == attribs_end) attribs_end += 2;
             }
             attribList += 2;
         }
@@ -1379,6 +1384,9 @@ static void x11drv_init_extensions( struct opengl_funcs *funcs, BOOLEAN extensio
 {
     /* ARB Extensions */
 
+    if (has_extension( glxExtensions, "GLX_ARB_create_context_robustness" ))
+        extensions[WGL_ARB_create_context_robustness] = 1;
+
     if (has_extension( glxExtensions, "GLX_ARB_multisample"))
         extensions[WGL_ARB_multisample] = 1;
 
@@ -1498,7 +1506,7 @@ static BOOL x11drv_egl_surface_swap( struct opengl_drawable *base )
 
     TRACE( "%s\n", debugstr_opengl_drawable( base ) );
 
-    funcs->p_eglSwapBuffers( egl->display, gl->base.surface );
+    if (!funcs->p_eglSwapBuffers( egl->display, gl->base.surface )) return FALSE;
 
     if (InterlockedCompareExchange( &base->client->offscreen, 0, 0 ))
         XFlush( gdi_display );

--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -1163,6 +1163,7 @@ SOURCES = \
 	wine/winebth.h \
 	wine/wined3d.h \
 	wine/wined3d_completion.h \
+	wine/wined3d_test.h \
 	wine/winedmo.h \
 	wine/winedxgi.idl \
 	wine/wingdi16.h \

--- a/include/wine/opengl_driver.h
+++ b/include/wine/opengl_driver.h
@@ -78,6 +78,7 @@ struct opengl_client_context
     GLenum                      last_error;
     GLint                       context_flags;
     GLint                       profile_mask;
+    GLint                       reset_notification;
     int                         major_version;
     int                         minor_version;
     char                        version_str[64];
@@ -119,7 +120,7 @@ struct __GLsync
 #include "wine/gdi_driver.h"
 
 /* Wine internal opengl driver version, needs to be bumped upon opengl_funcs changes. */
-#define WINE_OPENGL_DRIVER_VERSION 39
+#define WINE_OPENGL_DRIVER_VERSION 40
 
 struct opengl_drawable;
 

--- a/include/wine/wined3d_test.h
+++ b/include/wine/wined3d_test.h
@@ -1,0 +1,32 @@
+/* Internal WineD3D regression-test controls. */
+#ifndef __WINE_WINED3D_TEST_H
+#define __WINE_WINED3D_TEST_H
+
+#include "wine/wined3d.h"
+
+enum wined3d_gl_present_test
+{
+    WINED3D_GL_TEST_OBSERVE,
+    WINED3D_GL_TEST_MUTABLE_STORAGE,
+    WINED3D_GL_TEST_REUSE_NAME,
+    WINED3D_GL_TEST_REDEFINE_STORAGE,
+    WINED3D_GL_TEST_SWAP_FAILURE,
+    WINED3D_GL_TEST_INVALID_CONTEXT,
+    WINED3D_GL_TEST_BACKUP_DC,
+    WINED3D_GL_TEST_STALE_COMPLETION,
+    WINED3D_GL_TEST_PENDING,
+    WINED3D_GL_TEST_RESET,
+};
+
+struct wined3d_gl_storage_test_result
+{
+    HANDLE completion_gate;
+    unsigned int name;
+    uint64_t storage_serial;
+    uint64_t identity_generation;
+};
+
+HRESULT __cdecl wined3d_swapchain_test_gl(struct wined3d_swapchain *swapchain,
+        enum wined3d_gl_present_test action, unsigned int buffer_idx, struct wined3d_gl_storage_test_result *result);
+
+#endif


### PR DESCRIPTION
Releasing an explicit OpenGL swapchain left its device context pointing at freed memory. The Present1 history test reproduced a hang when the freed window/DC fields became pixel data (`0xff0000ff`) and context invalidation tried to lock that stale object. Detach borrowing contexts on the command stream before freeing the swapchain.

This also makes allocation/blit failures and EGL swap failures visible to completion, rejects old-generation results, and invalidates every WineD3D device sharing Wine's native GL context group after observed reset. Native reset policy is negotiated consistently for internal/client contexts, while each client's requested query/reset semantics remain intact. Private hooks cover real swap failure, GL-name reuse, same-name redefinition, pending results, and injected cross-device reset.

Stacked on #90 (`094667fc5fa`); review this PR against that branch. Do not merge this before its base. #89 does not fix reset-policy sharing and changes extension initialization and the driver ABI; integration onto it needs adaptation and validation.

OpenGL sparse remains **disabled**. Experimental capability publication passed the pixel/lifecycle matrix and cut benchmark API copy volume by97.9%, but four order-balanced trace-free Wayland pairs had slower p95 caller latency. Median per-run p95 was160.75µs sparse versus148.65µs full. The Plan10 no-regression performance gate therefore failed.

Validation:
- Both architectures rebuilt, including generated OpenGL wrappers and coupled Unix drivers.
- Experimental sparse matrix after the teardown fix: eight GL lanes ×1618 assertions and two Vulkan controls ×1517, all zero failures/skips. GL covers Wayland and Xwayland, x86-64/i386, normal/forced-full.
- Four WGL reset-policy lanes ×56 assertions and four GL boundary lanes ×108, zero failures/skips. Reset injection exercises the normal handler; no physical GPU reset/recovery was tested.
- Final fallback-only matrix also passed all ten lanes. Three further i386 Wayland forced-full reproductions passed1618 assertions each. After review fixes at79a9f13e84c, all ten lanes passed again with the same counts. No staging-allocation failure injection is claimed.
- Fresh-context Astra/high reviewed final commit79a9f13e84c and is satisfied: https://github.com/ttv20/wine4office/pull/91#pullrequestreview-5137361682.
- Bounded Word A/B on the fixed3-page/60-line fixture covered typing, Design and Shapes menus; GL sparse/full document pixels matched exactly, software Vulkan differed only in the caret. Sparse/Vulkan Ctrl+End reached page3. No actual shape insertion or long-duration memory acceptance is claimed.

Hardware: AMD REDWOOD/Mesa26.1.5 for OpenGL. Vulkan controls use CPU llvmpipe, not a second hardware GPU. Earlier failing timeout logs are retained alongside the causal diagnosis. No merge performed.


Review fixes propagate checked FBO failure through every direct caller, verify source/final staging-copy location masks, and reject a missing back-buffer array at the private test export. CodeRabbit acknowledged three FIXED findings and one FALSE POSITIVE, all threads resolved. Full latest-SHA re-review is rate-limited despite its green check. Greptile reviewed final79a9f13e84c and reported5/5 with no blocking findings. Qodo is paused and Sourcery exhausted its quota, so the complete automated-review gate remains **blocked**.

Final source and evidence: commit79a9f13e84c0e8d82a32ebc739740e50c36fc447; local artifacts/plan10-gl-present1-20260907/ contains final-source-provenance.json, gl-review-complete/, gl-benchmark-final/, rollout-report.md and word-evidence.md. The experimental runner supports the measured sparse comparison; final runner-plan10-review-complete leaves sparse off.

## Summary by Sourcery

Harden OpenGL presentation lifetime and reset handling so released or invalidated storage cannot be reused or reported as successfully presented.

Bug Fixes:
- Prevent OpenGL presentation from retaining released swapchain storage or publishing stale completion results after storage replacement, presentation failure, or context loss.
- Propagate OpenGL allocation, blit, framebuffer, and EGL/WGL swap failures to presentation completion instead of reporting success.
- Invalidate presentation state across all WineD3D devices sharing the affected native OpenGL context group after a graphics reset.

Enhancements:
- Align native and client OpenGL reset-notification policies while preserving each client's requested reset and query semantics.
- Detach device contexts from explicit swapchains before their storage is freed and track presentation storage generations to reject obsolete results.

Build:
- Regenerate and rebuild the OpenGL wrappers and coupled Unix drivers, including the OpenGL driver ABI update.

Tests:
- Add DXGI OpenGL presentation lifecycle tests covering storage/name reuse, same-name redefinition, swap and blit failures, pending and stale completions, backup contexts, and cross-device reset invalidation.
- Add OpenGL reset-notification tests covering queries, context sharing compatibility, texture preservation, and presentation for both reset strategies.

Build follow-up14a9b5d4621 registers wine/wined3d_test.h in include/Makefile.in. Makefile regeneration and focused rebuilt consumers now succeed; production behavior is unchanged. Astra reviewed that final header-only delta and is satisfied: https://github.com/ttv20/wine4office/pull/91#pullrequestreview-5137945566. Follow-up performance investigation and optimization are isolated in #92.
