### PR TITLE
d2d1: Skip hollow figures during self-intersection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Prevent hollow Direct2D paths from exhausting memory during geometry processing.
 - Retry Office installer downloads once, then offer manual download and file selection.
 - Bundle the certificate data needed to verify Office installers in standalone Manager builds.
 - Add Quick and Online Office repairs to the Manager and require Online Repair after a runner upgrade when Office is already installed.

--- a/dlls/d2d1/geometry.c
+++ b/dlls/d2d1/geometry.c
@@ -2754,6 +2754,9 @@ static BOOL d2d_geometry_intersect_self(struct d2d_geometry *geometry)
     for (idx_p.figure_idx = 0; idx_p.figure_idx < geometry->u.path.figure_count; ++idx_p.figure_idx)
     {
         figure_p = &geometry->u.path.figures[idx_p.figure_idx];
+        if (figure_p->flags & D2D_FIGURE_FLAG_HOLLOW)
+            continue;
+
         idx_p.control_idx = 0;
         for (idx_p.vertex_idx = 0; idx_p.vertex_idx < figure_p->vertex_count; ++idx_p.vertex_idx)
         {
@@ -2763,6 +2766,9 @@ static BOOL d2d_geometry_intersect_self(struct d2d_geometry *geometry)
             for (idx_q.figure_idx = 0; idx_q.figure_idx <= idx_p.figure_idx; ++idx_q.figure_idx)
             {
                 figure_q = &geometry->u.path.figures[idx_q.figure_idx];
+                if (figure_q->flags & D2D_FIGURE_FLAG_HOLLOW)
+                    continue;
+
                 if (idx_q.figure_idx != idx_p.figure_idx)
                 {
                     if (!d2d_rect_check_overlap(&figure_p->bounds, &figure_q->bounds))

--- a/dlls/d2d1/tests/d2d1.c
+++ b/dlls/d2d1/tests/d2d1.c
@@ -18594,6 +18594,8 @@ static HRESULT create_geometry_cache_pressure(ID2D1Factory *factory, ID2D1PathGe
         return hr;
     }
 
+    /* Coincident hollow curves exercise large simplified stroke entries without
+     * contributing to the geometry's fill or its self-intersection processing. */
     set_point(&point, 0.0f, 0.0f);
     ID2D1GeometrySink_BeginFigure(sink, point, D2D1_FIGURE_BEGIN_HOLLOW);
     for (i = 0; i < segment_count; ++i)
@@ -18615,6 +18617,11 @@ static HRESULT create_geometry_cache_pressure(ID2D1Factory *factory, ID2D1PathGe
     ID2D1GeometrySink_EndFigure(sink, D2D1_FIGURE_END_OPEN);
     hr = ID2D1GeometrySink_Close(sink);
     ID2D1GeometrySink_Release(sink);
+    if (FAILED(hr))
+    {
+        ID2D1PathGeometry_Release(*geometry);
+        *geometry = NULL;
+    }
     return hr;
 }
 


### PR DESCRIPTION
## Purpose

Prevent hollow Direct2D paths from exhausting memory while closing a geometry.

`test_geometry_cache_eviction` creates 800 coincident hollow Bezier curves. The fill self-intersection pass compared those curves even though hollow figures do not contribute to fill geometry. On i386 this returned `E_FAIL`; on x86_64 it exhausted an 8 GiB cgroup before the cache was reached.

## Changes

- Skip hollow figures on both sides of self-intersection processing, including mixed filled/hollow paths in either order.
- Preserve the existing cache-pressure regression and document why its coincident curves are intentional.
- Release the path geometry when the test helper's `Close()` fails, avoiding the secondary factory-reference failure.
- Add a user-facing changelog entry.

## Validation

- Canonical focused dry run: 8 compile/link commands for 4 explicit targets.
- Rebuilt `d2d1.dll` and `d2d1_test.exe` for i386 and x86_64 without warnings.
- `WINETEST_ONLY_GEOMETRY_CACHE_EVICTION=1`, x86_64: 20 tests, 0 failures, 0 skips, exit 0.
- Same focused test, i386: 20 tests, 0 failures, 0 skips, exit 0.
- Both runs completed in the task-owned KWin/Wayland environment with a 2 GiB cgroup; `oom=0` and `oom_kill=0`.
- `git diff --check` passed.
- Independent Astra review at high reasoning found no actionable findings.

## Risk

The change is limited to fill preprocessing. `EndFigure()` builds stroke outline data before self-intersection processing, while fill refinement, Bezier resolution, and triangulation already exclude hollow figures. The current focused test does not expose an internal eviction counter; it verifies the public draw path completes successfully under the intended cache pressure.

## Evidence

Local validation record: `/home/ttv20/Projects/wine-365/artifacts/geometry-cache-eviction-20260909/validation.md`

## Summary by Sourcery

Skip hollow figures during Direct2D fill self-intersection processing to prevent memory exhaustion when closing geometries.

Bug Fixes:
- Prevent hollow Direct2D figures from being included in fill self-intersection processing, avoiding excessive memory use and geometry failures.

Documentation:
- Document the hollow-figure geometry processing fix in the user-facing changelog.

Tests:
- Clarify the intentional coincident hollow-curve cache-pressure scenario and clean up failed test geometries to prevent secondary reference failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where hollow Direct2D paths could exhaust memory during geometry processing.
  - Hollow figures are now excluded from unnecessary self-intersection calculations, improving stability for complex path geometries.
  - Improved failure handling when closing path geometry, preventing invalid geometry references from being retained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->