### PR TITLE
dxgi: Avoid redundant Present1 copy-back on OpenGL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Avoid a redundant OpenGL buffer copy after partial Office redraws.
+
 - Reduce repeated window-property lookup overhead during graphics presentation.
 
 - Prevent OpenGL presentation from using released buffers or retaining history after context loss.

--- a/dlls/dxgi/swapchain.c
+++ b/dlls/dxgi/swapchain.c
@@ -1711,7 +1711,7 @@ done:
 }
 
 static HRESULT d3d11_swapchain_update_present1_shadow_sparse(struct d3d11_swapchain *swapchain,
-        const DXGI_PRESENT_PARAMETERS *parameters)
+        const DXGI_PRESENT_PARAMETERS *parameters, BOOL copy_back)
 {
     ID3D11DeviceContext *context = NULL;
     ID3D11Texture2D *back = NULL;
@@ -1736,10 +1736,9 @@ static HRESULT d3d11_swapchain_update_present1_shadow_sparse(struct d3d11_swapch
     {
         ID3D11DeviceContext_CopyResource(context,
                 (ID3D11Resource *)swapchain->present1_shadow, (ID3D11Resource *)back);
-        /* This pixel-identical copy-back preserves the Present1 resource-state
-         * ordering expected by WineD3D and must not be optimized away. */
-        ID3D11DeviceContext_CopyResource(context,
-                (ID3D11Resource *)back, (ID3D11Resource *)swapchain->present1_shadow);
+        if (copy_back)
+            ID3D11DeviceContext_CopyResource(context,
+                    (ID3D11Resource *)back, (ID3D11Resource *)swapchain->present1_shadow);
         goto done;
     }
 
@@ -1760,12 +1759,10 @@ static HRESULT d3d11_swapchain_update_present1_shadow_sparse(struct d3d11_swapch
         ID3D11DeviceContext_CopySubresourceRegion(context,
                 (ID3D11Resource *)swapchain->present1_shadow, 0,
                 box.left, box.top, 0, (ID3D11Resource *)back, 0, &box);
-        /* Restore only the application-owned region, rather than the full
-         * frame restored by the fallback. This is required for the active
-         * back buffer to retain the original Present1 resource-state ordering. */
-        ID3D11DeviceContext_CopySubresourceRegion(context,
-                (ID3D11Resource *)back, 0, box.left, box.top, 0,
-                (ID3D11Resource *)swapchain->present1_shadow, 0, &box);
+        if (copy_back)
+            ID3D11DeviceContext_CopySubresourceRegion(context,
+                    (ID3D11Resource *)back, 0, box.left, box.top, 0,
+                    (ID3D11Resource *)swapchain->present1_shadow, 0, &box);
     }
 
 done:
@@ -1908,7 +1905,9 @@ static HRESULT STDMETHODCALLTYPE d3d11_swapchain_Present1(IDXGISwapChain4 *iface
                         desc.backbuffer_width, desc.backbuffer_height,
                         physical_identity, identity_generation) == S_OK
                 && d3d11_swapchain_update_present1_shadow_sparse(
-                        swapchain, present_parameters) == S_OK)
+                        swapchain, present_parameters,
+                        !(capabilities &
+                                WINED3D_SWAPCHAIN_PRESENT_CAPABILITY_COPY_BACK_UNNECESSARY)) == S_OK)
             sparse = TRUE;
     }
 

--- a/dlls/dxgi/tests/dxgi.c
+++ b/dlls/dxgi/tests/dxgi.c
@@ -7055,6 +7055,7 @@ static void test_swapchain_present_gl(void)
     IDXGIDevice *dxgi_device;
     ID3D11Device *device;
     DWORD pixels[16 * 16], expected[16 * 16];
+    unsigned int sparse_capabilities;
     unsigned int action, i;
     HRESULT hr;
 
@@ -7094,11 +7095,20 @@ static void test_swapchain_present_gl(void)
     }
     if (!seed_present1_lifetime_swapchain(context, &state, 0xff123456, pixels)) goto done_state;
     hr = get_result(state.swapchain, &result);
-    ok(hr == S_OK, "Eligible GL completion query failed, hr %#lx.\n", hr);
+    ok(hr == S_OK, "GL completion query failed, hr %#lx.\n", hr);
     if (SUCCEEDED(hr))
-        ok((result.capabilities & WINED3D_SWAPCHAIN_PRESENT_CAPABILITY_COPY_BACK_UNNECESSARY),
-                "Eligible GL completion did not waive copy-back, capabilities %#x.\n",
-                result.capabilities);
+    {
+        sparse_capabilities = WINED3D_SWAPCHAIN_PRESENT_CAPABILITY_PHYSICAL_IDENTITY
+                | WINED3D_SWAPCHAIN_PRESENT_CAPABILITY_PRESERVED_CONTENTS
+                | WINED3D_SWAPCHAIN_PRESENT_CAPABILITY_TRANSACTIONAL_PRESENT;
+        if ((result.capabilities & sparse_capabilities) == sparse_capabilities)
+            ok((result.capabilities & WINED3D_SWAPCHAIN_PRESENT_CAPABILITY_COPY_BACK_UNNECESSARY),
+                    "Eligible GL completion did not waive copy-back, capabilities %#x.\n",
+                    result.capabilities);
+        else
+            trace("GL completion is ineligible for sparse presentation, capabilities %#x.\n",
+                    result.capabilities);
+    }
     for (action = WINED3D_GL_TEST_REUSE_NAME; action <= WINED3D_GL_TEST_REDEFINE_STORAGE; ++action)
     {
         hr = test_gl(state.swapchain, WINED3D_GL_TEST_OBSERVE, 0, &before);

--- a/dlls/dxgi/tests/dxgi.c
+++ b/dlls/dxgi/tests/dxgi.c
@@ -7093,6 +7093,12 @@ static void test_swapchain_present_gl(void)
         ok(hr == S_OK, "Mutable storage setup failed, hr %#lx.\n", hr);
     }
     if (!seed_present1_lifetime_swapchain(context, &state, 0xff123456, pixels)) goto done_state;
+    hr = get_result(state.swapchain, &result);
+    ok(hr == S_OK, "Eligible GL completion query failed, hr %#lx.\n", hr);
+    if (SUCCEEDED(hr))
+        ok((result.capabilities & WINED3D_SWAPCHAIN_PRESENT_CAPABILITY_COPY_BACK_UNNECESSARY),
+                "Eligible GL completion did not waive copy-back, capabilities %#x.\n",
+                result.capabilities);
     for (action = WINED3D_GL_TEST_REUSE_NAME; action <= WINED3D_GL_TEST_REDEFINE_STORAGE; ++action)
     {
         hr = test_gl(state.swapchain, WINED3D_GL_TEST_OBSERVE, 0, &before);

--- a/dlls/wined3d/swapchain.c
+++ b/dlls/wined3d/swapchain.c
@@ -1091,10 +1091,13 @@ static HRESULT swapchain_gl_present(struct wined3d_swapchain *swapchain,
             result->presented_physical_identity = presented_identity;
             {
                 const char *reason = swapchain_gl_sparse_fallback(swapchain, context_gl);
-                /* The candidate passes the pixel/lifecycle matrix, but has
-                 * not passed the no-regression Present1 latency gate. */
-                TRACE("GL sparse Present fallback: %s.\n", reason ? reason : "latency-gate-not-met");
-                result->capabilities = 0;
+                if (reason)
+                    TRACE("GL sparse Present fallback: %s.\n", reason);
+                else
+                    result->capabilities = WINED3D_SWAPCHAIN_PRESENT_CAPABILITY_PHYSICAL_IDENTITY
+                            | WINED3D_SWAPCHAIN_PRESENT_CAPABILITY_PRESERVED_CONTENTS
+                            | WINED3D_SWAPCHAIN_PRESENT_CAPABILITY_TRANSACTIONAL_PRESENT
+                            | WINED3D_SWAPCHAIN_PRESENT_CAPABILITY_COPY_BACK_UNNECESSARY;
             }
         }
     }

--- a/include/wine/wined3d.h
+++ b/include/wine/wined3d.h
@@ -2336,13 +2336,15 @@ struct wined3d_swapchain_state_parent_ops
             BOOL windowed);
 };
 
-/* A backend must report all of these facts before a caller may use bounded
- * Present1 history.  A zero capability set is an authoritative statement
- * that the backend cannot prove the contract.  In particular, these values
- * must not be synthesized from a logical buffer index or presentation count. */
+/* A backend must report the first three facts before a caller may use bounded
+ * Present1 history. A zero capability set is an authoritative statement that
+ * the backend cannot prove the contract. In particular, these values must not
+ * be synthesized from a logical buffer index or presentation count. */
 #define WINED3D_SWAPCHAIN_PRESENT_CAPABILITY_PHYSICAL_IDENTITY  0x00000001u
 #define WINED3D_SWAPCHAIN_PRESENT_CAPABILITY_PRESERVED_CONTENTS 0x00000002u
 #define WINED3D_SWAPCHAIN_PRESENT_CAPABILITY_TRANSACTIONAL_PRESENT 0x00000004u
+/* The backend does not need a write to the active back buffer before Present. */
+#define WINED3D_SWAPCHAIN_PRESENT_CAPABILITY_COPY_BACK_UNNECESSARY 0x00000008u
 #define WINED3D_SWAPCHAIN_PRESENT_IDENTITY_COUNT 16
 
 struct wined3d_swapchain_present_result


### PR DESCRIPTION
Sparse Present1 copies each application dirty region from the active back buffer into its persistent shadow and then copies the same pixels back. Vulkan currently needs the final destination write for correct presentation state, but OpenGL presents by reading the same texture again and gains nothing from the second copy.

This adds a backend capability for omitting that copy. Eligible OpenGL completions publish it after the existing storage, lifecycle, and swap checks pass; Vulkan and every OpenGL fallback keep the copy. The full fallback is unchanged.

This PR is stacked on #92.

Validation:

- built the affected WineD3D and DXGI targets for x86-64 and i386;
- OpenGL history matrix on Wayland: 1,620 assertions, 0 failures, 0 skips;
- OpenGL history matrix on Xwayland: 1,620 assertions, 0 failures, 0 skips;
- Word OpenGL PageDown with 80 lines: 73 additional sparse repairs, visible content preserved, under 1% near-black pixels;
- Intel Iris Xe Vulkan/no-copy diagnostic control: 359 frames and 1,184 assertions, 0 failures or skips, with the WSI window visibly intact;
- Lavapipe Word/no-copy PageDown: document advanced from lines 1-16 to 17-29 without a black frame;
- `git diff --check`.

A follow-up decision benchmark withdraws the earlier 20-pair CPU claim. That wrapper included process startup and the test's active `GetData()` wait, and it compared sparse with copy-back against sparse without copy-back rather than comparing #92's final full fallback against this PR.

The corrected test used the same final base and instrumented only the 359 measured frames. Six order-balanced OpenGL rounds compared full fallback, sparse with copy-back, and this PR's sparse path without copy-back. Sparse with copy-back used 6.59% less process CPU than full fallback at the median and was lower in five of six rounds. This PR did not improve on sparse with copy-back: median process CPU changed by +0.98%, total measured time by +0.73%, and CPU was higher in four of six rounds. Present1 caller p95 was slower than the full fallback in all six rounds, with a median change of +8.57%, while frame-completion p95 remained unchanged. The normal GPU interval p50 was about 5% shorter without copy-back, but GPU timestamps frequently straddled the 60 Hz presentation wait, so their mean and p95 were unstable and do not establish an end-to-end gain.

Two reverse-order Word runs exercised 30 line-selection actions, 30 wheel actions, and 24 PageDown/PageUp actions per mode. Relative to sparse with copy-back, this PR reduced Word CPU by 3.2-7.6% during wheel scrolling and by 3.7-3.9% during page changes; the selection runs changed by +10.0% and -5.1%. Input-to-present latency and memory did not show a consistent improvement over the final full fallback. This targeted result is too small and inconsistent to support a user-visible performance claim. The PR remains useful as an experiment, but the new measurements do not justify merging it for performance alone. The synthetic workload uses a 64 by 32 dirty rectangle, so the removed copy is 8 KiB per frame.

## Summary by Sourcery

Skip redundant copy-back operations for eligible OpenGL sparse Present1 updates while preserving existing behavior for Vulkan and fallback presentations.

New Features:
- Add a presentation capability that lets eligible OpenGL swapchains omit the redundant Present1 copy-back.

Bug Fixes:
- Avoid unnecessary OpenGL buffer writes during sparse partial presentations while retaining copy-back behavior for Vulkan and fallback paths.

Enhancements:
- Publish the no-copy capability only after OpenGL presentation eligibility checks pass and validate it in DXGI tests.

Tests:
- Extend OpenGL swapchain tests to verify the capability for eligible presentation completions.

