### PR TITLE
Reduce DXGI presentation overhead from missing window properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reduce repeated window-property lookup overhead during graphics presentation.
+
 - Prevent OpenGL presentation from using released buffers or retaining history after context loss.
 
 - Track graphics buffer allocations reliably when drivers reuse resource identifiers.

--- a/dlls/dxgi/dxgi_private.h
+++ b/dlls/dxgi/dxgi_private.h
@@ -214,6 +214,8 @@ struct d3d11_swapchain
     ID3D11Texture2D *present1_scratch;
     BOOL present1_shadow_valid;
     HWND composition_window;
+    ATOM detached_window_atom;
+    ATOM clip_enabled_atom;
 
     DXGI_SWAP_CHAIN_FULLSCREEN_DESC fullscreen_desc;
     IDXGIOutput *target;

--- a/dlls/dxgi/swapchain.c
+++ b/dlls/dxgi/swapchain.c
@@ -531,7 +531,8 @@ static BOOL d3d11_composition_window_get_rect(HWND window, HWND target, RECT *re
 static void d3d11_swapchain_update_composition_window(struct d3d11_swapchain *swapchain)
 {
     HWND window = d3d11_swapchain_get_hwnd(swapchain);
-    HWND target = GetPropW(window, L"__wine_dcomp_detached_window");
+    HWND target = GetPropW(window, swapchain->detached_window_atom
+            ? MAKEINTRESOURCEW(swapchain->detached_window_atom) : L"__wine_dcomp_detached_window");
     ATOM foreign_atom, old_foreign_atom;
     HWND base, foreign_parent, root;
     RECT rect;
@@ -622,7 +623,8 @@ static HRESULT d3d11_swapchain_present(struct d3d11_swapchain *swapchain,
     }
 
     window = d3d11_swapchain_get_hwnd(swapchain);
-    if (GetPropW(window, L"__wine_dcomp_clip_enabled")
+    if (GetPropW(window, swapchain->clip_enabled_atom
+            ? MAKEINTRESOURCEW(swapchain->clip_enabled_atom) : L"__wine_dcomp_clip_enabled")
             && !GetPropW(window, L"__wine_dcomp_bounds_enabled"))
     {
         source_rect.left = (LONG)HandleToULong(GetPropW(window, L"__wine_dcomp_clip_left"));
@@ -2161,6 +2163,8 @@ static void STDMETHODCALLTYPE d3d11_swapchain_wined3d_object_released(void *pare
     struct d3d11_swapchain *swapchain = parent;
 
     wined3d_private_store_cleanup(&swapchain->private_store);
+    if (swapchain->detached_window_atom) GlobalDeleteAtom(swapchain->detached_window_atom);
+    if (swapchain->clip_enabled_atom) GlobalDeleteAtom(swapchain->clip_enabled_atom);
     free(parent);
 }
 
@@ -2300,6 +2304,10 @@ HRESULT d3d11_swapchain_init(struct d3d11_swapchain *swapchain, struct dxgi_devi
     }
     wined3d_mutex_unlock();
 
+    /* Retain the names while using their atom values for per-frame queries.
+     * This also lets win32u validate cached misses without string atom lookup. */
+    swapchain->detached_window_atom = GlobalAddAtomW(L"__wine_dcomp_detached_window");
+    swapchain->clip_enabled_atom = GlobalAddAtomW(L"__wine_dcomp_clip_enabled");
     return S_OK;
 
 cleanup:

--- a/dlls/user32/tests/Makefile.in
+++ b/dlls/user32/tests/Makefile.in
@@ -22,6 +22,7 @@ SOURCES = \
 	msg.c \
 	resource.c \
 	popup.c \
+	property.c \
 	scroll.c \
 	static.c \
 	sysparams.c \

--- a/dlls/user32/tests/property.c
+++ b/dlls/user32/tests/property.c
@@ -1,0 +1,135 @@
+/* Window property lookup lifetime tests.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ */
+#include <stdlib.h>
+#include <stdio.h>
+#include "windows.h"
+#include "wine/test.h"
+
+static void check_missing(HWND hwnd, ATOM atom)
+{
+    unsigned int i;
+    for (i = 0; i < 3; ++i)
+    {
+        SetLastError(0xdeadbeef);
+        ok(!GetPropW(hwnd, MAKEINTRESOURCEW(atom)), "Unexpected property value.\n");
+        ok(GetLastError() == 0xdeadbeef, "Last error changed to %lu.\n", GetLastError());
+    }
+}
+
+static void test_properties(void)
+{
+    SECURITY_ATTRIBUTES sa = {sizeof(sa), NULL, TRUE};
+    STARTUPINFOA si = {sizeof(si)};
+    PROCESS_INFORMATION pi;
+    char path[MAX_PATH], command[2 * MAX_PATH];
+    HANDLE start, done, value;
+    HWND window, second;
+    ATOM atom, atoms[32];
+    unsigned int i;
+    DWORD error, other_error;
+    BOOL ret;
+
+    window = CreateWindowA("static", "property test", WS_POPUP, 0, 0, 10, 10, NULL, NULL, NULL, NULL);
+    second = CreateWindowA("static", "property test 2", WS_POPUP, 0, 0, 10, 10, NULL, NULL, NULL, NULL);
+    ok(!!window && !!second, "Failed to create windows.\n");
+    if (!window || !second) goto done_windows;
+    atom = GlobalAddAtomW(L"wine_property_lookup_lifetime");
+    ok(!!atom, "Failed to create atom.\n");
+    if (!atom) goto done_windows;
+    check_missing(window, atom);
+    ret = SetPropW(window, L"wine_property_lookup_lifetime", NULL);
+    ok(ret, "Failed to set NULL property.\n");
+    check_missing(window, atom);
+    ret = SetPropW(window, L"wine_property_lookup_lifetime", (HANDLE)0x1234);
+    ok(ret, "Failed to replace NULL property.\n");
+    value = GetPropW(window, MAKEINTRESOURCEW(atom));
+    ok(value == (HANDLE)0x1234, "Got stale value %p.\n", value);
+    ok(RemovePropW(window, MAKEINTRESOURCEW(atom)) == (HANDLE)0x1234, "Unexpected removed value.\n");
+    check_missing(window, atom);
+
+    start = CreateEventW(&sa, FALSE, FALSE, NULL);
+    done = CreateEventW(&sa, FALSE, FALSE, NULL);
+    GetModuleFileNameA(NULL, path, sizeof(path));
+    sprintf(command, "\"%s\" property child %Iu %u %Iu %Iu", path,
+            (ULONG_PTR)window, atom, (ULONG_PTR)start, (ULONG_PTR)done);
+    ret = CreateProcessA(NULL, command, NULL, NULL, TRUE, 0, NULL, NULL, &si, &pi);
+    ok(ret, "CreateProcess failed, error %lu.\n", GetLastError());
+    if (ret)
+    {
+        SetEvent(start);
+        ok(WaitForSingleObject(done, 10000) == WAIT_OBJECT_0, "Child set timed out.\n");
+        ok(GetPropW(window, MAKEINTRESOURCEW(atom)) == (HANDLE)0x5678, "Cross-process set was missed.\n");
+        SetEvent(start);
+        ok(WaitForSingleObject(done, 10000) == WAIT_OBJECT_0, "Child remove timed out.\n");
+        check_missing(window, atom);
+        winetest_wait_child_process(&pi);
+        CloseHandle(pi.hThread);
+        CloseHandle(pi.hProcess);
+    }
+    CloseHandle(start);
+    CloseHandle(done);
+
+    /* Atom-table changes without a window mutation must still affect strings. */
+    GetPropW(window, L"wine_property_lookup_lifetime");
+    GlobalDeleteAtom(atom);
+    SetLastError(0xdeadbeef);
+    GetPropW(window, L"wine_property_lookup_lifetime");
+    error = GetLastError();
+    SetLastError(0xdeadbeef);
+    GetPropW(second, L"wine_property_lookup_lifetime");
+    other_error = GetLastError();
+    ok(error == other_error, "Cached string error %lu differs from fresh window %lu.\n", error, other_error);
+
+    for (i = 0; i < ARRAY_SIZE(atoms); ++i)
+    {
+        char name[64];
+        sprintf(name, "wine_property_eviction_%u", i);
+        atoms[i] = GlobalAddAtomA(name);
+        check_missing(window, atoms[i]);
+    }
+    for (i = 0; i < ARRAY_SIZE(atoms); ++i)
+    {
+        SetPropW(window, MAKEINTRESOURCEW(atoms[i]), (HANDLE)(ULONG_PTR)(i + 1));
+        ok(GetPropW(window, MAKEINTRESOURCEW(atoms[i])) == (HANDLE)(ULONG_PTR)(i + 1), "Eviction/set mismatch %u.\n", i);
+        RemovePropW(window, MAKEINTRESOURCEW(atoms[i]));
+        GlobalDeleteAtom(atoms[i]);
+    }
+    check_missing(window, 1);
+    DestroyWindow(window);
+    for (i = 0; i < 2; ++i)
+    {
+        SetLastError(0xdeadbeef);
+        ok(!GetPropW(window, MAKEINTRESOURCEW(1)), "Destroyed window retained property.\n");
+        ok(GetLastError() == ERROR_INVALID_WINDOW_HANDLE, "Wrong destroyed-window error %lu.\n", GetLastError());
+    }
+    window = NULL;
+done_windows:
+    if (window) DestroyWindow(window);
+    if (second) DestroyWindow(second);
+}
+
+START_TEST(property)
+{
+    char **argv;
+    int argc = winetest_get_mainargs(&argv);
+    if (argc == 7 && !strcmp(argv[2], "child"))
+    {
+        HWND window = (HWND)(ULONG_PTR)strtoull(argv[3], NULL, 10);
+        ATOM atom = atoi(argv[4]);
+        HANDLE start = (HANDLE)(ULONG_PTR)strtoull(argv[5], NULL, 10);
+        HANDLE done = (HANDLE)(ULONG_PTR)strtoull(argv[6], NULL, 10);
+        ok(WaitForSingleObject(start, 10000) == WAIT_OBJECT_0, "Parent set signal timed out.\n");
+        ok(SetPropW(window, MAKEINTRESOURCEW(atom), (HANDLE)0x5678), "Child SetProp failed.\n");
+        SetEvent(done);
+        ok(WaitForSingleObject(start, 10000) == WAIT_OBJECT_0, "Parent remove signal timed out.\n");
+        ok(RemovePropW(window, MAKEINTRESOURCEW(atom)) == (HANDLE)0x5678, "Child RemoveProp failed.\n");
+        SetEvent(done);
+        return;
+    }
+    test_properties();
+}

--- a/dlls/win32u/window.c
+++ b/dlls/win32u/window.c
@@ -1770,20 +1770,77 @@ int get_window_pixel_format( HWND hwnd )
  * NOTE Native allows only ATOMs as the second argument. We allow strings
  *      to save extra server call in GetPropW.
  */
+/* Cache only negative property lookups. The server advances the shared window
+ * sequence on every property mutation, including writes from another process.
+ * The object id prevents a recycled HWND from inheriting a cached result. */
+static struct
+{
+    struct object_lock version;
+    ATOM atom;
+} missing_properties[16];
+static unsigned int next_missing_property;
+static pthread_mutex_t missing_properties_lock = PTHREAD_MUTEX_INITIALIZER;
+
+static BOOL get_window_property_version( HWND hwnd, struct object_lock *version )
+{
+    const window_shm_t *shared = NULL;
+    NTSTATUS status;
+
+    while ((status = get_shared_window( hwnd, version, &shared )) == STATUS_PENDING) {}
+    return !status;
+}
+
 HANDLE WINAPI NtUserGetProp( HWND hwnd, const WCHAR *str )
 {
+    struct object_lock before = OBJECT_LOCK_INIT, after = OBJECT_LOCK_INIT;
+    unsigned int i;
+    ATOM atom = IS_INTRESOURCE(str) ? LOWORD(str) : 0;
+    BOOL cacheable, success = FALSE, found = FALSE;
     ULONG_PTR ret = 0;
+
+    /* String queries also depend on the global atom table, whose mapping
+     * can change independently of this window. Only cache integer queries. */
+    cacheable = IS_INTRESOURCE(str) && get_window_property_version( hwnd, &before );
+    if (cacheable)
+    {
+        pthread_mutex_lock( &missing_properties_lock );
+        for (i = 0; i < ARRAY_SIZE(missing_properties); ++i)
+        {
+            if (missing_properties[i].version.id == before.id
+                    && missing_properties[i].version.seq == before.seq
+                    && missing_properties[i].atom == atom)
+            {
+                found = TRUE;
+                break;
+            }
+        }
+        pthread_mutex_unlock( &missing_properties_lock );
+        if (found) return 0;
+    }
 
     SERVER_START_REQ( get_window_property )
     {
         req->window = wine_server_user_handle( hwnd );
         if (IS_INTRESOURCE(str)) req->atom = LOWORD(str);
         else wine_server_add_data( req, str, lstrlenW(str) * sizeof(WCHAR) );
-        if (!wine_server_call_err( req )) ret = reply->data;
+        if ((success = !wine_server_call_err( req ))) ret = reply->data;
     }
     SERVER_END_REQ;
+
+    /* A concurrent mutation between the snapshot and the reply prevents caching.
+     * Errors must still take the server path to preserve their last-error value. */
+    if (cacheable && success && !ret && get_window_property_version( hwnd, &after )
+            && before.id == after.id && before.seq == after.seq)
+    {
+        pthread_mutex_lock( &missing_properties_lock );
+        i = next_missing_property++ % ARRAY_SIZE(missing_properties);
+        missing_properties[i].version = after;
+        missing_properties[i].atom = atom;
+        pthread_mutex_unlock( &missing_properties_lock );
+    }
     return (HANDLE)ret;
 }
+
 BOOL update_window_broadcast_exclusion( HWND hwnd, HWND target, BOOL add )
 {
     BOOL ret;

--- a/include/wine/server_protocol.h
+++ b/include/wine/server_protocol.h
@@ -7430,6 +7430,6 @@ union generic_reply
     struct alpc_create_port_reply alpc_create_port_reply;
 };
 
-#define SERVER_PROTOCOL_VERSION 966
+#define SERVER_PROTOCOL_VERSION 967
 
 #endif /* __WINE_WINE_SERVER_PROTOCOL_H */

--- a/server/window.c
+++ b/server/window.c
@@ -495,8 +495,13 @@ static void set_property( struct window *win, atom_t atom, lparam_t data, enum p
         }
         if (win->properties[i].atom == atom)
         {
-            win->properties[i].type = type;
-            win->properties[i].data = data;
+            /* Also invalidate clients' negative property lookup caches. */
+            SHARED_WRITE_BEGIN( win->shared, window_shm_t )
+            {
+                win->properties[i].type = type;
+                win->properties[i].data = data;
+            }
+            SHARED_WRITE_END;
             return;
         }
     }
@@ -521,9 +526,13 @@ static void set_property( struct window *win, atom_t atom, lparam_t data, enum p
         }
         free = win->prop_inuse++;
     }
-    win->properties[free].atom = atom;
-    win->properties[free].type = type;
-    win->properties[free].data = data;
+    SHARED_WRITE_BEGIN( win->shared, window_shm_t )
+    {
+        win->properties[free].atom = atom;
+        win->properties[free].type = type;
+        win->properties[free].data = data;
+    }
+    SHARED_WRITE_END;
 }
 
 /* remove a window property */
@@ -539,7 +548,11 @@ static lparam_t remove_property( struct window *win, atom_t atom )
         if (prop->atom == atom)
         {
             if (prop->type == PROP_TYPE_STRING) release_atom( table, atom );
-            prop->type = PROP_TYPE_FREE;
+            SHARED_WRITE_BEGIN( win->shared, window_shm_t )
+            {
+                prop->type = PROP_TYPE_FREE;
+            }
+            SHARED_WRITE_END;
             return prop->data;
         }
     }


### PR DESCRIPTION
Ordinary DXGI presentation asks Wine's server twice per frame whether DirectComposition window properties exist. Profiling found these repeated missing-property queries in the common presentation path, while sparse repair preparation itself took only a few microseconds.

Cache successful missing integer-atom property queries in win32u using the existing shared window identity and sequence. Server property insertions, replacements and removals advance that sequence, including changes from other processes. DXGI retains two internal property-name atoms for the swapchain's actual lifetime and uses atom queries. String queries retain their original server path because global atom mappings can change independently of the window. Errors remain uncached.

The server protocol version advances to967: new clients must reject an old server that does not provide the invalidation guarantee. This changes no shared layout. The cache is bounded to16 entries and never holds its mutex across an RPC.

Stacked on #91, which is stacked on #90. OpenGL sparse capabilities remain disabled; this improves the active full-copy path as well as the experimental sparse path.

Validation:
- Server, ntdll/win32u Unix components, both DXGI architectures and coupled protocol consumers rebuilt; regenerated request files are stable.
- Public User32 property regression covers cross-process mutation, NULL-to-value replacement, string/atom aliasing, eviction pressure and destroyed-window errors. Four final lanes each passed270 parent assertions plus4 child assertions, zero failures/skips.
- Final fallback-only Present1 history matrix: eight OpenGL lanes×1618 assertions and two software Vulkan controls×1517, all zero failures/skips.
-32 order-balanced benchmark runs on AMD REDWOOD/Mesa26.1.5, with separate prefixes per runner/display and no concurrent build. Each passed1184 assertions. Median per-run p95 Present1 caller latency:

| Display/mode | Before, microseconds | After, microseconds |
|---|---:|---:|
| Wayland sparse |143.40|96.45|
| Wayland full |156.05|96.10|
| Xwayland sparse |148.55|95.10|
| Xwayland full |145.50|95.50|

This is caller latency, not GPU execution time. Frame-completion p95 remained close to17.5–17.7ms. Experimental sparse was enabled only in the saved benchmark runners. The final protocol handshake change does not change the measured per-frame code; final builds/tests use the new protocol. The previous8% sparse p95 difference was not stable across repeats: a six-pair baseline rerun showed+1.45% on Wayland and-0.93% on Xwayland. A second-computer run on Intel Iris Xe/Mesa 26.2.2 passed the Vulkan history matrix and showed the same synthetic sparse copy reduction. A later Word run on its physical 1920x1080 60 Hz panel explicitly enabled experimental sparse OpenGL. Compared with the pre-PR90 full-copy build, render-burst onset changed from 12.7115 to 12.1423 ms at p50 and from 20.3171 to 20.3717 ms at p95; both confidence intervals crossed zero. Word CPU and memory also showed no repeatable change. No physical GPU reset was tested.

Fresh-context Astra/high reviewed commit5901b45d52a and is satisfied: https://github.com/ttv20/wine4office/pull/92#pullrequestreview-5138120109. Greptile also reported5/5 with no blocking findings. CodeRabbit completed the manual review of5901b45d52a with no actionable comments. Its generic80% docstring-coverage warning is not a Wine C repository requirement; the cache lifetime, invalidation and error contracts are documented inline. Qodo is paused and Sourcery quota is exhausted; the complete automated-review gate is blocked. Evidence is retained in local artifacts/plan10-sparse-perf-20260908/ and the task-owned remote workspace. No merge requested or performed.

The protocol guard was exercised against an old server and rejected the connection with version mismatch966/967, as intended.

