### PR TITLE
Add distro packages, AppImage, and package-managed updates

### DIFF
--- a/.github/workflows/wine4office-release.yml
+++ b/.github/workflows/wine4office-release.yml
@@ -239,9 +239,11 @@ jobs:
               apt-get update
               apt-get install -y --no-install-recommends wine4office
               cmp /opt/wine4office/bin/Wine4OfficeManager "$2"
-              QT_QPA_PLATFORM=offscreen \
+              useradd --create-home package-test
+              runuser -u package-test -- env QT_QPA_PLATFORM=offscreen \
                 /opt/wine4office/bin/Wine4OfficeManager --smoke-test
-              /opt/wine4office/runner/bin/wine --version
+              runuser -u package-test -- \
+                /opt/wine4office/runner/bin/wine --version
             ' -- "$deb" "/work/release/Wine4OfficeManager-${version}-x86_64"
           docker run --rm --init \
             --mount "type=bind,src=$GITHUB_WORKSPACE,dst=/work" \
@@ -258,9 +260,11 @@ jobs:
                 > /etc/yum.repos.d/wine4office-test.repo
               dnf install -y wine4office
               cmp /opt/wine4office/bin/Wine4OfficeManager "$2"
-              QT_QPA_PLATFORM=offscreen \
+              useradd --create-home package-test
+              runuser -u package-test -- env QT_QPA_PLATFORM=offscreen \
                 /opt/wine4office/bin/Wine4OfficeManager --smoke-test
-              /opt/wine4office/runner/bin/wine --version
+              runuser -u package-test -- \
+                /opt/wine4office/runner/bin/wine --version
             ' -- "$rpm" "/work/release/Wine4OfficeManager-${version}-x86_64"
           tar -C release/repositories --sort=name --mtime=@0 --owner=0 --group=0 \
             --numeric-owner -czf "release/wine4office-${version}-repositories-unsigned.tar.gz" .

--- a/.github/workflows/wine4office-release.yml
+++ b/.github/workflows/wine4office-release.yml
@@ -229,20 +229,20 @@ jobs:
         run: |
           set -euo pipefail
           version='${{ steps.version.outputs.version }}'
-          tool="$RUNNER_TEMP/appimagetool-uruntime-x86_64.AppImage"
-          runtime="$RUNNER_TEMP/uruntime-appimage-squashfs-lite-x86_64"
+          mkdwarfs="$RUNNER_TEMP/mkdwarfs"
+          runtime="$RUNNER_TEMP/uruntime-appimage-dwarfs-lite-x86_64"
           curl --proto '=https' --tlsv1.2 --fail --location --retry 3 --show-error \
-            --output "$tool" \
-            https://github.com/pkgforge-dev/appimagetool-uruntime/releases/download/continuous/appimagetool-x86_64.AppImage
-          echo "4cfda236f46c425aef5bfe397c572663fe1bf7d0a8f62fd31197bad37438c1ca  $tool" \
+            --output "$mkdwarfs" \
+            https://github.com/mhx/dwarfs/releases/download/v0.15.6/dwarfs-universal-0.15.6-Linux-x86_64
+          echo "50891c38ba359db8271819a6cbf6aaa8068681523f0c4f2b8242007a45edaa28  $mkdwarfs" \
             | sha256sum --check
           curl --proto '=https' --tlsv1.2 --fail --location --retry 3 --show-error \
             --output "$runtime" \
-            https://github.com/VHSgunzo/uruntime/releases/download/v0.6.1/uruntime-appimage-squashfs-lite-x86_64
-          echo "e5463fa896fc583cab3b03e498fde5d311b6661bb6e184797081dfdb863bab82  $runtime" \
+            https://github.com/VHSgunzo/uruntime/releases/download/v0.7.1/uruntime-appimage-dwarfs-lite-x86_64
+          echo "f19d2a58b5f7cb372b8a88b1e9414fd118d8da6d2c555cf3e7c0bac9373b8af9  $runtime" \
             | sha256sum --check
-          chmod 0755 "$tool"
-          APPIMAGETOOL="$tool" APPIMAGE_RUNTIME="$runtime" \
+          chmod 0755 "$mkdwarfs" "$runtime"
+          APPIMAGE_MKDWARFS="$mkdwarfs" APPIMAGE_RUNTIME="$runtime" \
             tools/wine4office-manager/packaging/distribution/build-appimage.sh \
               "release/Wine4OfficeManager-${version}-x86_64" \
               "release/wine4office-${version}-x86_64.tar.zst" \

--- a/.github/workflows/wine4office-release.yml
+++ b/.github/workflows/wine4office-release.yml
@@ -194,23 +194,29 @@ jobs:
         run: |
           set -euo pipefail
           version='${{ steps.version.outputs.version }}'
-          manager="/work/release/Wine4OfficeManager-${version}-x86_64"
-          runner="/work/release/wine4office-${version}-x86_64.tar.zst"
+          container_workspace=/work
+          workspace_args=(--mount "type=bind,src=$GITHUB_WORKSPACE,dst=$container_workspace")
+          if [[ -n ${HOSTNAME:-} ]] && docker container inspect "$HOSTNAME" >/dev/null 2>&1; then
+            workspace_args=(--volumes-from "$HOSTNAME")
+            container_workspace=$GITHUB_WORKSPACE
+          fi
+          manager="$container_workspace/release/Wine4OfficeManager-${version}-x86_64"
+          runner="$container_workspace/release/wine4office-${version}-x86_64.tar.zst"
           docker run --rm --init \
-            --mount "type=bind,src=$GITHUB_WORKSPACE,dst=/work" \
-            --workdir /work ubuntu:24.04 bash -eu -c '
+            "${workspace_args[@]}" \
+            --workdir "$container_workspace" ubuntu:24.04 bash -eu -c '
               apt-get update
               apt-get install -y --no-install-recommends dpkg-dev python3 zstd
               tools/wine4office-manager/packaging/distribution/build-deb.sh \
-                "$1" "$2" "$3" apt wine4office /work/release
-            ' -- "$manager" "$runner" "$version"
+                "$1" "$2" "$3" apt wine4office "$4/release"
+            ' -- "$manager" "$runner" "$version" "$container_workspace"
           docker run --rm --init \
-            --mount "type=bind,src=$GITHUB_WORKSPACE,dst=/work" \
-            --workdir /work fedora:latest bash -eu -c '
+            "${workspace_args[@]}" \
+            --workdir "$container_workspace" fedora:latest bash -eu -c '
               dnf install -y python3 rpm-build tar zstd
               tools/wine4office-manager/packaging/distribution/build-rpm.sh \
-                "$1" "$2" "$3" dnf wine4office /work/release
-            ' -- "$manager" "$runner" "$version"
+                "$1" "$2" "$3" dnf wine4office "$4/release"
+            ' -- "$manager" "$runner" "$version" "$container_workspace"
           python3 tools/wine4office-manager/packaging/distribution/generate-community-packages.py \
             release/release.json release/community
           tar -C release/community --sort=name --mtime=@0 --owner=0 --group=0 \
@@ -265,16 +271,24 @@ jobs:
           deb=$(find "$GITHUB_WORKSPACE/release" -maxdepth 1 -name 'wine4office_*_amd64.deb' -print -quit)
           rpm=$(find "$GITHUB_WORKSPACE/release" -maxdepth 1 -name 'wine4office-*.x86_64.rpm' -print -quit)
           test -n "$deb" && test -n "$rpm"
-          deb="/work/release/$(basename "$deb")"
-          rpm="/work/release/$(basename "$rpm")"
+          container_workspace=/work
+          workspace_args=(--mount "type=bind,src=$GITHUB_WORKSPACE,dst=$container_workspace")
+          if [[ -n ${HOSTNAME:-} ]] && docker container inspect "$HOSTNAME" >/dev/null 2>&1; then
+            workspace_args=(--volumes-from "$HOSTNAME")
+            container_workspace=$GITHUB_WORKSPACE
+          fi
+          deb="$container_workspace/release/$(basename "$deb")"
+          rpm="$container_workspace/release/$(basename "$rpm")"
+          manager="$container_workspace/release/Wine4OfficeManager-${version}-x86_64"
+          repositories="$container_workspace/release/repositories"
           docker run --rm --init \
-            --mount "type=bind,src=$GITHUB_WORKSPACE,dst=/work" \
-            --workdir /work ubuntu:24.04 bash -eu -c '
+            "${workspace_args[@]}" \
+            --workdir "$container_workspace" ubuntu:24.04 bash -eu -c '
               apt-get update
               apt-get install -y --no-install-recommends apt-utils
               tools/wine4office-manager/packaging/distribution/build-apt-repository.sh \
-                /work/release/repositories/apt stable "$1"
-              printf "deb [trusted=yes] file:/work/release/repositories/apt stable main\n" \
+                "$3/apt" stable "$1"
+              printf "deb [trusted=yes] file:$3/apt stable main\n" \
                 > /etc/apt/sources.list.d/wine4office-test.list
               apt-get update
               apt-get install -y --no-install-recommends wine4office
@@ -284,17 +298,17 @@ jobs:
                 /opt/wine4office/bin/Wine4OfficeManager --smoke-test
               runuser -u package-test -- \
                 /opt/wine4office/runner/bin/wine --version
-            ' -- "$deb" "/work/release/Wine4OfficeManager-${version}-x86_64"
+            ' -- "$deb" "$manager" "$repositories"
           docker run --rm --init \
-            --mount "type=bind,src=$GITHUB_WORKSPACE,dst=/work" \
-            --workdir /work fedora:latest bash -eu -c '
+            "${workspace_args[@]}" \
+            --workdir "$container_workspace" fedora:latest bash -eu -c '
               dnf install -y createrepo_c
               tools/wine4office-manager/packaging/distribution/build-rpm-repository.sh \
-                /work/release/repositories "$1"
+                "$3" "$1"
               printf "%s\n" \
                 "[wine4office-test]" \
                 "name=Wine4Office test" \
-                "baseurl=file:///work/release/repositories/rpm/x86_64" \
+                "baseurl=file://$3/rpm/x86_64" \
                 "enabled=1" \
                 "gpgcheck=0" \
                 > /etc/yum.repos.d/wine4office-test.repo
@@ -305,7 +319,7 @@ jobs:
                 /opt/wine4office/bin/Wine4OfficeManager --smoke-test
               runuser -u package-test -- \
                 /opt/wine4office/runner/bin/wine --version
-            ' -- "$rpm" "/work/release/Wine4OfficeManager-${version}-x86_64"
+            ' -- "$rpm" "$manager" "$repositories"
           tar -C release/repositories --sort=name --mtime=@0 --owner=0 --group=0 \
             --numeric-owner -czf "release/wine4office-${version}-repositories-unsigned.tar.gz" .
 

--- a/.github/workflows/wine4office-release.yml
+++ b/.github/workflows/wine4office-release.yml
@@ -109,6 +109,8 @@ jobs:
         run: python3 programs/wine4officeauth/tests/test_authorize_url.py
       - name: Test canonical Wine build contract
         run: tools/wine-build-env/tests/test_build_contract.sh
+      - name: Test AppImage packaging contract
+        run: tools/wine4office-manager/packaging/distribution/tests/test-package-builders.sh appimage
 
       - name: Configure and build Wine4Office
         env:
@@ -216,6 +218,44 @@ jobs:
           tar -C release/community --sort=name --mtime=@0 --owner=0 --group=0 \
             --numeric-owner -czf "release/wine4office-${version}-nix.tar.gz" nix
 
+      - name: Build and smoke-test AppImage
+        shell: bash
+        run: |
+          set -euo pipefail
+          version='${{ steps.version.outputs.version }}'
+          tool="$RUNNER_TEMP/appimagetool-uruntime-x86_64.AppImage"
+          runtime="$RUNNER_TEMP/uruntime-appimage-squashfs-lite-x86_64"
+          curl --proto '=https' --tlsv1.2 --fail --location --retry 3 --show-error \
+            --output "$tool" \
+            https://github.com/pkgforge-dev/appimagetool-uruntime/releases/download/continuous/appimagetool-x86_64.AppImage
+          echo "4cfda236f46c425aef5bfe397c572663fe1bf7d0a8f62fd31197bad37438c1ca  $tool" \
+            | sha256sum --check
+          curl --proto '=https' --tlsv1.2 --fail --location --retry 3 --show-error \
+            --output "$runtime" \
+            https://github.com/VHSgunzo/uruntime/releases/download/v0.6.1/uruntime-appimage-squashfs-lite-x86_64
+          echo "e5463fa896fc583cab3b03e498fde5d311b6661bb6e184797081dfdb863bab82  $runtime" \
+            | sha256sum --check
+          chmod 0755 "$tool"
+          APPIMAGETOOL="$tool" APPIMAGE_RUNTIME="$runtime" \
+            tools/wine4office-manager/packaging/distribution/build-appimage.sh \
+              "release/Wine4OfficeManager-${version}-x86_64" \
+              "release/wine4office-${version}-x86_64.tar.zst" \
+              release/release.json release/install.sh release
+
+          appimage="$GITHUB_WORKSPACE/release/Wine4Office-${version}-x86_64.AppImage"
+          test_home=$(mktemp -d)
+          APPIMAGE_EXTRACT_AND_RUN=1 HOME="$test_home" \
+          XDG_DATA_HOME="$test_home/.local/share" \
+          WINE4OFFICE_HOME="$test_home/.local/share/wine4office" \
+          WINE4OFFICE_BIN_HOME="$test_home/.local/bin" \
+            "$appimage" --appimage-install-only
+          mv "$appimage" "$appimage.after-install"
+          QT_QPA_PLATFORM=offscreen \
+            "$test_home/.local/share/wine4office/bin/Wine4OfficeManager" --smoke-test
+          "$test_home/.local/share/wine4office/runner/bin/wine" --version \
+            | grep -Fx "wine4office-${version} (Wine $(sed -n 's/^Wine version //p' VERSION))"
+          mv "$appimage.after-install" "$appimage"
+
       - name: Build testable static repository trees
         shell: bash
         run: |
@@ -305,6 +345,8 @@ jobs:
           path: |
             release/*.deb
             release/*.rpm
+            release/Wine4Office-${{ steps.version.outputs.version }}-x86_64.AppImage
+            release/Wine4Office-${{ steps.version.outputs.version }}-x86_64.AppImage.sha256
             release/wine4office-${{ steps.version.outputs.version }}-aur.tar.gz
             release/wine4office-${{ steps.version.outputs.version }}-nix.tar.gz
             release/wine4office-${{ steps.version.outputs.version }}-repositories-unsigned.tar.gz
@@ -331,6 +373,8 @@ jobs:
             "release/release.json"
             "release/"*.deb
             "release/"*.rpm
+            "release/Wine4Office-${version}-x86_64.AppImage"
+            "release/Wine4Office-${version}-x86_64.AppImage.sha256"
             "release/wine4office-${version}-aur.tar.gz"
             "release/wine4office-${version}-nix.tar.gz"
             "release/wine4office-${version}-repositories-unsigned.tar.gz"

--- a/.github/workflows/wine4office-release.yml
+++ b/.github/workflows/wine4office-release.yml
@@ -302,7 +302,7 @@ jobs:
           docker run --rm --init \
             "${workspace_args[@]}" \
             --workdir "$container_workspace" fedora:latest bash -eu -c '
-              dnf install -y createrepo_c
+              dnf install -y createrepo_c diffutils shadow-utils util-linux
               tools/wine4office-manager/packaging/distribution/build-rpm-repository.sh \
                 "$3" "$1"
               printf "%s\n" \

--- a/.github/workflows/wine4office-release.yml
+++ b/.github/workflows/wine4office-release.yml
@@ -111,7 +111,18 @@ jobs:
         run: tools/wine-build-env/tests/test_build_contract.sh
 
       - name: Configure and build Wine4Office
+        env:
+          WINE4OFFICE_RELEASE_VERSION: ${{ steps.version.outputs.version }}
         run: tools/wine-build-env/run-build-container.sh full "$GITHUB_WORKSPACE" "$GITHUB_WORKSPACE/build" "$GITHUB_WORKSPACE/stage"
+
+      - name: Verify Wine4Office version branding
+        run: |
+          expected='wine4office-${{ steps.version.outputs.version }} (Wine '
+          actual=$(stage/opt/wine4office/bin/wine --version)
+          [[ $actual == "$expected"*')' ]] || {
+            echo "Unexpected Wine version: $actual" >&2
+            exit 1
+          }
 
       - name: Bundle Wine Gecko and Mono
         shell: bash
@@ -172,8 +183,87 @@ jobs:
             '${{ steps.version.outputs.version }}' \
             "$CONFIGURED_METADATA_URL" \
             "$release_base_url" \
-            '${{ steps.version.outputs.channel }}'
+            '${{ steps.version.outputs.channel }}' \
+            "$(sed -n 's/^Wine version //p' VERSION)"
           install -m 0755 install.sh release/install.sh
+
+      - name: Build distribution packages from release artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+          version='${{ steps.version.outputs.version }}'
+          manager="/work/release/Wine4OfficeManager-${version}-x86_64"
+          runner="/work/release/wine4office-${version}-x86_64.tar.zst"
+          docker run --rm --init \
+            --mount "type=bind,src=$GITHUB_WORKSPACE,dst=/work" \
+            --workdir /work ubuntu:24.04 bash -eu -c '
+              apt-get update
+              apt-get install -y --no-install-recommends dpkg-dev python3 zstd
+              tools/wine4office-manager/packaging/distribution/build-deb.sh \
+                "$1" "$2" "$3" apt wine4office /work/release
+            ' -- "$manager" "$runner" "$version"
+          docker run --rm --init \
+            --mount "type=bind,src=$GITHUB_WORKSPACE,dst=/work" \
+            --workdir /work fedora:latest bash -eu -c '
+              dnf install -y python3 rpm-build tar zstd
+              tools/wine4office-manager/packaging/distribution/build-rpm.sh \
+                "$1" "$2" "$3" dnf wine4office /work/release
+            ' -- "$manager" "$runner" "$version"
+          python3 tools/wine4office-manager/packaging/distribution/generate-community-packages.py \
+            release/release.json release/community
+          tar -C release/community --sort=name --mtime=@0 --owner=0 --group=0 \
+            --numeric-owner -czf "release/wine4office-${version}-aur.tar.gz" aur
+          tar -C release/community --sort=name --mtime=@0 --owner=0 --group=0 \
+            --numeric-owner -czf "release/wine4office-${version}-nix.tar.gz" nix
+
+      - name: Build testable static repository trees
+        shell: bash
+        run: |
+          set -euo pipefail
+          version='${{ steps.version.outputs.version }}'
+          mkdir -p release/repositories
+          deb=$(find "$GITHUB_WORKSPACE/release" -maxdepth 1 -name 'wine4office_*_amd64.deb' -print -quit)
+          rpm=$(find "$GITHUB_WORKSPACE/release" -maxdepth 1 -name 'wine4office-*.x86_64.rpm' -print -quit)
+          test -n "$deb" && test -n "$rpm"
+          deb="/work/release/$(basename "$deb")"
+          rpm="/work/release/$(basename "$rpm")"
+          docker run --rm --init \
+            --mount "type=bind,src=$GITHUB_WORKSPACE,dst=/work" \
+            --workdir /work ubuntu:24.04 bash -eu -c '
+              apt-get update
+              apt-get install -y --no-install-recommends apt-utils
+              tools/wine4office-manager/packaging/distribution/build-apt-repository.sh \
+                /work/release/repositories/apt stable "$1"
+              printf "deb [trusted=yes] file:/work/release/repositories/apt stable main\n" \
+                > /etc/apt/sources.list.d/wine4office-test.list
+              apt-get update
+              apt-get install -y --no-install-recommends wine4office
+              cmp /opt/wine4office/bin/Wine4OfficeManager "$2"
+              QT_QPA_PLATFORM=offscreen \
+                /opt/wine4office/bin/Wine4OfficeManager --smoke-test
+              /opt/wine4office/runner/bin/wine --version
+            ' -- "$deb" "/work/release/Wine4OfficeManager-${version}-x86_64"
+          docker run --rm --init \
+            --mount "type=bind,src=$GITHUB_WORKSPACE,dst=/work" \
+            --workdir /work fedora:latest bash -eu -c '
+              dnf install -y createrepo_c
+              tools/wine4office-manager/packaging/distribution/build-rpm-repository.sh \
+                /work/release/repositories "$1"
+              printf "%s\n" \
+                "[wine4office-test]" \
+                "name=Wine4Office test" \
+                "baseurl=file:///work/release/repositories/rpm/x86_64" \
+                "enabled=1" \
+                "gpgcheck=0" \
+                > /etc/yum.repos.d/wine4office-test.repo
+              dnf install -y wine4office
+              cmp /opt/wine4office/bin/Wine4OfficeManager "$2"
+              QT_QPA_PLATFORM=offscreen \
+                /opt/wine4office/bin/Wine4OfficeManager --smoke-test
+              /opt/wine4office/runner/bin/wine --version
+            ' -- "$rpm" "/work/release/Wine4OfficeManager-${version}-x86_64"
+          tar -C release/repositories --sort=name --mtime=@0 --owner=0 --group=0 \
+            --numeric-owner -czf "release/wine4office-${version}-repositories-unsigned.tar.gz" .
 
       - name: Upload Wine4OfficeManager CI artifact
         uses: actions/upload-artifact@v4
@@ -204,6 +294,19 @@ jobs:
             release/install.sh
           if-no-files-found: error
 
+      - name: Upload distribution packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: wine4office-distribution-packages-${{ steps.version.outputs.version }}
+          path: |
+            release/*.deb
+            release/*.rpm
+            release/wine4office-${{ steps.version.outputs.version }}-aur.tar.gz
+            release/wine4office-${{ steps.version.outputs.version }}-nix.tar.gz
+            release/wine4office-${{ steps.version.outputs.version }}-repositories-unsigned.tar.gz
+          if-no-files-found: error
+          compression-level: 0
+
       - name: Publish tagged GitHub release
         if: steps.version.outputs.tagged_release == 'true'
         shell: bash
@@ -222,6 +325,11 @@ jobs:
             "release/wine4office-${version}-x86_64.tar.zst.sha256"
             "release/install.sh"
             "release/release.json"
+            "release/"*.deb
+            "release/"*.rpm
+            "release/wine4office-${version}-aur.tar.gz"
+            "release/wine4office-${version}-nix.tar.gz"
+            "release/wine4office-${version}-repositories-unsigned.tar.gz"
           )
           gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 || \
             gh release create "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - Prevent hollow Direct2D paths from exhausting memory during geometry processing.
+- Add reusable AUR, Nix, Ubuntu, and Fedora packages and route packaged installations through their package manager for updates.
+- Show Wine4Office and upstream Wine versions separately in release builds.
 - Retry Office installer downloads once, then offer manual download and file selection.
 - Bundle the certificate data needed to verify Office installers in standalone Manager builds.
 - Add Quick and Online Office repairs to the Manager and require Online Repair after a runner upgrade when Office is already installed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Unreleased
 
 - Prevent hollow Direct2D paths from exhausting memory during geometry processing.
-- Add reusable AUR, Nix, Ubuntu, and Fedora packages and route packaged installations through their package manager for updates.
+- Add reusable AUR, Nix, Ubuntu, and Fedora packages with package-manager updates, unprivileged startup checks, and persistent Nix runtime wrappers.
+- Keep Authenticode verification working with multi-digit OpenSSL patch versions.
 - Show Wine4Office and upstream Wine versions separately in release builds.
 - Retry Office installer downloads once, then offer manual download and file selection.
 - Bundle the certificate data needed to verify Office installers in standalone Manager builds.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Prevent hollow Direct2D paths from exhausting memory during geometry processing.
-- Add reusable AUR, Nix, Ubuntu, and Fedora packages with package-manager updates, unprivileged startup checks, and persistent Nix runtime wrappers.
+- Add AppImage, AUR, Nix, Ubuntu, and Fedora packages with durable user installs, package-manager updates, and startup checks.
 - Keep Authenticode verification working with multi-digit OpenSSL patch versions.
 - Show Wine4Office and upstream Wine versions separately in release builds.
 - Retry Office installer downloads once, then offer manual download and file selection.

--- a/configure
+++ b/configure
@@ -4708,6 +4708,19 @@ case $with_wine4office_version in #(
   *) :
      ;;
 esac
+if test -n "$with_wine4office_version"
+then :
+  case $with_wine4office_version in #(
+  [A-Za-z0-9]*) :
+     ;; #(
+  *) :
+    as_fn_error $? "invalid Wine4Office release version: $with_wine4office_version" "$LINENO" 5 ;;
+esac
+  if test ${#with_wine4office_version} -gt 128
+then :
+  as_fn_error $? "Wine4Office release version is longer than 128 characters" "$LINENO" 5
+fi
+fi
 WINE4OFFICE_VERSION=$with_wine4office_version
 
 

--- a/configure
+++ b/configure
@@ -4698,15 +4698,16 @@ then :
 fi
 
 
-if test "x$with_wine4office_version" != x
-then :
-  case $with_wine4office_version in #(
+case $with_wine4office_version in #(
+  no) :
+    with_wine4office_version= ;; #(
+  yes) :
+    as_fn_error $? "--with-wine4office-version requires an explicit VERSION value" "$LINENO" 5 ;; #(
   *[!A-Za-z0-9._+-]*) :
     as_fn_error $? "invalid Wine4Office release version: $with_wine4office_version" "$LINENO" 5 ;; #(
   *) :
      ;;
 esac
-fi
 WINE4OFFICE_VERSION=$with_wine4office_version
 
 

--- a/configure
+++ b/configure
@@ -891,6 +891,7 @@ build_os
 build_vendor
 build_cpu
 build
+WINE4OFFICE_VERSION
 system_dllpath
 ECHO_T
 ECHO_N
@@ -945,6 +946,7 @@ enable_silent_rules
 enable_werror
 with_alsa
 with_capi
+with_wine4office_version
 with_coreaudio
 with_cups
 with_dbus
@@ -2624,6 +2626,9 @@ Optional Packages:
   --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
   --without-alsa          do not use the Alsa sound support
   --without-capi          do not use CAPI (ISDN support)
+  --with-wine4office-version=VERSION
+                          brand the Wine build with a Wine4Office release
+                          version
   --without-coreaudio     do not use the CoreAudio sound support
   --without-cups          do not use CUPS
   --without-dbus          do not use DBus (dynamic device support)
@@ -4355,6 +4360,13 @@ then :
 fi
 
 
+# Check whether --with-wine4office-version was given.
+if test ${with_wine4office_version+y}
+then :
+  withval=$with_wine4office_version;
+fi
+
+
 # Check whether --with-coreaudio was given.
 if test ${with_coreaudio+y}
 then :
@@ -4684,6 +4696,18 @@ if test ${with_wine64+y}
 then :
   withval=$with_wine64;
 fi
+
+
+if test "x$with_wine4office_version" != x
+then :
+  case $with_wine4office_version in #(
+  *[!A-Za-z0-9._+-]*) :
+    as_fn_error $? "invalid Wine4Office release version: $with_wine4office_version" "$LINENO" 5 ;; #(
+  *) :
+     ;;
+esac
+fi
+WINE4OFFICE_VERSION=$with_wine4office_version
 
 
 
@@ -23787,7 +23811,7 @@ fi
 
 as_fn_append wine_rules "
 dlls/ntdll/unix/version.c: dummy
-	@version=\`(GIT_DIR=${wine_srcdir}.git git describe HEAD 2>/dev/null || echo \"wine-\$(PACKAGE_VERSION)\") | sed -n -e '\$\$s/\(.*\)/const char wine_build[] = \"\\1\";/p'\` && (echo \$\$version | cmp -s - \$@) || echo \$\$version >\$@ || (rm -f \$@ && exit 1)
+	@if test -n \"\$(WINE4OFFICE_VERSION)\"; then version='const char wine_build[] = \"wine4office-\$(WINE4OFFICE_VERSION) (Wine \$(PACKAGE_VERSION))\";'; else version=\`(GIT_DIR=${wine_srcdir}.git git describe HEAD 2>/dev/null || echo \"wine-\$(PACKAGE_VERSION)\") | sed -n -e '\$\$s/\(.*\)/const char wine_build[] = \"\\1\";/p'\`; fi && (echo \$\$version | cmp -s - \$@) || echo \$\$version >\$@ || (rm -f \$@ && exit 1)
 programs/winetest/build.rc: dummy
 	@build=\"STRINGTABLE { 1 \\\"\`GIT_DIR=${wine_srcdir}.git git rev-parse HEAD 2>/dev/null\`\\\" }\" && (echo \$\$build | cmp -s - \$@) || echo \$\$build >\$@ || (rm -f \$@ && exit 1)
 dlls/wineandroid.drv/wine-debug.apk: dlls/wineandroid.drv/build.gradle ${wine_srcdir}dlls/wineandroid.drv/AndroidManifest.xml ${wine_srcdir}dlls/wineandroid.drv/WineActivity.java ${wine_srcdir}dlls/wineandroid.drv/wine.svg
@@ -24501,6 +24525,7 @@ ECHO_C = $ECHO_C
 ECHO_N = $ECHO_N
 ECHO_T = $ECHO_T
 system_dllpath = $system_dllpath
+WINE4OFFICE_VERSION = $WINE4OFFICE_VERSION
 build = $build
 build_cpu = $build_cpu
 build_vendor = $build_vendor

--- a/configure.ac
+++ b/configure.ac
@@ -92,9 +92,10 @@ AC_ARG_WITH(system-dllpath,AS_HELP_STRING([--with-system-dllpath=PATH],[load ext
 AC_ARG_WITH(wine-tools,AS_HELP_STRING([--with-wine-tools=DIR],[use Wine tools from directory DIR]))
 AC_ARG_WITH(wine64,    AS_HELP_STRING([--with-wine64=DIR],[use the 64-bit Wine in DIR for a Wow64 build]))
 
-AS_IF([test "x$with_wine4office_version" != x],
-      [AS_CASE([$with_wine4office_version],
-               [*[[!A-Za-z0-9._+-]]*], [AC_MSG_ERROR([invalid Wine4Office release version: $with_wine4office_version])])])
+AS_CASE([$with_wine4office_version],
+        [no], [with_wine4office_version=],
+        [yes], [AC_MSG_ERROR([--with-wine4office-version requires an explicit VERSION value])],
+        [*[[!A-Za-z0-9._+-]]*], [AC_MSG_ERROR([invalid Wine4Office release version: $with_wine4office_version])])
 AC_SUBST([WINE4OFFICE_VERSION], [$with_wine4office_version])
 
 AC_CANONICAL_HOST

--- a/configure.ac
+++ b/configure.ac
@@ -28,6 +28,7 @@ AC_ARG_ENABLE(werror, AS_HELP_STRING([--enable-werror],[treat compilation warnin
 
 AC_ARG_WITH(alsa,      AS_HELP_STRING([--without-alsa],[do not use the Alsa sound support]))
 AC_ARG_WITH(capi,      AS_HELP_STRING([--without-capi],[do not use CAPI (ISDN support)]))
+AC_ARG_WITH(wine4office-version, AS_HELP_STRING([--with-wine4office-version=VERSION],[brand the Wine build with a Wine4Office release version]))
 AC_ARG_WITH(coreaudio, AS_HELP_STRING([--without-coreaudio],[do not use the CoreAudio sound support]))
 AC_ARG_WITH(cups,      AS_HELP_STRING([--without-cups],[do not use CUPS]))
 AC_ARG_WITH(dbus,      AS_HELP_STRING([--without-dbus],[do not use DBus (dynamic device support)]))
@@ -90,6 +91,11 @@ AC_ARG_WITH(system-dllpath,AS_HELP_STRING([--with-system-dllpath=PATH],[load ext
             AC_SUBST(system_dllpath,[$withval]))
 AC_ARG_WITH(wine-tools,AS_HELP_STRING([--with-wine-tools=DIR],[use Wine tools from directory DIR]))
 AC_ARG_WITH(wine64,    AS_HELP_STRING([--with-wine64=DIR],[use the 64-bit Wine in DIR for a Wow64 build]))
+
+AS_IF([test "x$with_wine4office_version" != x],
+      [AS_CASE([$with_wine4office_version],
+               [*[[!A-Za-z0-9._+-]]*], [AC_MSG_ERROR([invalid Wine4Office release version: $with_wine4office_version])])])
+AC_SUBST([WINE4OFFICE_VERSION], [$with_wine4office_version])
 
 AC_CANONICAL_HOST
 AC_SUBST(srcdir)
@@ -3846,7 +3852,7 @@ dnl Rules for generated source files
 
 WINE_APPEND_RULE(
 [dlls/ntdll/unix/version.c: dummy
-	@version=\`(GIT_DIR=${wine_srcdir}.git git describe HEAD 2>/dev/null || echo \"wine-\$(PACKAGE_VERSION)\") | sed -n -e '\$\$s/\(.*\)/const char wine_build[[]] = \"\\1\";/p'\` && (echo \$\$version | cmp -s - \$[@]) || echo \$\$version >\$[@] || (rm -f \$[@] && exit 1)
+	@if test -n \"\$(WINE4OFFICE_VERSION)\"; then version='const char wine_build[[]] = \"wine4office-\$(WINE4OFFICE_VERSION) (Wine \$(PACKAGE_VERSION))\";'; else version=\`(GIT_DIR=${wine_srcdir}.git git describe HEAD 2>/dev/null || echo \"wine-\$(PACKAGE_VERSION)\") | sed -n -e '\$\$s/\(.*\)/const char wine_build[[]] = \"\\1\";/p'\`; fi && (echo \$\$version | cmp -s - \$[@]) || echo \$\$version >\$[@] || (rm -f \$[@] && exit 1)
 programs/winetest/build.rc: dummy
 	@build=\"STRINGTABLE { 1 \\\"\`GIT_DIR=${wine_srcdir}.git git rev-parse HEAD 2>/dev/null\`\\\" }\" && (echo \$\$build | cmp -s - \$[@]) || echo \$\$build >\$[@] || (rm -f \$[@] && exit 1)
 dlls/wineandroid.drv/wine-debug.apk: dlls/wineandroid.drv/build.gradle ${wine_srcdir}dlls/wineandroid.drv/AndroidManifest.xml ${wine_srcdir}dlls/wineandroid.drv/WineActivity.java ${wine_srcdir}dlls/wineandroid.drv/wine.svg

--- a/configure.ac
+++ b/configure.ac
@@ -96,6 +96,12 @@ AS_CASE([$with_wine4office_version],
         [no], [with_wine4office_version=],
         [yes], [AC_MSG_ERROR([--with-wine4office-version requires an explicit VERSION value])],
         [*[[!A-Za-z0-9._+-]]*], [AC_MSG_ERROR([invalid Wine4Office release version: $with_wine4office_version])])
+AS_IF([test -n "$with_wine4office_version"],
+      [AS_CASE([$with_wine4office_version],
+               [[A-Za-z0-9]]*, [],
+               [AC_MSG_ERROR([invalid Wine4Office release version: $with_wine4office_version])])
+       AS_IF([test ${#with_wine4office_version} -gt 128],
+             [AC_MSG_ERROR([Wine4Office release version is longer than 128 characters])])])
 AC_SUBST([WINE4OFFICE_VERSION], [$with_wine4office_version])
 
 AC_CANONICAL_HOST

--- a/install.sh
+++ b/install.sh
@@ -5,6 +5,7 @@ umask 077
 
 DEFAULT_METADATA_URL=https://github.com/ttv20/wine4office/releases/latest/download/release.json
 METADATA_URL=${WINE4OFFICE_METADATA_URL:-$DEFAULT_METADATA_URL}
+BUNDLE_DIR=${WINE4OFFICE_BUNDLE_DIR:-}
 DATA_HOME=${XDG_DATA_HOME:-$HOME/.local/share}
 BIN_HOME=${WINE4OFFICE_BIN_HOME:-$HOME/.local/bin}
 ROOT=${WINE4OFFICE_HOME:-$DATA_HOME/wine4office}
@@ -92,11 +93,20 @@ prompt_and_launch_manager() {
     esac
 }
 
-for command in curl flock install python3 readlink sha256sum stat zstd; do
+required_commands=(flock install python3 readlink sha256sum stat zstd)
+[[ -n $BUNDLE_DIR ]] || required_commands+=(curl)
+for command in "${required_commands[@]}"; do
     command -v "$command" >/dev/null 2>&1 || fail "$command is required"
 done
 [[ $(uname -m) == x86_64 ]] || fail "only x86_64 Linux is currently supported"
 [[ $METADATA_URL == https://* ]] || fail "metadata URL must use HTTPS"
+if [[ -n $BUNDLE_DIR ]]; then
+    [[ $BUNDLE_DIR == /* && -d $BUNDLE_DIR ]] || \
+        fail "bundled release directory must be an absolute directory"
+    BUNDLE_DIR=$(readlink -f "$BUNDLE_DIR")
+    [[ -f $BUNDLE_DIR/release.json && ! -L $BUNDLE_DIR/release.json ]] || \
+        fail "bundled release metadata is missing"
+fi
 ROOT=$(python3 - "$ROOT" "$HOME" <<'PY'
 import pathlib
 import sys
@@ -265,23 +275,39 @@ fetch_limited() {
         python3 "$TMP/bounded_download.py" "$destination" "$maximum"
 }
 
-printf 'Fetching release metadata…\n'
-fetch_limited "$METADATA_URL" "$TMP/release.json" 1048576
+copy_limited() {
+    local source=$1 destination=$2 maximum=$3 size
+    [[ -f $source && ! -L $source ]] || fail "bundled release artifact is missing: $source"
+    size=$(stat -c '%s' "$source")
+    ((size > 0 && size <= maximum)) || \
+        fail "bundled release artifact exceeds $maximum bytes: $source"
+    install -m 0600 "$source" "$destination"
+}
+
+if [[ -n $BUNDLE_DIR ]]; then
+    printf 'Reading bundled release metadata…\n'
+    copy_limited "$BUNDLE_DIR/release.json" "$TMP/release.json" 1048576
+else
+    printf 'Fetching release metadata…\n'
+    fetch_limited "$METADATA_URL" "$TMP/release.json" 1048576
+fi
 mapfile -t RELEASE < <(python3 - "$METADATA_URL" "$TMP/release.json" \
-    "$TAGGED_RELEASE" <<'PY'
+    "$TAGGED_RELEASE" "$([[ -n $BUNDLE_DIR ]] && echo true || echo false)" <<'PY'
 import json
 import re
 import sys
 import urllib.parse
 
-source, path, tagged_text = sys.argv[1:]
+source, path, tagged_text, bundled_text = sys.argv[1:]
 tagged_release = tagged_text == "true"
+bundled_release = bundled_text == "true"
 with open(path, "rb") as release_file:
     payload = json.load(release_file)
 if not isinstance(payload, dict) or payload.get("schema_version") != 1:
     raise SystemExit("release.json must use schema version 1")
 channel = payload.get("channel")
-allowed_channels = {"stable", "prerelease"} if tagged_release else {"stable"}
+allowed_channels = ({"stable", "prerelease"}
+                    if tagged_release or bundled_release else {"stable"})
 if channel not in allowed_channels:
     expected = "stable or prerelease" if tagged_release else "stable"
     raise SystemExit(f"release.json must use the {expected} channel")
@@ -325,9 +351,10 @@ if (wine_base_version != "unknown"
 for field in (*manager, *wine, canonical):
     print(field)
 print(wine_base_version)
+print(channel)
 PY
 )
-[[ ${#RELEASE[@]} -eq 10 ]] || fail "release metadata did not produce ten validated fields"
+[[ ${#RELEASE[@]} -eq 11 ]] || fail "release metadata did not produce eleven validated fields"
 MANAGER_VERSION=${RELEASE[0]}
 MANAGER_URL=${RELEASE[1]}
 MANAGER_SHA256=${RELEASE[2]}
@@ -338,11 +365,19 @@ WINE_SHA256=${RELEASE[6]}
 WINE_SIZE=${RELEASE[7]}
 CANONICAL_METADATA_URL=${RELEASE[8]}
 WINE_BASE_VERSION=${RELEASE[9]}
+RELEASE_CHANNEL=${RELEASE[10]}
 
-printf 'Downloading Wine4Office Manager %s…\n' "$MANAGER_VERSION"
-fetch_limited "$MANAGER_URL" "$TMP/Wine4OfficeManager" "$MANAGER_SIZE"
-printf 'Downloading Wine runner %s…\n' "$WINE_VERSION"
-fetch_limited "$WINE_URL" "$TMP/wine.tar.zst" "$WINE_SIZE"
+if [[ -n $BUNDLE_DIR ]]; then
+    printf 'Reading bundled Wine4Office Manager %s…\n' "$MANAGER_VERSION"
+    copy_limited "$BUNDLE_DIR/Wine4OfficeManager" "$TMP/Wine4OfficeManager" "$MANAGER_SIZE"
+    printf 'Reading bundled Wine runner %s…\n' "$WINE_VERSION"
+    copy_limited "$BUNDLE_DIR/wine.tar.zst" "$TMP/wine.tar.zst" "$WINE_SIZE"
+else
+    printf 'Downloading Wine4Office Manager %s…\n' "$MANAGER_VERSION"
+    fetch_limited "$MANAGER_URL" "$TMP/Wine4OfficeManager" "$MANAGER_SIZE"
+    printf 'Downloading Wine runner %s…\n' "$WINE_VERSION"
+    fetch_limited "$WINE_URL" "$TMP/wine.tar.zst" "$WINE_SIZE"
+fi
 
 verify() {
     path=$1
@@ -598,7 +633,7 @@ printf '%s\n' "$MANAGER_VERSION" > "$TMP/metadata/VERSION"
 printf '%s\n' "$WINE_VERSION" > "$TMP/metadata/WINE_VERSION"
 printf '%s\n' "$WINE_BASE_VERSION" > "$TMP/metadata/WINE_BASE_VERSION"
 printf '%s\n' "$CANONICAL_METADATA_URL" > "$TMP/metadata/UPDATE_URL"
-printf 'stable\n' > "$TMP/metadata/UPDATE_CHANNEL"
+printf '%s\n' "$RELEASE_CHANNEL" > "$TMP/metadata/UPDATE_CHANNEL"
 printf 'Wine4OfficeManager\n' > "$TMP/metadata/STANDALONE"
 chmod 0644 "$TMP/metadata"/*
 

--- a/install.sh
+++ b/install.sh
@@ -220,7 +220,7 @@ cleanup() {
         rm -rf -- "$RUNNER_BACKUP"
         rm -f -- "$MANAGER_BACKUP"
         rm -f -- "$UNINSTALLER_BACKUP"
-        for name in VERSION WINE_VERSION UPDATE_URL UPDATE_CHANNEL STANDALONE; do
+        for name in VERSION WINE_VERSION WINE_BASE_VERSION UPDATE_URL UPDATE_CHANNEL STANDALONE; do
             rm -f -- "$ROOT/.$name.old.$$"
         done
     fi
@@ -315,11 +315,16 @@ def artifact(name, maximum, expected_format=None):
 manager = artifact("manager", 1024**3)
 wine = artifact("wine", 8 * 1024**3, "tar.zst")
 canonical = https_url(payload.get("metadata_url"), source, "metadata")
+wine_base_version = payload["wine"].get("base_version", "unknown")
+if (wine_base_version != "unknown"
+        and not re.fullmatch(r"[0-9]+(?:[.][0-9A-Za-z]+)+", wine_base_version)):
+    raise SystemExit("invalid Wine base version")
 for field in (*manager, *wine, canonical):
     print(field)
+print(wine_base_version)
 PY
 )
-[[ ${#RELEASE[@]} -eq 9 ]] || fail "release metadata did not produce nine validated fields"
+[[ ${#RELEASE[@]} -eq 10 ]] || fail "release metadata did not produce ten validated fields"
 MANAGER_VERSION=${RELEASE[0]}
 MANAGER_URL=${RELEASE[1]}
 MANAGER_SHA256=${RELEASE[2]}
@@ -329,6 +334,7 @@ WINE_URL=${RELEASE[5]}
 WINE_SHA256=${RELEASE[6]}
 WINE_SIZE=${RELEASE[7]}
 CANONICAL_METADATA_URL=${RELEASE[8]}
+WINE_BASE_VERSION=${RELEASE[9]}
 
 printf 'Downloading Wine4Office Manager %s…\n' "$MANAGER_VERSION"
 fetch_limited "$MANAGER_URL" "$TMP/Wine4OfficeManager" "$MANAGER_SIZE"
@@ -399,7 +405,7 @@ rm -f -- "$ROOT/bin/wine4office-manager" "$ROOT/bin/wine4office-launcher" \
     "$ROOT/bin/wine4office-preload-worker"
 if $PURGE_RUNNER; then
     rm -rf -- "$ROOT/runner"
-    rm -f -- "$ROOT/VERSION" "$ROOT/WINE_VERSION" "$ROOT/UPDATE_URL" \
+    rm -f -- "$ROOT/VERSION" "$ROOT/WINE_VERSION" "$ROOT/WINE_BASE_VERSION" "$ROOT/UPDATE_URL" \
         "$ROOT/UPDATE_CHANNEL" "$ROOT/STANDALONE" "$ROOT/install.json" \
         "$ROOT/.wine4office-update.lock"
     rm -rf -- "$CONFIG_HOME/wine4office"
@@ -587,6 +593,7 @@ install -m 0755 "$TMP/wine4office-uninstall" "$NEW_UNINSTALLER"
 mv -- "$EXTRACTED_ROOT" "$NEW_RUNNER"
 printf '%s\n' "$MANAGER_VERSION" > "$TMP/metadata/VERSION"
 printf '%s\n' "$WINE_VERSION" > "$TMP/metadata/WINE_VERSION"
+printf '%s\n' "$WINE_BASE_VERSION" > "$TMP/metadata/WINE_BASE_VERSION"
 printf '%s\n' "$CANONICAL_METADATA_URL" > "$TMP/metadata/UPDATE_URL"
 printf 'stable\n' > "$TMP/metadata/UPDATE_CHANNEL"
 printf 'Wine4OfficeManager\n' > "$TMP/metadata/STANDALONE"
@@ -610,7 +617,7 @@ if [[ -e $UNINSTALLER_TARGET || -L $UNINSTALLER_TARGET ]]; then
 fi
 UNINSTALLER_CHANGED=true
 mv -- "$NEW_UNINSTALLER" "$UNINSTALLER_TARGET"
-for name in VERSION WINE_VERSION UPDATE_URL UPDATE_CHANNEL STANDALONE; do
+for name in VERSION WINE_VERSION WINE_BASE_VERSION UPDATE_URL UPDATE_CHANNEL STANDALONE; do
     backup=$ROOT/.$name.old.$$
     [[ ! -e $backup && ! -L $backup ]] || fail "stale metadata backup exists: $backup"
     if [[ -e $ROOT/$name || -L $ROOT/$name ]]; then mv -- "$ROOT/$name" "$backup"; fi

--- a/install.sh
+++ b/install.sh
@@ -317,7 +317,10 @@ wine = artifact("wine", 8 * 1024**3, "tar.zst")
 canonical = https_url(payload.get("metadata_url"), source, "metadata")
 wine_base_version = payload["wine"].get("base_version", "unknown")
 if (wine_base_version != "unknown"
-        and not re.fullmatch(r"[0-9]+(?:[.][0-9A-Za-z]+)+", wine_base_version)):
+        and not re.fullmatch(
+            r"[0-9]+(?:[.][0-9A-Za-z]+)+(?:[-+][0-9A-Za-z][0-9A-Za-z.-]*)?",
+            wine_base_version,
+        )):
     raise SystemExit("invalid Wine base version")
 for field in (*manager, *wine, canonical):
     print(field)

--- a/tools/wine-build-env/build.sh
+++ b/tools/wine-build-env/build.sh
@@ -24,6 +24,7 @@ jobs=${WINE_BUILD_JOBS:-18}
 max_compile_commands=${WINE_BUILD_MAX_COMPILE_COMMANDS:-80}
 image_id=${WINE_BUILD_IMAGE_ID:-unknown}
 reconfigure=${WINE_BUILD_RECONFIGURE:-0}
+release_version=${WINE4OFFICE_RELEASE_VERSION:-}
 
 [[ "$jobs" =~ ^[1-9][0-9]*$ ]] || { echo "WINE_BUILD_JOBS must be a positive integer" >&2; exit 2; }
 [[ "$prefix" == /opt/wine4office ]] || { echo "WINE_BUILD_PREFIX must be /opt/wine4office" >&2; exit 2; }
@@ -33,6 +34,10 @@ reconfigure=${WINE_BUILD_RECONFIGURE:-0}
 }
 [[ "$max_compile_commands" =~ ^[0-9]+$ ]] || {
     echo "WINE_BUILD_MAX_COMPILE_COMMANDS must be a non-negative integer" >&2
+    exit 2
+}
+[[ -z "$release_version" || "$release_version" =~ ^[A-Za-z0-9][A-Za-z0-9._+-]{0,127}$ ]] || {
+    echo "WINE4OFFICE_RELEASE_VERSION is invalid" >&2
     exit 2
 }
 [[ -x "$source_dir/configure" ]] || { echo "Invalid Wine source tree: $source_dir" >&2; exit 1; }
@@ -46,6 +51,10 @@ stage_dir=$(cd "$stage_dir" && pwd)
 }
 
 configure_build() {
+    local -a product_version_arg=()
+    if [[ -n "$release_version" ]]; then
+        product_version_arg=("--with-wine4office-version=$release_version")
+    fi
     if [[ "$reconfigure" == 1 || ! -f "$build_dir/Makefile" ]]; then
         echo "Configuring the canonical Office build in $build_dir"
         (
@@ -55,7 +64,8 @@ configure_build() {
                 --prefix="$prefix" \
                 --enable-archs=i386,x86_64 \
                 --with-gssapi \
-                --with-krb5
+                --with-krb5 \
+                "${product_version_arg[@]}"
         )
     fi
 
@@ -70,6 +80,15 @@ configure_build() {
             exit 1
         }
     done
+    if [[ -n "$release_version" ]]; then
+        grep -F -- "--with-wine4office-version=$release_version" "$build_dir/config.status" >/dev/null || {
+            echo "Build tree is branded for a different Wine4Office release" >&2
+            exit 1
+        }
+    elif grep -F -- "--with-wine4office-version=" "$build_dir/config.status" >/dev/null; then
+        echo "Development build tree unexpectedly has release branding" >&2
+        exit 1
+    fi
     grep -Fx "srcdir = $source_dir" "$build_dir/Makefile" >/dev/null || {
         echo "Build tree source provenance mismatch: expected $source_dir" >&2
         exit 1
@@ -117,6 +136,7 @@ configure_prefix=$prefix
 configure_archs=i386,x86_64
 configure_gssapi=required
 configure_krb5=required
+wine4office_release_version=${release_version:-development}
 jobs=$jobs
 EOF
     if [[ -n "$install_plan_sha256" ]]; then

--- a/tools/wine-build-env/build.sh
+++ b/tools/wine-build-env/build.sh
@@ -81,11 +81,11 @@ configure_build() {
         }
     done
     if [[ -n "$release_version" ]]; then
-        grep -F -- "--with-wine4office-version=$release_version" "$build_dir/config.status" >/dev/null || {
+        grep -Fx -- "WINE4OFFICE_VERSION = $release_version" "$build_dir/Makefile" >/dev/null || {
             echo "Build tree is branded for a different Wine4Office release" >&2
             exit 1
         }
-    elif grep -F -- "--with-wine4office-version=" "$build_dir/config.status" >/dev/null; then
+    elif ! grep -Fx -- "WINE4OFFICE_VERSION = " "$build_dir/Makefile" >/dev/null; then
         echo "Development build tree unexpectedly has release branding" >&2
         exit 1
     fi

--- a/tools/wine-build-env/run-build-container.sh
+++ b/tools/wine-build-env/run-build-container.sh
@@ -72,6 +72,7 @@ exec docker run --rm --init \
     --env WINE_BUILD_JOBS="$jobs" \
     --env WINE_BUILD_RECONFIGURE="${WINE_BUILD_RECONFIGURE:-0}" \
     --env WINE_BUILD_MAX_COMPILE_COMMANDS="${WINE_BUILD_MAX_COMPILE_COMMANDS:-80}" \
+    --env WINE4OFFICE_RELEASE_VERSION="${WINE4OFFICE_RELEASE_VERSION:-}" \
     --env WINE_BUILD_IMAGE_ID="$image_id" \
     "$image" \
     "$container_contract/build.sh" "$mode" "$@"

--- a/tools/wine-build-env/tests/test_build_contract.sh
+++ b/tools/wine-build-env/tests/test_build_contract.sh
@@ -15,6 +15,17 @@ if (cd "$tmp/configure-sentinel" && \
 fi
 grep -F -- '--with-wine4office-version requires an explicit VERSION value' \
     "$tmp/configure-sentinel.log" >/dev/null
+overlong_version=$(printf 'a%.0s' {1..129})
+for invalid_version in -rc1 "$overlong_version"; do
+    invalid_dir=$tmp/configure-invalid-${invalid_version:0:8}
+    mkdir "$invalid_dir"
+    if (cd "$invalid_dir" && \
+            "$root/configure" "--with-wine4office-version=$invalid_version") \
+            >"$invalid_dir.log" 2>&1; then
+        echo "Configure accepted an invalid Wine4Office version" >&2
+        exit 1
+    fi
+done
 
 assert_absent() {
     local pattern=$1

--- a/tools/wine-build-env/tests/test_build_contract.sh
+++ b/tools/wine-build-env/tests/test_build_contract.sh
@@ -196,8 +196,13 @@ grep -F 'libfreetype-dev:i386' "$contract/image/Dockerfile" >/dev/null
 grep -F 'libfontconfig-dev:i386' "$contract/image/Dockerfile" >/dev/null
 grep -F 'tools/wine-build-env/run-build-container.sh full' \
     "$root/.github/workflows/wine4office-release.yml" >/dev/null
-grep -F -- '--workdir /work ubuntu:24.04' \
+grep -F -- '--workdir "$container_workspace" ubuntu:24.04' \
     "$root/.github/workflows/wine4office-release.yml" >/dev/null
+[[ $(grep -Fc 'workspace_args=(--volumes-from "$HOSTNAME")' \
+    "$root/.github/workflows/wine4office-release.yml") -eq 2 ]] || {
+    echo "Release package containers must inherit a containerized runner workspace" >&2
+    exit 1
+}
 assert_absent 'Install build dependencies when permitted' \
     "$root/.github/workflows/wine4office-release.yml"
 grep -F -- '--exclude=/.git' "$contract/sync-agent-source.sh" >/dev/null

--- a/tools/wine-build-env/tests/test_build_contract.sh
+++ b/tools/wine-build-env/tests/test_build_contract.sh
@@ -198,6 +198,8 @@ grep -F 'tools/wine-build-env/run-build-container.sh full' \
     "$root/.github/workflows/wine4office-release.yml" >/dev/null
 grep -F -- '--workdir "$container_workspace" ubuntu:24.04' \
     "$root/.github/workflows/wine4office-release.yml" >/dev/null
+grep -F 'dnf install -y createrepo_c diffutils shadow-utils util-linux' \
+    "$root/.github/workflows/wine4office-release.yml" >/dev/null
 [[ $(grep -Fc 'workspace_args=(--volumes-from "$HOSTNAME")' \
     "$root/.github/workflows/wine4office-release.yml") -eq 2 ]] || {
     echo "Release package containers must inherit a containerized runner workspace" >&2

--- a/tools/wine-build-env/tests/test_build_contract.sh
+++ b/tools/wine-build-env/tests/test_build_contract.sh
@@ -58,6 +58,8 @@ build_env=(
 env "${build_env[@]}" "$contract/build.sh" configure
 grep -qx 'configure_archs=i386,x86_64' "$build_dir/WINE4OFFICE_BUILD.env"
 grep -qx 'jobs=12' "$build_dir/WINE4OFFICE_BUILD.env"
+grep -qx 'wine4office_release_version=development' \
+    "$build_dir/WINE4OFFICE_BUILD.env"
 provenance_before=$(sha256sum "$build_dir/WINE4OFFICE_BUILD.env")
 if env "${build_env[@]}" "$contract/build.sh" invalid >"$tmp/invalid-mode.log" 2>&1; then
     echo "Build contract accepted an invalid mode" >&2
@@ -67,6 +69,25 @@ fi
     echo "Invalid mode changed build provenance" >&2
     exit 1
 }
+
+sed -i "s/--with-krb5/--with-krb5 --with-wine4office-version=0.2.2/" \
+    "$build_dir/config.status"
+env "${build_env[@]}" WINE4OFFICE_RELEASE_VERSION=0.2.2 \
+    "$contract/build.sh" configure
+grep -qx 'wine4office_release_version=0.2.2' \
+    "$build_dir/WINE4OFFICE_BUILD.env"
+if env "${build_env[@]}" WINE4OFFICE_RELEASE_VERSION=0.2.3 \
+        "$contract/build.sh" configure >"$tmp/wrong-brand.log" 2>&1; then
+    echo "Build contract accepted a differently branded Wine tree" >&2
+    exit 1
+fi
+grep -F 'branded for a different Wine4Office release' \
+    "$tmp/wrong-brand.log" >/dev/null
+sed -i 's/ --with-wine4office-version=0.2.2//' "$build_dir/config.status"
+env "${build_env[@]}" "$contract/build.sh" configure
+
+grep -F 'wine4office-\$(WINE4OFFICE_VERSION) (Wine \$(PACKAGE_VERSION))' \
+    "$root/configure.ac" >/dev/null
 
 cp "$build_dir/include/config.h" "$tmp/config.good"
 sed -i '/SONAME_LIBGSSAPI_KRB5/d' "$build_dir/include/config.h"

--- a/tools/wine-build-env/tests/test_build_contract.sh
+++ b/tools/wine-build-env/tests/test_build_contract.sh
@@ -6,6 +6,16 @@ contract=$root/tools/wine-build-env
 tmp=$(mktemp -d)
 trap 'rm -rf -- "$tmp"' EXIT
 
+mkdir "$tmp/configure-sentinel"
+if (cd "$tmp/configure-sentinel" && \
+        "$root/configure" --with-wine4office-version) \
+        >"$tmp/configure-sentinel.log" 2>&1; then
+    echo "Configure accepted Wine4Office branding without an explicit version" >&2
+    exit 1
+fi
+grep -F -- '--with-wine4office-version requires an explicit VERSION value' \
+    "$tmp/configure-sentinel.log" >/dev/null
+
 assert_absent() {
     local pattern=$1
     local file=$2
@@ -31,7 +41,7 @@ mkdir -p "$source_dir/tools/wine4office-manager/packaging/linux-uapi" \
     "$build_dir/include" "$stage_dir" "$fake_bin"
 printf '#!/bin/sh\nexit 99\n' > "$source_dir/configure"
 chmod 0755 "$source_dir/configure"
-printf 'srcdir = %s\n' "$source_dir" > "$build_dir/Makefile"
+printf 'srcdir = %s\nWINE4OFFICE_VERSION = \n' "$source_dir" > "$build_dir/Makefile"
 cat > "$build_dir/config.status" <<'EOF'
 ac_cs_config='--prefix=/opt/wine4office --enable-archs=i386,x86_64 --with-gssapi --with-krb5'
 EOF
@@ -72,18 +82,23 @@ fi
 
 sed -i "s/--with-krb5/--with-krb5 --with-wine4office-version=0.2.2/" \
     "$build_dir/config.status"
+sed -i 's/^WINE4OFFICE_VERSION = $/WINE4OFFICE_VERSION = 0.2.2/' \
+    "$build_dir/Makefile"
 env "${build_env[@]}" WINE4OFFICE_RELEASE_VERSION=0.2.2 \
     "$contract/build.sh" configure
 grep -qx 'wine4office_release_version=0.2.2' \
     "$build_dir/WINE4OFFICE_BUILD.env"
-if env "${build_env[@]}" WINE4OFFICE_RELEASE_VERSION=0.2.3 \
+sed -i 's/0.2.2/0.2.22/g' "$build_dir/config.status" "$build_dir/Makefile"
+if env "${build_env[@]}" WINE4OFFICE_RELEASE_VERSION=0.2.2 \
         "$contract/build.sh" configure >"$tmp/wrong-brand.log" 2>&1; then
-    echo "Build contract accepted a differently branded Wine tree" >&2
+    echo "Build contract accepted a prefix-matching Wine4Office brand" >&2
     exit 1
 fi
 grep -F 'branded for a different Wine4Office release' \
     "$tmp/wrong-brand.log" >/dev/null
-sed -i 's/ --with-wine4office-version=0.2.2//' "$build_dir/config.status"
+sed -i 's/ --with-wine4office-version=0.2.22//' "$build_dir/config.status"
+sed -i 's/^WINE4OFFICE_VERSION = 0.2.22$/WINE4OFFICE_VERSION = /' \
+    "$build_dir/Makefile"
 env "${build_env[@]}" "$contract/build.sh" configure
 
 grep -F 'wine4office-\$(WINE4OFFICE_VERSION) (Wine \$(PACKAGE_VERSION))' \

--- a/tools/wine-build-env/tests/test_build_contract.sh
+++ b/tools/wine-build-env/tests/test_build_contract.sh
@@ -149,7 +149,10 @@ grep -F 'libfreetype-dev:i386' "$contract/image/Dockerfile" >/dev/null
 grep -F 'libfontconfig-dev:i386' "$contract/image/Dockerfile" >/dev/null
 grep -F 'tools/wine-build-env/run-build-container.sh full' \
     "$root/.github/workflows/wine4office-release.yml" >/dev/null
-assert_absent 'apt-get install' "$root/.github/workflows/wine4office-release.yml"
+grep -F -- '--workdir /work ubuntu:24.04' \
+    "$root/.github/workflows/wine4office-release.yml" >/dev/null
+assert_absent 'Install build dependencies when permitted' \
+    "$root/.github/workflows/wine4office-release.yml"
 grep -F -- '--exclude=/.git' "$contract/sync-agent-source.sh" >/dev/null
 assert_absent '--exclude=/.git/' "$contract/sync-agent-source.sh"
 grep -F 'docker container inspect "$HOSTNAME"' "$contract/run-build-container.sh" >/dev/null

--- a/tools/wine4office-manager/README.md
+++ b/tools/wine4office-manager/README.md
@@ -151,6 +151,7 @@ The generic Zstandard Wine archive has one root, `wine4office-1.0.0-x86_64/`. Pa
   },
   "wine": {
     "version": "1.0.0",
+    "base_version": "11.17",
     "url": "https://github.com/ttv20/wine4office/releases/latest/download/wine4office-1.0.0-x86_64.tar.zst",
     "sha256": "64 lowercase hexadecimal characters",
     "size": 123456789,
@@ -164,6 +165,13 @@ Artifact URLs may be absolute HTTPS URLs or paths relative to `metadata_url`. A 
 ## GitHub CI/CD
 
 `.github/workflows/wine4office-release.yml` runs manually and for `wine4office-v*` tags on a `self-hosted`, `linux`, `x64` GitHub Actions runner. It reuses the Wine configure/build/install staging process, builds Wine4Office Manager as a separate PyInstaller binary, packages the manager and Wine artifacts, and publishes `install.sh`. The manager pair, Wine pair, and release metadata plus installer are uploaded as separate CI artifacts.
+
+The same workflow packages those exact artifacts as DEB and RPM files and
+generates fixed-hash AUR and Nix sources. Packaged installations contain a
+root-owned `PACKAGE-INSTALLATION.json`. The Manager uses it to send APT and DNF
+updates through the system package manager, show AUR or Nix update instructions,
+and reject direct replacement of package-owned Manager or Wine files. See
+`packaging/distribution/README.md` for repository layout and signing.
 
 Tagged runs use the workflow's `contents: write` permission and `GITHUB_TOKEN` to create the GitHub Release when needed, then upload the manager pair, Wine pair, `install.sh`, and finally `release.json` with `gh release upload --clobber`. Publishing `release.json` last keeps it as the feed commit marker. Reruns replace matching assets instead of creating duplicates.
 

--- a/tools/wine4office-manager/README.md
+++ b/tools/wine4office-manager/README.md
@@ -170,7 +170,10 @@ The same workflow packages those exact artifacts as DEB and RPM files and
 generates fixed-hash AUR and Nix sources. Packaged installations contain a
 root-owned `PACKAGE-INSTALLATION.json`. The Manager uses it to send APT and DNF
 updates through the system package manager, show AUR or Nix update instructions,
-and reject direct replacement of package-owned Manager or Wine files. See
+hide standalone feed and prerelease controls, and reject direct replacement of
+package-owned Manager or Wine files. Package updates are verified by rereading
+the installed component versions before Wine migration or Manager restart work.
+See
 `packaging/distribution/README.md` for repository layout and signing.
 
 Tagged runs use the workflow's `contents: write` permission and `GITHUB_TOKEN` to create the GitHub Release when needed, then upload the manager pair, Wine pair, `install.sh`, and finally `release.json` with `gh release upload --clobber`. Publishing `release.json` last keeps it as the feed commit marker. Reruns replace matching assets instead of creating duplicates.

--- a/tools/wine4office-manager/packaging/build-release-artifacts.sh
+++ b/tools/wine4office-manager/packaging/build-release-artifacts.sh
@@ -30,10 +30,10 @@ mono="$RUNNER/share/wine/mono/wine-mono-${MONO_VERSION}-x86.msi"
 [[ $VERSION =~ ^[A-Za-z0-9][A-Za-z0-9._+-]{0,127}$ ]] || { echo "Unsafe version: $VERSION" >&2; exit 1; }
 [[ $CHANNEL =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$ ]] || { echo "Unsafe channel: $CHANNEL" >&2; exit 1; }
 if [[ -n $WINE_BASE_VERSION ]]; then
-    [[ $WINE_BASE_VERSION =~ ^[0-9]+([.][0-9A-Za-z]+)+$ ]] || {
+    [[ $WINE_BASE_VERSION =~ ^[0-9]+([.][0-9A-Za-z]+)+([-+][0-9A-Za-z][0-9A-Za-z.-]*)?$ ]] || {
         echo "Unsafe Wine base version: $WINE_BASE_VERSION" >&2; exit 1;
     }
-    [[ $($RUNNER/bin/wine --version) == "wine4office-${VERSION} (Wine ${WINE_BASE_VERSION})" ]] || {
+    [[ $("$RUNNER/bin/wine" --version) == "wine4office-${VERSION} (Wine ${WINE_BASE_VERSION})" ]] || {
         echo "Wine runner branding does not match the release and base versions" >&2
         exit 1
     }

--- a/tools/wine4office-manager/packaging/build-release-artifacts.sh
+++ b/tools/wine4office-manager/packaging/build-release-artifacts.sh
@@ -3,10 +3,10 @@
 set -euo pipefail
 
 usage() {
-    echo "Usage: $0 RUNNER_DIR MANAGER_BINARY OUTPUT_DIR VERSION METADATA_URL [RELEASE_BASE_URL] [CHANNEL]" >&2
+    echo "Usage: $0 RUNNER_DIR MANAGER_BINARY OUTPUT_DIR VERSION METADATA_URL [RELEASE_BASE_URL] [CHANNEL] [WINE_BASE_VERSION]" >&2
     exit 2
 }
-[[ $# -ge 5 && $# -le 7 ]] || usage
+[[ $# -ge 5 && $# -le 8 ]] || usage
 
 RUNNER=$(cd "$1" && pwd)
 MANAGER=$(cd "$(dirname "$2")" && pwd)/$(basename "$2")
@@ -15,6 +15,7 @@ VERSION=$4
 METADATA_URL=$5
 RELEASE_BASE_URL=${6:-}
 CHANNEL=${7:-stable}
+WINE_BASE_VERSION=${8:-}
 
 [[ -x "$RUNNER/bin/wine" ]] || { echo "Runner has no executable bin/wine: $RUNNER" >&2; exit 1; }
 [[ -x "$MANAGER" ]] || { echo "Wine4Office Manager binary is missing or not executable: $MANAGER" >&2; exit 1; }
@@ -28,6 +29,15 @@ mono="$RUNNER/share/wine/mono/wine-mono-${MONO_VERSION}-x86.msi"
 [[ -f "$mono" ]] || { echo "Runner is missing bundled Wine Mono: $mono" >&2; exit 1; }
 [[ $VERSION =~ ^[A-Za-z0-9][A-Za-z0-9._+-]{0,127}$ ]] || { echo "Unsafe version: $VERSION" >&2; exit 1; }
 [[ $CHANNEL =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$ ]] || { echo "Unsafe channel: $CHANNEL" >&2; exit 1; }
+if [[ -n $WINE_BASE_VERSION ]]; then
+    [[ $WINE_BASE_VERSION =~ ^[0-9]+([.][0-9A-Za-z]+)+$ ]] || {
+        echo "Unsafe Wine base version: $WINE_BASE_VERSION" >&2; exit 1;
+    }
+    [[ $($RUNNER/bin/wine --version) == "wine4office-${VERSION} (Wine ${WINE_BASE_VERSION})" ]] || {
+        echo "Wine runner branding does not match the release and base versions" >&2
+        exit 1
+    }
+fi
 command -v zstd >/dev/null || { echo "zstd is required" >&2; exit 1; }
 
 mkdir -p "$OUTPUT_DIR"
@@ -81,6 +91,7 @@ tar --zstd -tf "$TMP/$WINE_NAME" \
 )
 
 VERSION="$VERSION" CHANNEL="$CHANNEL" METADATA_URL="$METADATA_URL" \
+WINE_BASE_VERSION="$WINE_BASE_VERSION" \
 RELEASE_BASE_URL="$RELEASE_BASE_URL" MANAGER_NAME="$MANAGER_NAME" WINE_NAME="$WINE_NAME" \
 MANAGER_SHA256="$(sha256sum "$TMP/$MANAGER_NAME" | cut -d ' ' -f 1)" \
 MANAGER_SIZE="$(stat -c '%s' "$TMP/$MANAGER_NAME")" \
@@ -129,6 +140,8 @@ release = {
         "format": "tar.zst",
     },
 }
+if os.environ["WINE_BASE_VERSION"]:
+    release["wine"]["base_version"] = os.environ["WINE_BASE_VERSION"]
 with open(sys.argv[1], "w", encoding="utf-8") as destination:
     json.dump(release, destination, indent=2)
     destination.write("\n")

--- a/tools/wine4office-manager/packaging/distribution/README.md
+++ b/tools/wine4office-manager/packaging/distribution/README.md
@@ -9,10 +9,29 @@ The package layout is `/opt/wine4office`, with command links in `/usr/bin`.
 User prefixes, Office installations, configuration, and documents stay in the
 user's home directory and package removal does not delete them.
 
-`build-deb.sh` and `build-rpm.sh` consume the two release artifacts. The release
-workflow runs each builder in its matching distribution container. AUR and Nix
-sources are generated from `release.json`, so their URLs and SHA-256 hashes are
-fixed to one release.
+`build-deb.sh`, `build-rpm.sh`, and `build-appimage.sh` consume the same release
+artifacts. The release workflow runs the DEB and RPM builders in matching
+distribution containers. AUR and Nix sources are generated from `release.json`,
+so their URLs and SHA-256 hashes are fixed to one release.
+
+The AppImage is a single-file installer. Its first launch verifies and installs
+the bundled Manager and Wine runner under `~/.local/share/wine4office`, then runs
+the installed Manager. Later launches reuse that durable installation. Office
+shortcuts, Wine services, and updates therefore keep working if the downloaded
+AppImage is moved or removed. The installed copy follows the existing standalone
+release feed and does not claim package-manager ownership.
+
+Build an AppImage with the pinned `appimagetool-uruntime` used by the release
+workflow:
+
+```bash
+APPIMAGETOOL=/path/to/appimagetool-x86_64.AppImage \
+APPIMAGE_RUNTIME=/path/to/uruntime-appimage-squashfs-lite-x86_64 \
+tools/wine4office-manager/packaging/distribution/build-appimage.sh \
+    release/Wine4OfficeManager-VERSION-x86_64 \
+    release/wine4office-VERSION-x86_64.tar.zst \
+    release/release.json release/install.sh release
+```
 
 APT and RPM repositories are static HTTPS directory trees. Run
 `build-apt-repository.sh` or `build-rpm-repository.sh` with

--- a/tools/wine4office-manager/packaging/distribution/README.md
+++ b/tools/wine4office-manager/packaging/distribution/README.md
@@ -23,7 +23,8 @@ release artifacts for testing only.
 
 Published package filenames are immutable. Rebuilds with different bytes must
 use a new DEB version or RPM release so existing repository metadata never
-points to replaced content.
+points to replaced content. Enabling RPM package signing for a previously
+unsigned filename also requires a new RPM release.
 
 Packaged installations use the distribution package source as their update
 authority. The Manager hides the standalone metadata URL, prerelease selector,

--- a/tools/wine4office-manager/packaging/distribution/README.md
+++ b/tools/wine4office-manager/packaging/distribution/README.md
@@ -21,12 +21,12 @@ shortcuts, Wine services, and updates therefore keep working if the downloaded
 AppImage is moved or removed. The installed copy follows the existing standalone
 release feed and does not claim package-manager ownership.
 
-Build an AppImage with the pinned `appimagetool-uruntime` used by the release
-workflow:
+Build a reproducible DwarFS AppImage with the pinned `mkdwarfs` and `uruntime`
+used by the release workflow:
 
 ```bash
-APPIMAGETOOL=/path/to/appimagetool-x86_64.AppImage \
-APPIMAGE_RUNTIME=/path/to/uruntime-appimage-squashfs-lite-x86_64 \
+APPIMAGE_MKDWARFS=/path/to/mkdwarfs \
+APPIMAGE_RUNTIME=/path/to/uruntime-appimage-dwarfs-lite-x86_64 \
 tools/wine4office-manager/packaging/distribution/build-appimage.sh \
     release/Wine4OfficeManager-VERSION-x86_64 \
     release/wine4office-VERSION-x86_64.tar.zst \

--- a/tools/wine4office-manager/packaging/distribution/README.md
+++ b/tools/wine4office-manager/packaging/distribution/README.md
@@ -1,0 +1,54 @@
+# Distribution packages
+
+Wine4Office publishes one combined `wine4office` package. It installs the exact
+standalone Manager and Wine runner produced by the release workflow. The package
+adds only system integration and `PACKAGE-INSTALLATION.json`; it does not rebuild
+or modify either release payload.
+
+The package layout is `/opt/wine4office`, with command links in `/usr/bin`.
+User prefixes, Office installations, configuration, and documents stay in the
+user's home directory and package removal does not delete them.
+
+`build-deb.sh` and `build-rpm.sh` consume the two release artifacts. The release
+workflow runs each builder in its matching distribution container. AUR and Nix
+sources are generated from `release.json`, so their URLs and SHA-256 hashes are
+fixed to one release.
+
+APT and RPM repositories are static HTTPS directory trees. Run
+`build-apt-repository.sh` or `build-rpm-repository.sh` with
+`WINE4OFFICE_GPG_KEY_ID` set to sign production metadata. Publish the resulting
+tree atomically under `https://packages.wine4office.org/`. Until a package server
+and signing key exist, CI uploads the packages and unsigned repository trees as
+release artifacts for testing only.
+
+Suggested production paths:
+
+```text
+packages.wine4office.org/apt/dists/stable/...
+packages.wine4office.org/apt/pool/...
+packages.wine4office.org/rpm/x86_64/...
+packages.wine4office.org/keys/wine4office-packages.asc
+```
+
+Ubuntu users add `deb [signed-by=/usr/share/keyrings/wine4office.asc]
+https://packages.wine4office.org/apt stable main`. Fedora users install
+`wine4office.repo`. AUR remains hosted by the AUR and downloads immutable GitHub
+release assets. The generated Nix flake uses an FHS environment because the
+PyInstaller one-file Manager extracts embedded ELF libraries at runtime.
+
+The repository trees need only static HTTPS hosting; no package-specific web
+application or database is required. They can be served by the same Nginx,
+object-storage bucket, or CDN as the project website. A production APT or DNF
+update requires the published tree, a stable URL, and a signing key. AUR and Nix
+packages fetch immutable GitHub release assets and do not require this package
+server.
+
+The release runner is built on Ubuntu 24.04 and reused byte-for-byte in every
+package. This keeps the package set small and makes the Manager and core Wine
+runner portable, but some optional Unix-side Wine modules link to exact library
+ABIs. For example, a runner linked to `libavcodec.so.60` cannot load that media
+module on a Fedora release that provides only a newer FFmpeg soname. The RPM
+therefore declares only the core runtime dependencies and disables automatic ELF
+dependency generation. Full optional-module parity across distributions would
+require bundling those ABI-sensitive libraries or rebuilding the Unix modules
+for each distribution.

--- a/tools/wine4office-manager/packaging/distribution/README.md
+++ b/tools/wine4office-manager/packaging/distribution/README.md
@@ -21,6 +21,13 @@ tree atomically under `https://packages.wine4office.org/`. Until a package serve
 and signing key exist, CI uploads the packages and unsigned repository trees as
 release artifacts for testing only.
 
+Packaged installations use the distribution package source as their update
+authority. The Manager hides the standalone metadata URL, prerelease selector,
+and background release-feed controls. APT and DNF updates run as one combined
+Manager-and-Wine transaction; the Manager compares the installed versions before
+and after the transaction and runs Wine migration only when both components
+actually advanced. AUR and Nix show copyable update instructions.
+
 Suggested production paths:
 
 ```text
@@ -34,7 +41,11 @@ Ubuntu users add `deb [signed-by=/usr/share/keyrings/wine4office.asc]
 https://packages.wine4office.org/apt stable main`. Fedora users install
 `wine4office.repo`. AUR remains hosted by the AUR and downloads immutable GitHub
 release assets. The generated Nix flake uses an FHS environment because the
-PyInstaller one-file Manager extracts embedded ELF libraries at runtime.
+PyInstaller one-file Manager extracts embedded ELF libraries at runtime. Its
+wrapper is also embedded into generated Office shortcuts and user services so
+later launches re-enter that environment. Install the flake into a Nix profile
+or NixOS configuration before creating persistent shortcuts; a transient
+`nix run` store path is not a durable installation location.
 
 The repository trees need only static HTTPS hosting; no package-specific web
 application or database is required. They can be served by the same Nginx,

--- a/tools/wine4office-manager/packaging/distribution/README.md
+++ b/tools/wine4office-manager/packaging/distribution/README.md
@@ -21,6 +21,10 @@ tree atomically under `https://packages.wine4office.org/`. Until a package serve
 and signing key exist, CI uploads the packages and unsigned repository trees as
 release artifacts for testing only.
 
+Published package filenames are immutable. Rebuilds with different bytes must
+use a new DEB version or RPM release so existing repository metadata never
+points to replaced content.
+
 Packaged installations use the distribution package source as their update
 authority. The Manager hides the standalone metadata URL, prerelease selector,
 and background release-feed controls. APT and DNF updates run as one combined

--- a/tools/wine4office-manager/packaging/distribution/build-appimage.sh
+++ b/tools/wine4office-manager/packaging/distribution/build-appimage.sh
@@ -11,19 +11,19 @@ wine_archive=$(cd "$(dirname "$2")" && pwd)/$(basename "$2")
 release_json=$(cd "$(dirname "$3")" && pwd)/$(basename "$3")
 installer=$(cd "$(dirname "$4")" && pwd)/$(basename "$4")
 output_dir=$5
-appimagetool=${APPIMAGETOOL:-}
 appimage_runtime=${APPIMAGE_RUNTIME:-}
+appimage_mkdwarfs=${APPIMAGE_MKDWARFS:-}
 
 [[ -x $manager ]] || { echo "Manager binary is not executable" >&2; exit 1; }
 [[ -f $wine_archive && ! -L $wine_archive ]] || { echo "Wine archive is missing" >&2; exit 1; }
 [[ -f $release_json && ! -L $release_json ]] || { echo "release.json is missing" >&2; exit 1; }
 [[ -x $installer ]] || { echo "Installer is not executable" >&2; exit 1; }
-[[ -n $appimagetool && -x $appimagetool ]] || {
-    echo "APPIMAGETOOL must name an executable appimagetool" >&2
+[[ -n $appimage_runtime && -x $appimage_runtime && ! -L $appimage_runtime ]] || {
+    echo "APPIMAGE_RUNTIME must name an executable pinned AppImage runtime" >&2
     exit 1
 }
-[[ -n $appimage_runtime && -f $appimage_runtime && ! -L $appimage_runtime ]] || {
-    echo "APPIMAGE_RUNTIME must name a pinned AppImage runtime" >&2
+[[ -n $appimage_mkdwarfs && -x $appimage_mkdwarfs && ! -L $appimage_mkdwarfs ]] || {
+    echo "APPIMAGE_MKDWARFS must name an executable pinned mkdwarfs" >&2
     exit 1
 }
 for command in ldd python3 readlink sha256sum stat; do
@@ -100,6 +100,23 @@ printf '%s\n' "$version" > "$payload_dir/VERSION"
 printf '%s\n' "$metadata_url" > "$payload_dir/METADATA_URL"
 
 install -m 0644 "$here/wine4office.desktop" "$appdir/wine4office.desktop"
+python3 - "$appdir/wine4office.desktop" "$version" <<'PY'
+from pathlib import Path
+import sys
+
+desktop = Path(sys.argv[1])
+version = sys.argv[2]
+lines = [
+    line for line in desktop.read_text(encoding="utf-8").splitlines()
+    if not line.startswith(("X-AppImage-Name=", "X-AppImage-Version=", "X-AppImage-Arch="))
+]
+lines.extend((
+    "X-AppImage-Name=Wine4Office",
+    f"X-AppImage-Version={version}",
+    "X-AppImage-Arch=x86_64",
+))
+desktop.write_text("\n".join(lines) + "\n", encoding="utf-8")
+PY
 install -m 0644 "$here/../../icons/wine4office-manager.png" \
     "$appdir/wine4office-manager.png"
 ln -s wine4office-manager.png "$appdir/.DirIcon"
@@ -123,9 +140,10 @@ epoch=${SOURCE_DATE_EPOCH:-0}
 [[ $epoch =~ ^[0-9]+$ ]] || { echo "SOURCE_DATE_EPOCH must be an integer" >&2; exit 1; }
 find "$appdir" -print0 | xargs -0 touch -h -d "@$epoch"
 output=$output_dir/Wine4Office-${version}-x86_64.AppImage
-ARCH=x86_64 APPIMAGE_EXTRACT_AND_RUN=1 SOURCE_DATE_EPOCH=$epoch \
-    "$appimagetool" --no-appstream --comp zstd --runtime-file "$appimage_runtime" \
-        "$appdir" "$output"
+"$appimage_mkdwarfs" --tool=mkdwarfs --force --order=path \
+    --set-owner 0 --set-group 0 --no-history --no-create-timestamp \
+    --header "$appimage_runtime" --input "$appdir" \
+    -C zstd:level=22 -S26 -B6 --output "$output"
 chmod 0755 "$output"
 (cd "$output_dir" && sha256sum "$(basename "$output")" > "$(basename "$output").sha256")
 printf 'Created Wine4Office AppImage: %s\n' "$output"

--- a/tools/wine4office-manager/packaging/distribution/build-appimage.sh
+++ b/tools/wine4office-manager/packaging/distribution/build-appimage.sh
@@ -140,7 +140,9 @@ epoch=${SOURCE_DATE_EPOCH:-0}
 [[ $epoch =~ ^[0-9]+$ ]] || { echo "SOURCE_DATE_EPOCH must be an integer" >&2; exit 1; }
 find "$appdir" -print0 | xargs -0 touch -h -d "@$epoch"
 output=$output_dir/Wine4Office-${version}-x86_64.AppImage
-"$appimage_mkdwarfs" --tool=mkdwarfs --force --order=path \
+mkdwarfs=$tmp/mkdwarfs
+install -m 0755 "$appimage_mkdwarfs" "$mkdwarfs"
+"$mkdwarfs" --force --order=path \
     --set-owner 0 --set-group 0 --no-history --no-create-timestamp \
     --header "$appimage_runtime" --input "$appdir" \
     -C zstd:level=22 -S26 -B6 --output "$output"

--- a/tools/wine4office-manager/packaging/distribution/build-appimage.sh
+++ b/tools/wine4office-manager/packaging/distribution/build-appimage.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+[[ $# -eq 5 ]] || {
+    echo "Usage: $0 MANAGER_BINARY WINE_ARCHIVE RELEASE_JSON INSTALLER OUTPUT_DIR" >&2
+    exit 2
+}
+here=$(cd "$(dirname "$0")" && pwd)
+manager=$(cd "$(dirname "$1")" && pwd)/$(basename "$1")
+wine_archive=$(cd "$(dirname "$2")" && pwd)/$(basename "$2")
+release_json=$(cd "$(dirname "$3")" && pwd)/$(basename "$3")
+installer=$(cd "$(dirname "$4")" && pwd)/$(basename "$4")
+output_dir=$5
+appimagetool=${APPIMAGETOOL:-}
+appimage_runtime=${APPIMAGE_RUNTIME:-}
+
+[[ -x $manager ]] || { echo "Manager binary is not executable" >&2; exit 1; }
+[[ -f $wine_archive && ! -L $wine_archive ]] || { echo "Wine archive is missing" >&2; exit 1; }
+[[ -f $release_json && ! -L $release_json ]] || { echo "release.json is missing" >&2; exit 1; }
+[[ -x $installer ]] || { echo "Installer is not executable" >&2; exit 1; }
+[[ -n $appimagetool && -x $appimagetool ]] || {
+    echo "APPIMAGETOOL must name an executable appimagetool" >&2
+    exit 1
+}
+[[ -n $appimage_runtime && -f $appimage_runtime && ! -L $appimage_runtime ]] || {
+    echo "APPIMAGE_RUNTIME must name a pinned AppImage runtime" >&2
+    exit 1
+}
+for command in ldd python3 readlink sha256sum stat; do
+    command -v "$command" >/dev/null || { echo "$command is required" >&2; exit 1; }
+done
+zstd_binary=$(command -v zstd) || { echo "zstd is required" >&2; exit 1; }
+
+mapfile -t metadata < <(python3 - "$release_json" "$manager" "$wine_archive" <<'PY'
+import hashlib
+import json
+import pathlib
+import re
+import sys
+import urllib.parse
+
+metadata_path, manager_path, wine_path = map(pathlib.Path, sys.argv[1:])
+payload = json.loads(metadata_path.read_text(encoding="utf-8"))
+if not isinstance(payload, dict) or payload.get("schema_version") != 1:
+    raise SystemExit("release.json must use schema version 1")
+channel = payload.get("channel")
+if not isinstance(channel, str) or not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,63}", channel):
+    raise SystemExit("release.json has an invalid channel")
+metadata_url = payload.get("metadata_url")
+parsed = urllib.parse.urlsplit(metadata_url if isinstance(metadata_url, str) else "")
+if parsed.scheme != "https" or not parsed.hostname or parsed.username or parsed.password or parsed.fragment:
+    raise SystemExit("release.json has an invalid canonical metadata URL")
+
+def verify(name, path, expected_format=None):
+    component = payload.get(name)
+    if not isinstance(component, dict):
+        raise SystemExit(f"release.json is missing {name}")
+    version = component.get("version")
+    if not isinstance(version, str) or not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._+-]{0,127}", version):
+        raise SystemExit(f"release.json has an invalid {name} version")
+    if expected_format and component.get("format") != expected_format:
+        raise SystemExit(f"release.json has an invalid {name} format")
+    digest_builder = hashlib.sha256()
+    with path.open("rb") as artifact:
+        for chunk in iter(lambda: artifact.read(1024 * 1024), b""):
+            digest_builder.update(chunk)
+    digest = digest_builder.hexdigest()
+    if component.get("sha256") != digest or component.get("size") != path.stat().st_size:
+        raise SystemExit(f"{name} artifact does not match release.json")
+    return version
+
+manager_version = verify("manager", manager_path)
+wine_version = verify("wine", wine_path, "tar.zst")
+if manager_version != wine_version:
+    raise SystemExit("Manager and Wine versions must match for the AppImage")
+print(manager_version)
+print(channel)
+print(metadata_url)
+PY
+)
+[[ ${#metadata[@]} -eq 3 ]] || { echo "Invalid release metadata output" >&2; exit 1; }
+version=${metadata[0]}
+metadata_url=${metadata[2]}
+[[ $version =~ ^[A-Za-z0-9][A-Za-z0-9._+-]{0,127}$ ]] || exit 1
+
+mkdir -p "$output_dir"
+output_dir=$(cd "$output_dir" && pwd)
+tmp=$(mktemp -d "$output_dir/.appimage.XXXXXX")
+trap 'rm -rf -- "$tmp"' EXIT
+appdir=$tmp/AppDir
+payload_dir=$appdir/payload
+mkdir -p "$payload_dir" "$appdir/usr/bin" "$appdir/usr/lib"
+
+install -m 0755 "$here/wine4office.AppRun" "$appdir/AppRun"
+install -m 0755 "$installer" "$payload_dir/install.sh"
+install -m 0755 "$manager" "$payload_dir/Wine4OfficeManager"
+install -m 0644 "$wine_archive" "$payload_dir/wine.tar.zst"
+install -m 0644 "$release_json" "$payload_dir/release.json"
+printf '%s\n' "$version" > "$payload_dir/VERSION"
+printf '%s\n' "$metadata_url" > "$payload_dir/METADATA_URL"
+
+install -m 0644 "$here/wine4office.desktop" "$appdir/wine4office.desktop"
+install -m 0644 "$here/../../icons/wine4office-manager.png" \
+    "$appdir/wine4office-manager.png"
+ln -s wine4office-manager.png "$appdir/.DirIcon"
+
+install -m 0755 "$zstd_binary" "$appdir/usr/bin/zstd.real"
+while read -r soname _ path _; do
+    [[ -n ${path:-} && -f $path ]] || continue
+    case $soname in
+        libc.so.*|libdl.so.*|libpthread.so.*|librt.so.*) continue ;;
+    esac
+    install -m 0644 "$(readlink -f "$path")" "$appdir/usr/lib/$soname"
+done < <(ldd "$zstd_binary")
+cat > "$appdir/usr/bin/zstd" <<'SH'
+#!/bin/sh
+exec env LD_LIBRARY_PATH="$APPDIR/usr/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
+    "$APPDIR/usr/bin/zstd.real" "$@"
+SH
+chmod 0755 "$appdir/usr/bin/zstd"
+
+epoch=${SOURCE_DATE_EPOCH:-0}
+[[ $epoch =~ ^[0-9]+$ ]] || { echo "SOURCE_DATE_EPOCH must be an integer" >&2; exit 1; }
+find "$appdir" -print0 | xargs -0 touch -h -d "@$epoch"
+output=$output_dir/Wine4Office-${version}-x86_64.AppImage
+ARCH=x86_64 APPIMAGE_EXTRACT_AND_RUN=1 SOURCE_DATE_EPOCH=$epoch \
+    "$appimagetool" --no-appstream --comp zstd --runtime-file "$appimage_runtime" \
+        "$appdir" "$output"
+chmod 0755 "$output"
+(cd "$output_dir" && sha256sum "$(basename "$output")" > "$(basename "$output").sha256")
+printf 'Created Wine4Office AppImage: %s\n' "$output"

--- a/tools/wine4office-manager/packaging/distribution/build-apt-repository.sh
+++ b/tools/wine4office-manager/packaging/distribution/build-apt-repository.sh
@@ -9,21 +9,52 @@ codename=$2
 shift 2
 [[ $codename =~ ^[a-z0-9][a-z0-9.-]*$ ]] || { echo "Invalid codename" >&2; exit 1; }
 command -v apt-ftparchive >/dev/null || { echo "apt-ftparchive is required" >&2; exit 1; }
-
-pool=$repository/pool/main/w/wine4office
-binary=$repository/dists/$codename/main/binary-amd64
-mkdir -p "$pool" "$binary"
 for package in "$@"; do
     [[ -f $package && $package == *.deb ]] || { echo "Invalid DEB: $package" >&2; exit 1; }
-    install -m 0644 "$package" "$pool/$(basename "$package")"
 done
-rm -f -- "$repository/dists/$codename/InRelease" \
-    "$repository/dists/$codename/Release.gpg"
+
+mkdir -p "$repository"
+repository=$(cd "$repository" && pwd)
+pool=$repository/pool/main/w/wine4office
+distributions=$repository/dists
+live_distribution=$distributions/$codename
+mkdir -p "$pool" "$distributions"
+staged_repository=$(mktemp -d "$repository/.apt-repository.XXXXXX")
+staged_pool=$staged_repository/pool/main/w/wine4office
+staged_distribution=$staged_repository/dists/$codename
+backup_distribution=
+package_commit_temp=
+cleanup() {
+    local status=$?
+    [[ -z ${package_commit_temp:-} || ! -e $package_commit_temp ]] || \
+        rm -f -- "$package_commit_temp"
+    [[ -z ${staged_repository:-} || ! -e $staged_repository ]] || \
+        rm -rf -- "$staged_repository"
+    if ((status != 0)) && [[ -n ${backup_distribution:-} \
+            && -e $backup_distribution && ! -e $live_distribution ]]; then
+        mv -- "$backup_distribution" "$live_distribution"
+    fi
+}
+trap cleanup EXIT
+mkdir -p "$staged_pool" "$staged_repository/dists"
+if [[ -d $pool ]]; then
+    cp -al "$pool/." "$staged_pool/"
+fi
+for package in "$@"; do
+    staged_package=$staged_pool/$(basename "$package")
+    rm -f -- "$staged_package"
+    install -m 0644 "$package" "$staged_package"
+done
+if [[ -e $live_distribution ]]; then
+    mkdir -p "$staged_distribution"
+    cp -a "$live_distribution/." "$staged_distribution/"
+fi
+binary=$staged_distribution/main/binary-amd64
+mkdir -p "$binary"
 (
-    cd "$repository"
-    apt-ftparchive packages pool/main > "dists/$codename/main/binary-amd64/Packages"
-    gzip -n -9 -c "dists/$codename/main/binary-amd64/Packages" \
-        > "dists/$codename/main/binary-amd64/Packages.gz"
+    cd "$staged_repository"
+    apt-ftparchive packages pool/main > "$binary/Packages"
+    gzip -n -9 -c "$binary/Packages" > "$binary/Packages.gz"
     apt-ftparchive \
         -o APT::FTPArchive::Release::Origin=Wine4Office \
         -o APT::FTPArchive::Release::Label=Wine4Office \
@@ -31,13 +62,39 @@ rm -f -- "$repository/dists/$codename/InRelease" \
         -o APT::FTPArchive::Release::Codename="$codename" \
         -o APT::FTPArchive::Release::Architectures=amd64 \
         -o APT::FTPArchive::Release::Components=main \
-        release "dists/$codename" > "dists/$codename/Release"
+        release "$staged_distribution" > "$staged_distribution/Release"
 )
 if [[ -n ${WINE4OFFICE_GPG_KEY_ID:-} ]]; then
     gpg --batch --yes --local-user "$WINE4OFFICE_GPG_KEY_ID" \
-        --detach-sign --armor --output "$repository/dists/$codename/Release.gpg" \
-        "$repository/dists/$codename/Release"
+        --detach-sign --armor --output "$staged_distribution/Release.gpg" \
+        "$staged_distribution/Release"
     gpg --batch --yes --local-user "$WINE4OFFICE_GPG_KEY_ID" \
-        --clearsign --output "$repository/dists/$codename/InRelease" \
-        "$repository/dists/$codename/Release"
+        --clearsign --output "$staged_distribution/InRelease" \
+        "$staged_distribution/Release"
+else
+    rm -f -- "$staged_distribution/InRelease" "$staged_distribution/Release.gpg"
+fi
+
+for package in "$@"; do
+    package_name=$(basename "$package")
+    package_commit_temp=$(mktemp "$pool/.${package_name}.XXXXXX")
+    install -m 0644 "$staged_pool/$package_name" "$package_commit_temp"
+    mv -f -- "$package_commit_temp" "$pool/$package_name"
+    package_commit_temp=
+done
+if [[ -e $live_distribution ]]; then
+    backup_distribution=$(mktemp -d "$distributions/.${codename}.backup.XXXXXX")
+    rmdir "$backup_distribution"
+    mv -- "$live_distribution" "$backup_distribution"
+fi
+if ! mv -- "$staged_distribution" "$live_distribution"; then
+    [[ -z $backup_distribution || ! -e $backup_distribution ]] || \
+        mv -- "$backup_distribution" "$live_distribution"
+    exit 1
+fi
+rm -rf -- "$staged_repository"
+staged_repository=
+if [[ -n $backup_distribution ]]; then
+    rm -rf -- "$backup_distribution"
+    backup_distribution=
 fi

--- a/tools/wine4office-manager/packaging/distribution/build-apt-repository.sh
+++ b/tools/wine4office-manager/packaging/distribution/build-apt-repository.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+[[ $# -ge 3 ]] || {
+    echo "Usage: $0 REPOSITORY_DIR CODENAME DEB..." >&2
+    exit 2
+}
+repository=$1
+codename=$2
+shift 2
+[[ $codename =~ ^[a-z0-9][a-z0-9.-]*$ ]] || { echo "Invalid codename" >&2; exit 1; }
+command -v apt-ftparchive >/dev/null || { echo "apt-ftparchive is required" >&2; exit 1; }
+
+pool=$repository/pool/main/w/wine4office
+binary=$repository/dists/$codename/main/binary-amd64
+mkdir -p "$pool" "$binary"
+for package in "$@"; do
+    [[ -f $package && $package == *.deb ]] || { echo "Invalid DEB: $package" >&2; exit 1; }
+    install -m 0644 "$package" "$pool/$(basename "$package")"
+done
+(
+    cd "$repository"
+    apt-ftparchive packages pool/main > "dists/$codename/main/binary-amd64/Packages"
+    gzip -n -9 -c "dists/$codename/main/binary-amd64/Packages" \
+        > "dists/$codename/main/binary-amd64/Packages.gz"
+    apt-ftparchive \
+        -o APT::FTPArchive::Release::Origin=Wine4Office \
+        -o APT::FTPArchive::Release::Label=Wine4Office \
+        -o APT::FTPArchive::Release::Suite="$codename" \
+        -o APT::FTPArchive::Release::Codename="$codename" \
+        -o APT::FTPArchive::Release::Architectures=amd64 \
+        -o APT::FTPArchive::Release::Components=main \
+        release "dists/$codename" > "dists/$codename/Release"
+)
+if [[ -n ${WINE4OFFICE_GPG_KEY_ID:-} ]]; then
+    gpg --batch --yes --local-user "$WINE4OFFICE_GPG_KEY_ID" \
+        --detach-sign --armor --output "$repository/dists/$codename/Release.gpg" \
+        "$repository/dists/$codename/Release"
+    gpg --batch --yes --local-user "$WINE4OFFICE_GPG_KEY_ID" \
+        --clearsign --output "$repository/dists/$codename/InRelease" \
+        "$repository/dists/$codename/Release"
+fi

--- a/tools/wine4office-manager/packaging/distribution/build-apt-repository.sh
+++ b/tools/wine4office-manager/packaging/distribution/build-apt-repository.sh
@@ -24,6 +24,7 @@ staged_pool=$staged_repository/pool/main/w/wine4office
 staged_distribution=$staged_repository/dists/$codename
 backup_distribution=
 package_commit_temp=
+committed_new_packages=()
 cleanup() {
     local status=$?
     [[ -z ${package_commit_temp:-} || ! -e $package_commit_temp ]] || \
@@ -33,6 +34,9 @@ cleanup() {
     if ((status != 0)) && [[ -n ${backup_distribution:-} \
             && -e $backup_distribution && ! -e $live_distribution ]]; then
         mv -- "$backup_distribution" "$live_distribution"
+    fi
+    if ((status != 0)); then
+        rm -f -- "${committed_new_packages[@]}"
     fi
 }
 trap cleanup EXIT
@@ -44,6 +48,11 @@ for package in "$@"; do
     staged_package=$staged_pool/$(basename "$package")
     rm -f -- "$staged_package"
     install -m 0644 "$package" "$staged_package"
+    live_package=$pool/$(basename "$package")
+    if [[ -e $live_package ]] && ! cmp -s "$staged_package" "$live_package"; then
+        echo "Refusing to replace published DEB; use a new package version: $live_package" >&2
+        exit 1
+    fi
 done
 if [[ -e $live_distribution ]]; then
     mkdir -p "$staged_distribution"
@@ -77,10 +86,13 @@ fi
 
 for package in "$@"; do
     package_name=$(basename "$package")
-    package_commit_temp=$(mktemp "$pool/.${package_name}.XXXXXX")
-    install -m 0644 "$staged_pool/$package_name" "$package_commit_temp"
-    mv -f -- "$package_commit_temp" "$pool/$package_name"
-    package_commit_temp=
+    if [[ ! -e $pool/$package_name ]]; then
+        package_commit_temp=$(mktemp "$pool/.${package_name}.XXXXXX")
+        install -m 0644 "$staged_pool/$package_name" "$package_commit_temp"
+        mv -- "$package_commit_temp" "$pool/$package_name"
+        package_commit_temp=
+        committed_new_packages+=("$pool/$package_name")
+    fi
 done
 if [[ -e $live_distribution ]]; then
     backup_distribution=$(mktemp -d "$distributions/.${codename}.backup.XXXXXX")
@@ -98,3 +110,4 @@ if [[ -n $backup_distribution ]]; then
     rm -rf -- "$backup_distribution"
     backup_distribution=
 fi
+committed_new_packages=()

--- a/tools/wine4office-manager/packaging/distribution/build-apt-repository.sh
+++ b/tools/wine4office-manager/packaging/distribution/build-apt-repository.sh
@@ -17,6 +17,8 @@ for package in "$@"; do
     [[ -f $package && $package == *.deb ]] || { echo "Invalid DEB: $package" >&2; exit 1; }
     install -m 0644 "$package" "$pool/$(basename "$package")"
 done
+rm -f -- "$repository/dists/$codename/InRelease" \
+    "$repository/dists/$codename/Release.gpg"
 (
     cd "$repository"
     apt-ftparchive packages pool/main > "dists/$codename/main/binary-amd64/Packages"

--- a/tools/wine4office-manager/packaging/distribution/build-apt-repository.sh
+++ b/tools/wine4office-manager/packaging/distribution/build-apt-repository.sh
@@ -104,10 +104,10 @@ if ! mv -- "$staged_distribution" "$live_distribution"; then
         mv -- "$backup_distribution" "$live_distribution"
     exit 1
 fi
+committed_new_packages=()
 rm -rf -- "$staged_repository"
 staged_repository=
 if [[ -n $backup_distribution ]]; then
     rm -rf -- "$backup_distribution"
     backup_distribution=
 fi
-committed_new_packages=()

--- a/tools/wine4office-manager/packaging/distribution/build-deb.sh
+++ b/tools/wine4office-manager/packaging/distribution/build-deb.sh
@@ -26,7 +26,7 @@ Version: $deb_version
 Architecture: amd64
 Maintainer: Wine4Office Project <noreply@wine4office.org>
 Installed-Size: $installed_size
-Depends: libc6 (>= 2.35), libgcc-s1, libgl1, libegl1, libfontconfig1, libfreetype6, libdbus-1-3, libgnutls30t64
+Depends: libc6 (>= 2.35), libgcc-s1, libgl1, libegl1, libglib2.0-0t64, libxkbcommon0, libxkbcommon-x11-0, libx11-xcb1, libxcb-cursor0, libxcb-icccm4, libxcb-image0, libxcb-keysyms1, libxcb-render0, libxcb-render-util0, libxcb-shape0, libxcb-util1, libxcb-xkb1, libfontconfig1, libfreetype6, libdbus-1-3, libgnutls30t64, libkrb5-3, libgssapi-krb5-2
 Suggests: policykit-1
 Section: otherosfs
 Priority: optional

--- a/tools/wine4office-manager/packaging/distribution/build-deb.sh
+++ b/tools/wine4office-manager/packaging/distribution/build-deb.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+here=$(cd "$(dirname "$0")" && pwd)
+# Populated by validate_package_input from common.sh.
+package_version=''
+package_name=''
+package_output=''
+# shellcheck disable=SC1091
+source "$here/common.sh"
+validate_package_input "$@"
+command -v dpkg-deb >/dev/null || { echo "dpkg-deb is required" >&2; exit 1; }
+
+tmp=$(mktemp -d)
+trap 'rm -rf -- "$tmp"' EXIT
+root=$tmp/root
+stage_package_payload "$root"
+install -d "$root/DEBIAN"
+installed_size=$(du -sk "$root" | awk '{print $1}')
+deb_version=$package_version
+if [[ $package_version == *-* ]]; then
+    deb_version="${package_version%%-*}~${package_version#*-}"
+fi
+cat > "$root/DEBIAN/control" <<EOF
+Package: $package_name
+Version: $deb_version
+Architecture: amd64
+Maintainer: Wine4Office Project <noreply@wine4office.org>
+Installed-Size: $installed_size
+Depends: libc6 (>= 2.35), libgcc-s1, libgl1, libegl1, libfontconfig1, libfreetype6, libdbus-1-3, libgnutls30t64
+Suggests: policykit-1
+Section: otherosfs
+Priority: optional
+Homepage: https://github.com/ttv20/wine4office
+Description: Wine and manager tuned for Microsoft Office
+ Wine4Office packages the project release runner and standalone Qt manager.
+ User Wine prefixes and Microsoft Office files remain outside the package.
+EOF
+cat > "$root/DEBIAN/postinst" <<'EOF'
+#!/bin/sh
+set -e
+command -v update-desktop-database >/dev/null 2>&1 && \
+    update-desktop-database /usr/share/applications >/dev/null 2>&1 || true
+EOF
+chmod 0755 "$root/DEBIAN/postinst"
+mkdir -p "$package_output"
+package_output=$(cd "$package_output" && pwd)
+dpkg-deb --root-owner-group -Zzstd -z10 --threads-max=0 --build "$root" \
+    "$package_output/${package_name}_${deb_version}_amd64.deb"

--- a/tools/wine4office-manager/packaging/distribution/build-rpm-repository.sh
+++ b/tools/wine4office-manager/packaging/distribution/build-rpm-repository.sh
@@ -13,11 +13,14 @@ mkdir -p "$packages"
 install -m 0644 "$here/wine4office.repo" "$repository/wine4office.repo"
 for package in "$@"; do
     [[ -f $package && $package == *.rpm ]] || { echo "Invalid RPM: $package" >&2; exit 1; }
+    repository_package=$packages/$(basename "$package")
+    install -m 0644 "$package" "$repository_package"
     if [[ -n ${WINE4OFFICE_GPG_KEY_ID:-} ]]; then
-        rpmsign --addsign --define "_gpg_name $WINE4OFFICE_GPG_KEY_ID" "$package"
+        rpmsign --addsign --define "_gpg_name $WINE4OFFICE_GPG_KEY_ID" \
+            "$repository_package"
     fi
-    install -m 0644 "$package" "$packages/$(basename "$package")"
 done
+rm -f -- "$repository/rpm/x86_64/repodata/repomd.xml.asc"
 createrepo_c --update "$repository/rpm/x86_64"
 if [[ -n ${WINE4OFFICE_GPG_KEY_ID:-} ]]; then
     gpg --batch --yes --local-user "$WINE4OFFICE_GPG_KEY_ID" \

--- a/tools/wine4office-manager/packaging/distribution/build-rpm-repository.sh
+++ b/tools/wine4office-manager/packaging/distribution/build-rpm-repository.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+here=$(cd "$(dirname "$0")" && pwd)
+[[ $# -ge 2 ]] || {
+    echo "Usage: $0 REPOSITORY_DIR RPM..." >&2
+    exit 2
+}
+repository=$1
+shift
+command -v createrepo_c >/dev/null || { echo "createrepo_c is required" >&2; exit 1; }
+packages=$repository/rpm/x86_64/Packages
+mkdir -p "$packages"
+install -m 0644 "$here/wine4office.repo" "$repository/wine4office.repo"
+for package in "$@"; do
+    [[ -f $package && $package == *.rpm ]] || { echo "Invalid RPM: $package" >&2; exit 1; }
+    if [[ -n ${WINE4OFFICE_GPG_KEY_ID:-} ]]; then
+        rpmsign --addsign --define "_gpg_name $WINE4OFFICE_GPG_KEY_ID" "$package"
+    fi
+    install -m 0644 "$package" "$packages/$(basename "$package")"
+done
+createrepo_c --update "$repository/rpm/x86_64"
+if [[ -n ${WINE4OFFICE_GPG_KEY_ID:-} ]]; then
+    gpg --batch --yes --local-user "$WINE4OFFICE_GPG_KEY_ID" \
+        --detach-sign --armor \
+        "$repository/rpm/x86_64/repodata/repomd.xml"
+fi

--- a/tools/wine4office-manager/packaging/distribution/build-rpm-repository.sh
+++ b/tools/wine4office-manager/packaging/distribution/build-rpm-repository.sh
@@ -25,6 +25,7 @@ backup_metadata=
 package_commit_temp=
 committed_new_packages=()
 declare -A package_source_digests=()
+declare -A package_signing_states=()
 cleanup() {
     local status=$?
     [[ -z ${package_commit_temp:-} || ! -e $package_commit_temp ]] || \
@@ -53,10 +54,19 @@ for package in "$@"; do
     live_package=$packages/$package_name
     source_digest=$(sha256sum "$package" | cut -d ' ' -f 1)
     package_source_digests["$package_name"]=$source_digest
+    desired_signing_state=${WINE4OFFICE_GPG_KEY_ID:-unsigned}
+    package_signing_states["$package_name"]=$desired_signing_state
     rm -f -- "$staged_package"
     source_digest_file=$source_digests/$package_name.sha256
+    signing_state_file=$source_digests/$package_name.signing-key
     if [[ -e $live_package && -f $source_digest_file \
             && $(cat "$source_digest_file") == "$source_digest" ]]; then
+        if [[ -n ${WINE4OFFICE_GPG_KEY_ID:-} \
+                && (! -f $signing_state_file \
+                    || $(cat "$signing_state_file") != "$desired_signing_state") ]]; then
+            echo "Refusing to change signing state for a published RPM; use a new package release: $live_package" >&2
+            exit 1
+        fi
         install -m 0644 "$live_package" "$staged_package"
     else
         install -m 0644 "$package" "$staged_package"
@@ -97,6 +107,14 @@ for package in "$@"; do
         package_commit_temp=
         committed_new_packages+=("$source_digest_file")
     fi
+    signing_state_file=$source_digests/$package_name.signing-key
+    if [[ ! -e $signing_state_file ]]; then
+        package_commit_temp=$(mktemp "$source_digests/.${package_name}.XXXXXX")
+        printf '%s\n' "${package_signing_states[$package_name]}" > "$package_commit_temp"
+        mv -- "$package_commit_temp" "$signing_state_file"
+        package_commit_temp=
+        committed_new_packages+=("$signing_state_file")
+    fi
 done
 if [[ -e $repository_root/repodata ]]; then
     backup_metadata=$(mktemp -d "$repository_root/.repodata.backup.XXXXXX")
@@ -108,10 +126,10 @@ if ! mv -- "$staged_repository/repodata" "$repository_root/repodata"; then
         mv -- "$backup_metadata" "$repository_root/repodata"
     exit 1
 fi
+committed_new_packages=()
 rm -rf -- "$staged_repository"
 staged_repository=
 if [[ -n $backup_metadata ]]; then
     rm -rf -- "$backup_metadata"
     backup_metadata=
 fi
-committed_new_packages=()

--- a/tools/wine4office-manager/packaging/distribution/build-rpm-repository.sh
+++ b/tools/wine4office-manager/packaging/distribution/build-rpm-repository.sh
@@ -16,12 +16,15 @@ mkdir -p "$repository"
 repository=$(cd "$repository" && pwd)
 repository_root=$repository/rpm/x86_64
 packages=$repository_root/Packages
-mkdir -p "$packages"
+source_digests=$repository/rpm/.wine4office-source-sha256
+mkdir -p "$packages" "$source_digests"
 install -m 0644 "$here/wine4office.repo" "$repository/wine4office.repo"
 staged_repository=$(mktemp -d "$repository_root/.repository.XXXXXX")
 staged_packages=$staged_repository/Packages
 backup_metadata=
 package_commit_temp=
+committed_new_packages=()
+declare -A package_source_digests=()
 cleanup() {
     local status=$?
     [[ -z ${package_commit_temp:-} || ! -e $package_commit_temp ]] || \
@@ -31,6 +34,9 @@ cleanup() {
     if ((status != 0)) && [[ -n ${backup_metadata:-} && -e $backup_metadata \
             && ! -e $repository_root/repodata ]]; then
         mv -- "$backup_metadata" "$repository_root/repodata"
+    fi
+    if ((status != 0)); then
+        rm -f -- "${committed_new_packages[@]}"
     fi
 }
 trap cleanup EXIT
@@ -44,11 +50,24 @@ fi
 for package in "$@"; do
     package_name=$(basename "$package")
     staged_package=$staged_packages/$package_name
+    live_package=$packages/$package_name
+    source_digest=$(sha256sum "$package" | cut -d ' ' -f 1)
+    package_source_digests["$package_name"]=$source_digest
     rm -f -- "$staged_package"
-    install -m 0644 "$package" "$staged_package"
-    if [[ -n ${WINE4OFFICE_GPG_KEY_ID:-} ]]; then
-        rpmsign --addsign --define "_gpg_name $WINE4OFFICE_GPG_KEY_ID" \
-            "$staged_package"
+    source_digest_file=$source_digests/$package_name.sha256
+    if [[ -e $live_package && -f $source_digest_file \
+            && $(cat "$source_digest_file") == "$source_digest" ]]; then
+        install -m 0644 "$live_package" "$staged_package"
+    else
+        install -m 0644 "$package" "$staged_package"
+        if [[ -n ${WINE4OFFICE_GPG_KEY_ID:-} ]]; then
+            rpmsign --addsign --define "_gpg_name $WINE4OFFICE_GPG_KEY_ID" \
+                "$staged_package"
+        fi
+    fi
+    if [[ -e $live_package ]] && ! cmp -s "$staged_package" "$live_package"; then
+        echo "Refusing to replace published RPM; use a new package release: $live_package" >&2
+        exit 1
     fi
 done
 createrepo_c --update "$staged_repository"
@@ -63,10 +82,21 @@ fi
 
 for package in "$@"; do
     package_name=$(basename "$package")
-    package_commit_temp=$(mktemp "$packages/.${package_name}.XXXXXX")
-    install -m 0644 "$staged_packages/$package_name" "$package_commit_temp"
-    mv -f -- "$package_commit_temp" "$packages/$package_name"
-    package_commit_temp=
+    if [[ ! -e $packages/$package_name ]]; then
+        package_commit_temp=$(mktemp "$packages/.${package_name}.XXXXXX")
+        install -m 0644 "$staged_packages/$package_name" "$package_commit_temp"
+        mv -- "$package_commit_temp" "$packages/$package_name"
+        package_commit_temp=
+        committed_new_packages+=("$packages/$package_name")
+    fi
+    source_digest_file=$source_digests/$package_name.sha256
+    if [[ ! -e $source_digest_file ]]; then
+        package_commit_temp=$(mktemp "$source_digests/.${package_name}.XXXXXX")
+        printf '%s\n' "${package_source_digests[$package_name]}" > "$package_commit_temp"
+        mv -- "$package_commit_temp" "$source_digest_file"
+        package_commit_temp=
+        committed_new_packages+=("$source_digest_file")
+    fi
 done
 if [[ -e $repository_root/repodata ]]; then
     backup_metadata=$(mktemp -d "$repository_root/.repodata.backup.XXXXXX")
@@ -84,3 +114,4 @@ if [[ -n $backup_metadata ]]; then
     rm -rf -- "$backup_metadata"
     backup_metadata=
 fi
+committed_new_packages=()

--- a/tools/wine4office-manager/packaging/distribution/build-rpm-repository.sh
+++ b/tools/wine4office-manager/packaging/distribution/build-rpm-repository.sh
@@ -8,22 +8,79 @@ here=$(cd "$(dirname "$0")" && pwd)
 repository=$1
 shift
 command -v createrepo_c >/dev/null || { echo "createrepo_c is required" >&2; exit 1; }
-packages=$repository/rpm/x86_64/Packages
-mkdir -p "$packages"
-install -m 0644 "$here/wine4office.repo" "$repository/wine4office.repo"
 for package in "$@"; do
     [[ -f $package && $package == *.rpm ]] || { echo "Invalid RPM: $package" >&2; exit 1; }
-    repository_package=$packages/$(basename "$package")
-    install -m 0644 "$package" "$repository_package"
+done
+
+mkdir -p "$repository"
+repository=$(cd "$repository" && pwd)
+repository_root=$repository/rpm/x86_64
+packages=$repository_root/Packages
+mkdir -p "$packages"
+install -m 0644 "$here/wine4office.repo" "$repository/wine4office.repo"
+staged_repository=$(mktemp -d "$repository_root/.repository.XXXXXX")
+staged_packages=$staged_repository/Packages
+backup_metadata=
+package_commit_temp=
+cleanup() {
+    local status=$?
+    [[ -z ${package_commit_temp:-} || ! -e $package_commit_temp ]] || \
+        rm -f -- "$package_commit_temp"
+    [[ -z ${staged_repository:-} || ! -e $staged_repository ]] || \
+        rm -rf -- "$staged_repository"
+    if ((status != 0)) && [[ -n ${backup_metadata:-} && -e $backup_metadata \
+            && ! -e $repository_root/repodata ]]; then
+        mv -- "$backup_metadata" "$repository_root/repodata"
+    fi
+}
+trap cleanup EXIT
+mkdir -p "$staged_packages"
+if [[ -d $packages ]]; then
+    cp -al "$packages/." "$staged_packages/"
+fi
+if [[ -d $repository_root/repodata ]]; then
+    cp -a "$repository_root/repodata" "$staged_repository/repodata"
+fi
+for package in "$@"; do
+    package_name=$(basename "$package")
+    staged_package=$staged_packages/$package_name
+    rm -f -- "$staged_package"
+    install -m 0644 "$package" "$staged_package"
     if [[ -n ${WINE4OFFICE_GPG_KEY_ID:-} ]]; then
         rpmsign --addsign --define "_gpg_name $WINE4OFFICE_GPG_KEY_ID" \
-            "$repository_package"
+            "$staged_package"
     fi
 done
-rm -f -- "$repository/rpm/x86_64/repodata/repomd.xml.asc"
-createrepo_c --update "$repository/rpm/x86_64"
+createrepo_c --update "$staged_repository"
 if [[ -n ${WINE4OFFICE_GPG_KEY_ID:-} ]]; then
     gpg --batch --yes --local-user "$WINE4OFFICE_GPG_KEY_ID" \
         --detach-sign --armor \
-        "$repository/rpm/x86_64/repodata/repomd.xml"
+        --output "$staged_repository/repodata/repomd.xml.asc" \
+        "$staged_repository/repodata/repomd.xml"
+else
+    rm -f -- "$staged_repository/repodata/repomd.xml.asc"
+fi
+
+for package in "$@"; do
+    package_name=$(basename "$package")
+    package_commit_temp=$(mktemp "$packages/.${package_name}.XXXXXX")
+    install -m 0644 "$staged_packages/$package_name" "$package_commit_temp"
+    mv -f -- "$package_commit_temp" "$packages/$package_name"
+    package_commit_temp=
+done
+if [[ -e $repository_root/repodata ]]; then
+    backup_metadata=$(mktemp -d "$repository_root/.repodata.backup.XXXXXX")
+    rmdir "$backup_metadata"
+    mv -- "$repository_root/repodata" "$backup_metadata"
+fi
+if ! mv -- "$staged_repository/repodata" "$repository_root/repodata"; then
+    [[ -z $backup_metadata || ! -e $backup_metadata ]] || \
+        mv -- "$backup_metadata" "$repository_root/repodata"
+    exit 1
+fi
+rm -rf -- "$staged_repository"
+staged_repository=
+if [[ -n $backup_metadata ]]; then
+    rm -rf -- "$backup_metadata"
+    backup_metadata=
 fi

--- a/tools/wine4office-manager/packaging/distribution/build-rpm.sh
+++ b/tools/wine4office-manager/packaging/distribution/build-rpm.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+here=$(cd "$(dirname "$0")" && pwd)
+# Populated by validate_package_input from common.sh.
+package_version=''
+package_name=''
+package_output=''
+# shellcheck disable=SC1091
+source "$here/common.sh"
+validate_package_input "$@"
+command -v rpmbuild >/dev/null || { echo "rpmbuild is required" >&2; exit 1; }
+
+rpm_version=${package_version%%-*}
+rpm_release=1
+if [[ $package_version == *-* ]]; then
+    suffix=${package_version#*-}
+    suffix=${suffix//-/.}
+    [[ $suffix =~ ^[A-Za-z0-9.]+$ ]] || { echo "Invalid RPM prerelease" >&2; exit 1; }
+    rpm_release="0.${suffix}.1"
+fi
+[[ $rpm_version =~ ^[0-9]+([.][0-9A-Za-z]+)*$ ]] || {
+    echo "Version cannot be represented as an RPM version" >&2; exit 1;
+}
+
+tmp=$(mktemp -d)
+trap 'rm -rf -- "$tmp"' EXIT
+payload=$tmp/payload
+stage_package_payload "$payload"
+mkdir -p "$tmp/rpmbuild"/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
+tar -C "$payload" --sort=name --mtime=@0 --owner=0 --group=0 --numeric-owner \
+    -czf "$tmp/rpmbuild/SOURCES/payload.tar.gz" .
+cat > "$tmp/rpmbuild/SPECS/wine4office.spec" <<EOF
+%global debug_package %{nil}
+%global __os_install_post %{nil}
+%global _binary_payload w10T0.zstdio
+Name:           $package_name
+Version:        $rpm_version
+Release:        $rpm_release%{?dist}
+Summary:        Wine and manager tuned for Microsoft Office
+License:        LGPL-2.1-or-later
+URL:            https://github.com/ttv20/wine4office
+Source0:        payload.tar.gz
+BuildArch:      x86_64
+AutoReqProv:    no
+Requires:       glibc, libglvnd-glx, libglvnd-egl, fontconfig, freetype, dbus-libs, gnutls
+
+%description
+Wine4Office packages the project release runner and standalone Qt manager.
+User Wine prefixes and Microsoft Office files remain outside the package.
+
+%prep
+
+%build
+
+%install
+mkdir -p %{buildroot}
+tar -xzf %{SOURCE0} -C %{buildroot}
+
+%files
+/opt/wine4office
+/usr/bin/Wine4OfficeManager
+/usr/bin/wine4office
+/usr/share/applications/wine4office.desktop
+/usr/share/icons/hicolor/256x256/apps/wine4office-manager.png
+
+%changelog
+* Wed Sep 09 2026 Wine4Office Project <noreply@wine4office.org> - $rpm_version-$rpm_release
+- Package Wine4Office release $package_version
+EOF
+rpmbuild -bb --define "_topdir $tmp/rpmbuild" \
+    --define "_build_id_links none" "$tmp/rpmbuild/SPECS/wine4office.spec"
+mkdir -p "$package_output"
+find "$tmp/rpmbuild/RPMS" -type f -name '*.rpm' \
+    -exec install -m 0644 {} "$package_output/" \;

--- a/tools/wine4office-manager/packaging/distribution/build-rpm.sh
+++ b/tools/wine4office-manager/packaging/distribution/build-rpm.sh
@@ -10,13 +10,24 @@ source "$here/common.sh"
 validate_package_input "$@"
 command -v rpmbuild >/dev/null || { echo "rpmbuild is required" >&2; exit 1; }
 
-rpm_version=${package_version%%-*}
+version_without_build=${package_version%%+*}
+build_metadata=
+if [[ $package_version == *+* ]]; then
+    build_metadata=${package_version#*+}
+    [[ $build_metadata =~ ^[A-Za-z0-9]+([.-][A-Za-z0-9]+)*$ ]] || {
+        echo "Invalid RPM build metadata" >&2; exit 1;
+    }
+fi
+rpm_version=${version_without_build%%-*}
 rpm_release=1
-if [[ $package_version == *-* ]]; then
-    suffix=${package_version#*-}
+if [[ $version_without_build == *-* ]]; then
+    suffix=${version_without_build#*-}
     suffix=${suffix//-/.}
     [[ $suffix =~ ^[A-Za-z0-9.]+$ ]] || { echo "Invalid RPM prerelease" >&2; exit 1; }
     rpm_release="0.${suffix}.1"
+fi
+if [[ -n $build_metadata ]]; then
+    rpm_release+=".${build_metadata//-/.}"
 fi
 [[ $rpm_version =~ ^[0-9]+([.][0-9A-Za-z]+)*$ ]] || {
     echo "Version cannot be represented as an RPM version" >&2; exit 1;
@@ -42,7 +53,7 @@ URL:            https://github.com/ttv20/wine4office
 Source0:        payload.tar.gz
 BuildArch:      x86_64
 AutoReqProv:    no
-Requires:       glibc, libglvnd-glx, libglvnd-egl, fontconfig, freetype, dbus-libs, gnutls
+Requires:       glibc, glib2, libxkbcommon, libxkbcommon-x11, libX11-xcb, libxcb, xcb-util, xcb-util-cursor, xcb-util-image, xcb-util-keysyms, xcb-util-renderutil, xcb-util-wm, libglvnd-glx, libglvnd-egl, fontconfig, freetype, dbus-libs, gnutls, krb5-libs
 
 %description
 Wine4Office packages the project release runner and standalone Qt manager.

--- a/tools/wine4office-manager/packaging/distribution/common.sh
+++ b/tools/wine4office-manager/packaging/distribution/common.sh
@@ -29,7 +29,8 @@ validate_package_input() {
 }
 
 stage_package_payload() {
-    local destination=$1 extraction root
+    local destination=$1 extraction root wine_base_version wine_build_id
+    local wine_build_prefix candidate
     extraction=$(mktemp -d)
     tar --zstd -xf "$wine_archive" -C "$extraction"
     mapfile -t roots < <(find "$extraction" -mindepth 1 -maxdepth 1 -type d -print)
@@ -48,8 +49,13 @@ stage_package_payload() {
     cp -a "$root/." "$destination/opt/wine4office/runner/"
     wine_base_version=unknown
     wine_build_id=$("$root/bin/wine" --version 2>/dev/null || true)
-    if [[ $wine_build_id =~ ^wine4office-[^[:space:]]+[[:space:]]\(Wine[[:space:]]([0-9]+([.][0-9A-Za-z]+)+)\)$ ]]; then
-        wine_base_version=${BASH_REMATCH[1]}
+    wine_build_prefix="wine4office-${package_version} (Wine "
+    if [[ $wine_build_id == "$wine_build_prefix"*')' ]]; then
+        candidate=${wine_build_id#"$wine_build_prefix"}
+        candidate=${candidate%')'}
+        if [[ $candidate =~ ^[0-9]+([.][0-9A-Za-z]+)+([-+][0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+            wine_base_version=$candidate
+        fi
     fi
     ln -s /opt/wine4office/bin/Wine4OfficeManager \
         "$destination/usr/bin/Wine4OfficeManager"

--- a/tools/wine4office-manager/packaging/distribution/common.sh
+++ b/tools/wine4office-manager/packaging/distribution/common.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+distribution_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+validate_package_input() {
+    [[ $# -eq 6 ]] || {
+        echo "Usage: $0 MANAGER_BINARY WINE_ARCHIVE VERSION PROVIDER PACKAGE OUTPUT" >&2
+        exit 2
+    }
+    manager_binary=$(cd "$(dirname "$1")" && pwd)/$(basename "$1")
+    wine_archive=$(cd "$(dirname "$2")" && pwd)/$(basename "$2")
+    package_version=$3
+    package_provider=$4
+    package_name=$5
+    package_output=$6
+    [[ -x "$manager_binary" ]] || { echo "Manager binary is not executable" >&2; exit 1; }
+    [[ -f "$wine_archive" ]] || { echo "Wine archive is missing" >&2; exit 1; }
+    [[ $package_version =~ ^[A-Za-z0-9][A-Za-z0-9._+-]{0,127}$ ]] || {
+        echo "Invalid package version" >&2; exit 1;
+    }
+    [[ $package_provider =~ ^(apt|dnf|aur|nix)$ ]] || {
+        echo "Invalid package provider" >&2; exit 1;
+    }
+    [[ $package_name =~ ^[A-Za-z0-9][A-Za-z0-9+_.-]{0,127}$ ]] || {
+        echo "Invalid package name" >&2; exit 1;
+    }
+}
+
+stage_package_payload() {
+    local destination=$1 extraction root
+    extraction=$(mktemp -d)
+    tar --zstd -xf "$wine_archive" -C "$extraction"
+    mapfile -t roots < <(find "$extraction" -mindepth 1 -maxdepth 1 -type d -print)
+    [[ ${#roots[@]} -eq 1 && -x ${roots[0]}/bin/wine ]] || {
+        echo "Wine archive must contain one runner with bin/wine" >&2
+        exit 1
+    }
+    root=${roots[0]}
+    install -d "$destination/opt/wine4office/bin" \
+        "$destination/opt/wine4office/runner" \
+        "$destination/usr/bin" \
+        "$destination/usr/share/applications" \
+        "$destination/usr/share/icons/hicolor/256x256/apps"
+    install -m 0755 "$manager_binary" \
+        "$destination/opt/wine4office/bin/Wine4OfficeManager"
+    cp -a "$root/." "$destination/opt/wine4office/runner/"
+    wine_base_version=unknown
+    wine_build_id=$("$root/bin/wine" --version 2>/dev/null || true)
+    if [[ $wine_build_id =~ ^wine4office-[^[:space:]]+[[:space:]]\(Wine[[:space:]]([0-9]+([.][0-9A-Za-z]+)+)\)$ ]]; then
+        wine_base_version=${BASH_REMATCH[1]}
+    fi
+    ln -s /opt/wine4office/bin/Wine4OfficeManager \
+        "$destination/usr/bin/Wine4OfficeManager"
+    ln -s /opt/wine4office/runner/bin/wine "$destination/usr/bin/wine4office"
+    install -m 0644 "$distribution_dir/wine4office.desktop" \
+        "$destination/usr/share/applications/wine4office.desktop"
+    install -m 0644 "$distribution_dir/../../icons/wine4office-manager.png" \
+        "$destination/usr/share/icons/hicolor/256x256/apps/wine4office-manager.png"
+    printf 'Wine4OfficeManager\n' > "$destination/opt/wine4office/STANDALONE"
+    printf '%s\n' "$package_version" > "$destination/opt/wine4office/VERSION"
+    printf '%s\n' "$package_version" > "$destination/opt/wine4office/WINE_VERSION"
+    printf '%s\n' "$wine_base_version" > "$destination/opt/wine4office/WINE_BASE_VERSION"
+    printf 'stable\n' > "$destination/opt/wine4office/UPDATE_CHANNEL"
+    python3 - "$destination/opt/wine4office/PACKAGE-INSTALLATION.json" \
+        "$package_provider" "$package_name" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "w", encoding="utf-8") as target:
+    json.dump({
+        "schema_version": 1,
+        "provider": sys.argv[2],
+        "package": sys.argv[3],
+        "components": ["manager", "wine"],
+    }, target, indent=2)
+    target.write("\n")
+PY
+    rm -rf -- "$extraction"
+}

--- a/tools/wine4office-manager/packaging/distribution/common.sh
+++ b/tools/wine4office-manager/packaging/distribution/common.sh
@@ -13,6 +13,7 @@ validate_package_input() {
     package_version=$3
     package_provider=$4
     package_name=$5
+    # shellcheck disable=SC2034 # Consumed by the sourcing package builder.
     package_output=$6
     [[ -x "$manager_binary" ]] || { echo "Manager binary is not executable" >&2; exit 1; }
     [[ -f "$wine_archive" ]] || { echo "Wine archive is missing" >&2; exit 1; }

--- a/tools/wine4office-manager/packaging/distribution/generate-community-packages.py
+++ b/tools/wine4office-manager/packaging/distribution/generate-community-packages.py
@@ -11,6 +11,16 @@ import urllib.parse
 from pathlib import Path
 
 
+def shell_single_quote(value: str) -> str:
+    return "'" + value.replace("'", "'\"'\"'") + "'"
+
+
+def nix_string(value: str) -> str:
+    return '"' + value.replace("\\", "\\\\").replace('"', '\\"').replace(
+        "${", "\\${"
+    ) + '"'
+
+
 def validated_release(path: Path) -> dict:
     data = json.loads(path.read_text(encoding="utf-8"))
     if data.get("schema_version") != 1:
@@ -21,18 +31,29 @@ def validated_release(path: Path) -> dict:
             or data.get("wine", {}).get("version") != version):
         raise ValueError("manager and Wine must use the same valid product version")
     metadata_url = data.get("metadata_url")
+    if not isinstance(metadata_url, str):
+        raise ValueError("metadata_url must use HTTPS")
     parsed = urllib.parse.urlsplit(metadata_url)
-    if parsed.scheme != "https" or not parsed.hostname:
+    if (parsed.scheme != "https" or not parsed.hostname or parsed.username is not None
+            or parsed.password is not None or parsed.fragment):
         raise ValueError("metadata_url must use HTTPS")
     for name in ("manager", "wine"):
-        component = data[name]
+        component = data.get(name)
+        if not isinstance(component, dict) or not isinstance(component.get("url"), str):
+            raise ValueError(f"{name} release entry is invalid")
         url = urllib.parse.urljoin(metadata_url, component["url"])
         parsed = urllib.parse.urlsplit(url)
-        if parsed.scheme != "https" or not parsed.hostname:
+        if (parsed.scheme != "https" or not parsed.hostname or parsed.username is not None
+                or parsed.password is not None or parsed.fragment
+                or any(ord(character) < 0x21 or ord(character) == 0x7f for character in url)):
             raise ValueError(f"{name} URL must use HTTPS")
         if not re.fullmatch(r"[0-9a-f]{64}", component["sha256"]):
             raise ValueError(f"{name} SHA-256 is invalid")
         component["resolved_url"] = url
+    base_version = data["wine"].get("base_version", "unknown")
+    if (base_version != "unknown" and (not isinstance(base_version, str)
+            or not re.fullmatch(r"[0-9]+(?:[.][0-9A-Za-z]+)+", base_version))):
+        raise ValueError("Wine base version is invalid")
     return data
 
 
@@ -51,6 +72,8 @@ def generate_aur(release: dict, output: Path, distribution: Path) -> None:
     pkgver = version.replace("-", "_")
     manager_url = release["manager"]["resolved_url"]
     wine_url = release["wine"]["resolved_url"]
+    manager_source = shell_single_quote(f"Wine4OfficeManager::{manager_url}")
+    wine_source = shell_single_quote(f"wine4office-runner::{wine_url}")
     pkgbuild = f'''# Generated from release.json. Do not edit hashes by hand.
 pkgname=wine4office-bin
 pkgver={pkgver}
@@ -60,7 +83,10 @@ pkgdesc="Wine and manager tuned for Microsoft Office"
 arch=('x86_64')
 url="https://github.com/ttv20/wine4office"
 license=('LGPL-2.1-or-later')
-depends=('glibc' 'gcc-libs' 'libglvnd' 'fontconfig' 'freetype2' 'dbus' 'gnutls')
+depends=('glibc' 'gcc-libs' 'glib2' 'libxkbcommon' 'libxkbcommon-x11'
+         'libxcb' 'xcb-util' 'xcb-util-cursor' 'xcb-util-image'
+         'xcb-util-keysyms' 'xcb-util-renderutil' 'xcb-util-wm'
+         'libglvnd' 'fontconfig' 'freetype2' 'dbus' 'gnutls' 'krb5')
 optdepends=('polkit: install updates from the Manager'
             'libx11: X11 display driver'
             'wayland: native Wayland display driver'
@@ -69,8 +95,8 @@ provides=('wine4office')
 conflicts=('wine4office')
 options=('!strip')
 source=('wine4office.desktop' 'wine4office-manager.png')
-source_x86_64=('Wine4OfficeManager::{manager_url}'
-               'wine4office-runner::{wine_url}')
+source_x86_64=({manager_source}
+               {wine_source})
 sha256sums=('{file_sha256(desktop)}'
             '{file_sha256(icon)}')
 sha256sums_x86_64=('{release["manager"]["sha256"]}'
@@ -117,11 +143,22 @@ EOF
 \tlicense = LGPL-2.1-or-later
 \tdepends = glibc
 \tdepends = gcc-libs
+\tdepends = glib2
+\tdepends = libxkbcommon
+\tdepends = libxkbcommon-x11
+\tdepends = libxcb
+\tdepends = xcb-util
+\tdepends = xcb-util-cursor
+\tdepends = xcb-util-image
+\tdepends = xcb-util-keysyms
+\tdepends = xcb-util-renderutil
+\tdepends = xcb-util-wm
 \tdepends = libglvnd
 \tdepends = fontconfig
 \tdepends = freetype2
 \tdepends = dbus
 \tdepends = gnutls
+\tdepends = krb5
 \toptdepends = polkit: install updates from the Manager
 \toptdepends = libx11: X11 display driver
 \toptdepends = wayland: native Wayland display driver
@@ -161,7 +198,7 @@ def generate_nix(release: dict, output: Path, distribution: Path) -> None:
     }
     lines = ["{"]
     for key, value in data.items():
-        lines.append(f"  {key} = {json.dumps(value)};")
+        lines.append(f"  {key} = {nix_string(value)};")
     lines.append("}")
     (output / "release.nix").write_text("\n".join(lines) + "\n", encoding="utf-8")
 

--- a/tools/wine4office-manager/packaging/distribution/generate-community-packages.py
+++ b/tools/wine4office-manager/packaging/distribution/generate-community-packages.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Generate fixed-hash AUR and Nix sources from a Wine4Office release manifest."""
+
+import argparse
+import base64
+import hashlib
+import json
+import re
+import shutil
+import urllib.parse
+from pathlib import Path
+
+
+def validated_release(path: Path) -> dict:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if data.get("schema_version") != 1:
+        raise ValueError("release.json schema_version must be 1")
+    version = data.get("manager", {}).get("version")
+    if (not isinstance(version, str)
+            or not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._+-]{0,127}", version)
+            or data.get("wine", {}).get("version") != version):
+        raise ValueError("manager and Wine must use the same valid product version")
+    metadata_url = data.get("metadata_url")
+    parsed = urllib.parse.urlsplit(metadata_url)
+    if parsed.scheme != "https" or not parsed.hostname:
+        raise ValueError("metadata_url must use HTTPS")
+    for name in ("manager", "wine"):
+        component = data[name]
+        url = urllib.parse.urljoin(metadata_url, component["url"])
+        parsed = urllib.parse.urlsplit(url)
+        if parsed.scheme != "https" or not parsed.hostname:
+            raise ValueError(f"{name} URL must use HTTPS")
+        if not re.fullmatch(r"[0-9a-f]{64}", component["sha256"]):
+            raise ValueError(f"{name} SHA-256 is invalid")
+        component["resolved_url"] = url
+    return data
+
+
+def file_sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def generate_aur(release: dict, output: Path, distribution: Path) -> None:
+    output.mkdir(parents=True, exist_ok=True)
+    desktop = distribution / "wine4office.desktop"
+    icon = distribution.parent.parent / "icons/wine4office-manager.png"
+    shutil.copyfile(desktop, output / desktop.name)
+    shutil.copyfile(icon, output / "wine4office-manager.png")
+    version = release["manager"]["version"]
+    base_version = release["wine"].get("base_version", "unknown")
+    pkgver = version.replace("-", "_")
+    manager_url = release["manager"]["resolved_url"]
+    wine_url = release["wine"]["resolved_url"]
+    pkgbuild = f'''# Generated from release.json. Do not edit hashes by hand.
+pkgname=wine4office-bin
+pkgver={pkgver}
+_release_version={version}
+pkgrel=1
+pkgdesc="Wine and manager tuned for Microsoft Office"
+arch=('x86_64')
+url="https://github.com/ttv20/wine4office"
+license=('LGPL-2.1-or-later')
+depends=('glibc' 'gcc-libs' 'libglvnd' 'fontconfig' 'freetype2' 'dbus' 'gnutls')
+optdepends=('polkit: install updates from the Manager'
+            'libx11: X11 display driver'
+            'wayland: native Wayland display driver'
+            'vulkan-icd-loader: Vulkan support')
+provides=('wine4office')
+conflicts=('wine4office')
+options=('!strip')
+source=('wine4office.desktop' 'wine4office-manager.png')
+source_x86_64=('Wine4OfficeManager::{manager_url}'
+               'wine4office-runner::{wine_url}')
+sha256sums=('{file_sha256(desktop)}'
+            '{file_sha256(icon)}')
+sha256sums_x86_64=('{release["manager"]["sha256"]}'
+                   '{release["wine"]["sha256"]}')
+
+package() {{
+    install -d "$pkgdir/opt/wine4office/bin" "$pkgdir/opt/wine4office/runner" \
+        "$pkgdir/usr/bin" "$pkgdir/usr/share/applications" \
+        "$pkgdir/usr/share/icons/hicolor/256x256/apps"
+    install -m755 "$srcdir/Wine4OfficeManager" \
+        "$pkgdir/opt/wine4office/bin/Wine4OfficeManager"
+    local runner_root
+    runner_root=$(find "$srcdir" -maxdepth 1 -type d -name 'wine4office-*-x86_64' -print -quit)
+    [[ -n $runner_root && -x $runner_root/bin/wine ]]
+    cp -a "$runner_root/." "$pkgdir/opt/wine4office/runner/"
+    ln -s /opt/wine4office/bin/Wine4OfficeManager "$pkgdir/usr/bin/Wine4OfficeManager"
+    ln -s /opt/wine4office/runner/bin/wine "$pkgdir/usr/bin/wine4office"
+    install -m644 "$srcdir/wine4office.desktop" \
+        "$pkgdir/usr/share/applications/wine4office.desktop"
+    install -m644 "$srcdir/wine4office-manager.png" \
+        "$pkgdir/usr/share/icons/hicolor/256x256/apps/wine4office-manager.png"
+    printf 'Wine4OfficeManager\\n' > "$pkgdir/opt/wine4office/STANDALONE"
+    printf '%s\\n' "$_release_version" > "$pkgdir/opt/wine4office/VERSION"
+    printf '%s\\n' "$_release_version" > "$pkgdir/opt/wine4office/WINE_VERSION"
+    printf '%s\\n' "{base_version}" > "$pkgdir/opt/wine4office/WINE_BASE_VERSION"
+    printf 'stable\\n' > "$pkgdir/opt/wine4office/UPDATE_CHANNEL"
+    cat > "$pkgdir/opt/wine4office/PACKAGE-INSTALLATION.json" <<'EOF'
+{{
+  "schema_version": 1,
+  "provider": "aur",
+  "package": "wine4office-bin",
+  "components": ["manager", "wine"]
+}}
+EOF
+}}
+'''
+    (output / "PKGBUILD").write_text(pkgbuild, encoding="utf-8")
+    srcinfo = f'''pkgbase = wine4office-bin
+\tpkgdesc = Wine and manager tuned for Microsoft Office
+\tpkgver = {pkgver}
+\tpkgrel = 1
+\turl = https://github.com/ttv20/wine4office
+\tarch = x86_64
+\tlicense = LGPL-2.1-or-later
+\tdepends = glibc
+\tdepends = gcc-libs
+\tdepends = libglvnd
+\tdepends = fontconfig
+\tdepends = freetype2
+\tdepends = dbus
+\tdepends = gnutls
+\toptdepends = polkit: install updates from the Manager
+\toptdepends = libx11: X11 display driver
+\toptdepends = wayland: native Wayland display driver
+\toptdepends = vulkan-icd-loader: Vulkan support
+\tprovides = wine4office
+\tconflicts = wine4office
+\toptions = !strip
+\tsource = wine4office.desktop
+\tsource = wine4office-manager.png
+\tsha256sums = {file_sha256(desktop)}
+\tsha256sums = {file_sha256(icon)}
+\tsource_x86_64 = Wine4OfficeManager::{manager_url}
+\tsource_x86_64 = wine4office-runner::{wine_url}
+\tsha256sums_x86_64 = {release["manager"]["sha256"]}
+\tsha256sums_x86_64 = {release["wine"]["sha256"]}
+
+pkgname = wine4office-bin
+'''
+    (output / ".SRCINFO").write_text(srcinfo, encoding="utf-8")
+
+
+def sri(hex_digest: str) -> str:
+    return "sha256-" + base64.b64encode(bytes.fromhex(hex_digest)).decode("ascii")
+
+
+def generate_nix(release: dict, output: Path, distribution: Path) -> None:
+    output.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(distribution / "nix/flake.nix", output / "flake.nix")
+    shutil.copyfile(distribution / "nix/package.nix", output / "package.nix")
+    data = {
+        "version": release["manager"]["version"],
+        "managerUrl": release["manager"]["resolved_url"],
+        "managerHash": sri(release["manager"]["sha256"]),
+        "wineUrl": release["wine"]["resolved_url"],
+        "wineHash": sri(release["wine"]["sha256"]),
+        "wineBaseVersion": release["wine"].get("base_version", "unknown"),
+    }
+    lines = ["{"]
+    for key, value in data.items():
+        lines.append(f"  {key} = {json.dumps(value)};")
+    lines.append("}")
+    (output / "release.nix").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("release_json", type=Path)
+    parser.add_argument("output", type=Path)
+    args = parser.parse_args()
+    release = validated_release(args.release_json)
+    distribution = Path(__file__).resolve().parent
+    generate_aur(release, args.output / "aur", distribution)
+    generate_nix(release, args.output / "nix", distribution)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/wine4office-manager/packaging/distribution/generate-community-packages.py
+++ b/tools/wine4office-manager/packaging/distribution/generate-community-packages.py
@@ -10,6 +10,10 @@ import shutil
 import urllib.parse
 from pathlib import Path
 
+WINE_BASE_VERSION_PATTERN = re.compile(
+    r"[0-9]+(?:[.][0-9A-Za-z]+)+(?:[-+][0-9A-Za-z][0-9A-Za-z.-]*)?"
+)
+
 
 def shell_single_quote(value: str) -> str:
     return "'" + value.replace("'", "'\"'\"'") + "'"
@@ -52,7 +56,7 @@ def validated_release(path: Path) -> dict:
         component["resolved_url"] = url
     base_version = data["wine"].get("base_version", "unknown")
     if (base_version != "unknown" and (not isinstance(base_version, str)
-            or not re.fullmatch(r"[0-9]+(?:[.][0-9A-Za-z]+)+", base_version))):
+            or not WINE_BASE_VERSION_PATTERN.fullmatch(base_version))):
         raise ValueError("Wine base version is invalid")
     return data
 

--- a/tools/wine4office-manager/packaging/distribution/nix/flake.nix
+++ b/tools/wine4office-manager/packaging/distribution/nix/flake.nix
@@ -1,0 +1,22 @@
+{
+  description = "Wine4Office binary release";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs = { self, nixpkgs }:
+    let
+      system = "x86_64-linux";
+      pkgs = import nixpkgs { inherit system; };
+      release = import ./release.nix;
+      wine4office = import ./package.nix { inherit pkgs release; };
+    in {
+      packages.${system} = {
+        default = wine4office;
+        wine4office = wine4office;
+      };
+      apps.${system}.default = {
+        type = "app";
+        program = "${wine4office}/bin/wine4office";
+      };
+    };
+}

--- a/tools/wine4office-manager/packaging/distribution/nix/package.nix
+++ b/tools/wine4office-manager/packaging/distribution/nix/package.nix
@@ -1,0 +1,72 @@
+{ pkgs, release }:
+let
+  manager = pkgs.fetchurl {
+    url = release.managerUrl;
+    hash = release.managerHash;
+  };
+  runner = pkgs.fetchurl {
+    url = release.wineUrl;
+    hash = release.wineHash;
+  };
+  payload = pkgs.stdenvNoCC.mkDerivation {
+    pname = "wine4office-payload";
+    version = release.version;
+    dontUnpack = true;
+    dontPatchELF = true;
+    dontPatchShebangs = true;
+    dontStrip = true;
+    nativeBuildInputs = [ pkgs.zstd ];
+    installPhase = ''
+      runHook preInstall
+      mkdir -p "$out/opt/wine4office/bin" "$out/opt/wine4office/runner"
+      install -m755 ${manager} "$out/opt/wine4office/bin/Wine4OfficeManager"
+      work=$(mktemp -d)
+      tar --zstd -xf ${runner} -C "$work"
+      runner_root=$(find "$work" -mindepth 1 -maxdepth 1 -type d -print)
+      test -x "$runner_root/bin/wine"
+      cp -a "$runner_root/." "$out/opt/wine4office/runner/"
+      printf 'Wine4OfficeManager\n' > "$out/opt/wine4office/STANDALONE"
+      printf '%s\n' ${release.version} > "$out/opt/wine4office/VERSION"
+      printf '%s\n' ${release.version} > "$out/opt/wine4office/WINE_VERSION"
+      printf '%s\n' ${release.wineBaseVersion} > "$out/opt/wine4office/WINE_BASE_VERSION"
+      printf 'stable\n' > "$out/opt/wine4office/UPDATE_CHANNEL"
+      cat > "$out/opt/wine4office/PACKAGE-INSTALLATION.json" <<'EOF'
+      {
+        "schema_version": 1,
+        "provider": "nix",
+        "package": "wine4office",
+        "components": ["manager", "wine"]
+      }
+      EOF
+      runHook postInstall
+    '';
+  };
+in pkgs.buildFHSEnv {
+  name = "wine4office";
+  targetPkgs = p: with p; [
+    alsa-lib cups dbus ffmpeg fontconfig freetype gnutls krb5
+    libGL libgphoto2 libpulseaudio libusb1 libva libxkbcommon
+    ocl-icd pcsclite sane-backends SDL2 stdenv.cc.cc.lib
+    unixodbc vulkan-loader wayland zlib
+    gst_all_1.gstreamer gst_all_1.gst-plugins-base
+    libx11 libxcomposite libxcursor libxext libxi libxinerama
+    libxrandr libxrender libxxf86vm
+  ];
+  multiPkgs = p: with p; [
+    alsa-lib fontconfig freetype gnutls stdenv.cc.cc.lib zlib
+  ];
+  profile = ''
+    export WINE4OFFICE_MANAGER_ROOT=${payload}/opt/wine4office
+  '';
+  runScript = "${payload}/opt/wine4office/bin/Wine4OfficeManager";
+  extraInstallCommands = ''
+    ln -s "$out/bin/wine4office" "$out/bin/Wine4OfficeManager"
+  '';
+  meta = {
+    description = "Wine and manager tuned for Microsoft Office";
+    homepage = "https://github.com/ttv20/wine4office";
+    license = pkgs.lib.licenses.lgpl21Plus;
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "wine4office";
+  };
+}

--- a/tools/wine4office-manager/packaging/distribution/nix/package.nix
+++ b/tools/wine4office-manager/packaging/distribution/nix/package.nix
@@ -41,26 +41,53 @@ let
       runHook postInstall
     '';
   };
-in pkgs.buildFHSEnv {
-  name = "wine4office";
-  targetPkgs = p: with p; [
-    alsa-lib cups dbus ffmpeg fontconfig freetype gnutls krb5
-    libGL libgphoto2 libpulseaudio libusb1 libva libxkbcommon
-    ocl-icd pcsclite sane-backends SDL2 stdenv.cc.cc.lib
-    unixodbc vulkan-loader wayland zlib
-    gst_all_1.gstreamer gst_all_1.gst-plugins-base
-    libx11 libxcomposite libxcursor libxext libxi libxinerama
-    libxrandr libxrender libxxf86vm
-  ];
-  multiPkgs = p: with p; [
-    alsa-lib fontconfig freetype gnutls stdenv.cc.cc.lib zlib
-  ];
-  profile = ''
-    export WINE4OFFICE_MANAGER_ROOT=${payload}/opt/wine4office
+  dispatcher = pkgs.writeShellScript "wine4office-dispatch" ''
+    if [ "''${1-}" = "--exec" ]; then
+      shift
+      if [ "$#" -eq 0 ]; then
+        echo "wine4office: --exec requires a command" >&2
+        exit 2
+      fi
+      exec "$@"
+    fi
+    exec ${payload}/opt/wine4office/bin/Wine4OfficeManager "$@"
   '';
-  runScript = "${payload}/opt/wine4office/bin/Wine4OfficeManager";
-  extraInstallCommands = ''
-    ln -s "$out/bin/wine4office" "$out/bin/Wine4OfficeManager"
+  fhs = pkgs.buildFHSEnv {
+    name = "wine4office-fhs";
+    targetPkgs = p: with p; [
+      alsa-lib cups dbus ffmpeg fontconfig freetype glib gnutls krb5
+      libGL libgphoto2 libpulseaudio libusb1 libva libxkbcommon
+      ocl-icd pcsclite sane-backends SDL2 stdenv.cc.cc.lib
+      unixodbc vulkan-loader wayland zlib
+      gst_all_1.gstreamer gst_all_1.gst-plugins-base
+      libx11 libxcomposite libxcursor libxext libxi libxinerama
+      libxrandr libxrender libxxf86vm
+      libxcb-util libxcb-render-util xcb-util-cursor
+      xcbutilimage xcbutilkeysyms xcbutilwm
+    ];
+    multiPkgs = p: with p; [
+      alsa-lib fontconfig freetype gnutls stdenv.cc.cc.lib zlib
+    ];
+    profile = ''
+      export WINE4OFFICE_MANAGER_ROOT=${payload}/opt/wine4office
+    '';
+    runScript = dispatcher;
+  };
+in pkgs.symlinkJoin {
+  name = "wine4office-${release.version}";
+  paths = [ fhs ];
+  postBuild = ''
+    cat > "$out/bin/wine4office" <<EOF
+    #!${pkgs.runtimeShell}
+    case \$0 in
+      /*) package_wrapper=\$0 ;;
+      *) package_wrapper=\$(command -v -- "\$0") ;;
+    esac
+    export WINE4OFFICE_PACKAGE_WRAPPER=\$package_wrapper
+    exec ${fhs}/bin/wine4office-fhs "\$@"
+    EOF
+    chmod 0755 "$out/bin/wine4office"
+    ln -s wine4office "$out/bin/Wine4OfficeManager"
   '';
   meta = {
     description = "Wine and manager tuned for Microsoft Office";

--- a/tools/wine4office-manager/packaging/distribution/nix/package.nix
+++ b/tools/wine4office-manager/packaging/distribution/nix/package.nix
@@ -68,9 +68,6 @@ let
     multiPkgs = p: with p; [
       alsa-lib fontconfig freetype gnutls stdenv.cc.cc.lib zlib
     ];
-    profile = ''
-      export WINE4OFFICE_MANAGER_ROOT=${payload}/opt/wine4office
-    '';
     runScript = dispatcher;
   };
 in pkgs.symlinkJoin {

--- a/tools/wine4office-manager/packaging/distribution/tests/test-package-builders.sh
+++ b/tools/wine4office-manager/packaging/distribution/tests/test-package-builders.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
-mode=${1:?usage: test-package-builders.sh deb|rpm|community}
+mode=${1:?usage: test-package-builders.sh deb|rpm|community|appimage}
 root=$(cd "$(dirname "$0")/../../../../.." && pwd)
 distribution=$root/tools/wine4office-manager/packaging/distribution
 release_builder=$root/tools/wine4office-manager/packaging/build-release-artifacts.sh
@@ -263,6 +263,76 @@ PY
             echo "Community package generator accepted an invalid Wine base version" >&2
             exit 1
         fi
+        ;;
+    appimage)
+        fake_appimagetool=$tmp/fake-appimagetool
+        cat > "$fake_appimagetool" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+appdir=${@: -2:1}
+output=${@: -1}
+tar -C "$appdir" -cf "${WINE4OFFICE_TEST_APPDIR_CAPTURE:?}" .
+: > "$output"
+EOF
+        chmod 0755 "$fake_appimagetool"
+        : > "$tmp/fake-runtime"
+        capture=$tmp/AppDir.tar
+        APPIMAGETOOL="$fake_appimagetool" \
+        APPIMAGE_RUNTIME="$tmp/fake-runtime" \
+        WINE4OFFICE_TEST_APPDIR_CAPTURE="$capture" \
+            "$distribution/build-appimage.sh" \
+            "$release/Wine4OfficeManager-${version}-x86_64" \
+            "$release/wine4office-${version}-x86_64.tar.zst" \
+            "$release/release.json" "$root/install.sh" "$tmp/packages"
+        appimage=$tmp/packages/Wine4Office-2.3.4-x86_64.AppImage
+        [[ -x $appimage && -f $appimage.sha256 ]]
+        mkdir "$tmp/appdir"
+        tar -xf "$capture" -C "$tmp/appdir"
+        bash -n "$tmp/appdir/AppRun"
+        bash -n "$tmp/appdir/payload/install.sh"
+        cmp "$manager" "$tmp/appdir/payload/Wine4OfficeManager"
+        cmp "$release/wine4office-${version}-x86_64.tar.zst" \
+            "$tmp/appdir/payload/wine.tar.zst"
+        cmp "$release/release.json" "$tmp/appdir/payload/release.json"
+        [[ $(cat "$tmp/appdir/payload/VERSION") == 2.3.4 ]]
+        [[ $(cat "$tmp/appdir/payload/METADATA_URL") == \
+            https://updates.example/releases/release.json ]]
+        [[ ! -e $tmp/appdir/payload/PACKAGE-INSTALLATION.json ]]
+
+        appimage_home=$tmp/appimage-home
+        appimage_root=$appimage_home/data/wine4office
+        APPDIR="$tmp/appdir" \
+        HOME="$appimage_home" XDG_DATA_HOME="$appimage_home/data" \
+        WINE4OFFICE_HOME="$appimage_root" \
+        WINE4OFFICE_BIN_HOME="$appimage_home/bin" \
+            "$tmp/appdir/AppRun" --appimage-install-only >/dev/null
+        cmp "$manager" "$appimage_root/bin/Wine4OfficeManager"
+        cmp "$runner/bin/wine" "$appimage_root/runner/bin/wine"
+        [[ $(cat "$appimage_root/UPDATE_CHANNEL") == stable ]]
+        [[ ! -e $appimage_root/PACKAGE-INSTALLATION.json ]]
+
+        runner_identity=$(stat -c '%d:%i' "$appimage_root/runner/bin/wine")
+        APPDIR="$tmp/appdir" \
+        HOME="$appimage_home" XDG_DATA_HOME="$appimage_home/data" \
+        WINE4OFFICE_HOME="$appimage_root" \
+        WINE4OFFICE_BIN_HOME="$appimage_home/bin" \
+            "$tmp/appdir/AppRun" --appimage-install-only >/dev/null
+        [[ $(stat -c '%d:%i' "$appimage_root/runner/bin/wine") == "$runner_identity" ]]
+
+        printf '9.0.0\n' > "$appimage_root/VERSION"
+        APPDIR="$tmp/appdir" \
+        HOME="$appimage_home" \
+        XDG_DATA_HOME="$appimage_home/data" \
+        WINE4OFFICE_HOME="$appimage_root" \
+        WINE4OFFICE_BIN_HOME="$appimage_home/bin" \
+            "$tmp/appdir/AppRun" --appimage-install-only \
+            | grep -F 'not downgrading' >/dev/null
+        [[ $(cat "$appimage_root/VERSION") == 9.0.0 ]]
+
+        mv "$tmp/appdir" "$tmp/AppDir.removed"
+        "$appimage_root/bin/Wine4OfficeManager" --smoke-test
+        [[ $("$appimage_root/runner/bin/wine" --version) == \
+            'wine4office-2.3.4 (Wine 11.17-rc1)' ]]
         ;;
     *) echo "Unknown mode: $mode" >&2; exit 2 ;;
 esac

--- a/tools/wine4office-manager/packaging/distribution/tests/test-package-builders.sh
+++ b/tools/wine4office-manager/packaging/distribution/tests/test-package-builders.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+mode=${1:?usage: test-package-builders.sh deb|rpm|community}
+root=$(cd "$(dirname "$0")/../../../../.." && pwd)
+distribution=$root/tools/wine4office-manager/packaging/distribution
+release_builder=$root/tools/wine4office-manager/packaging/build-release-artifacts.sh
+tmp=$(mktemp -d)
+trap 'rm -rf -- "$tmp"' EXIT
+chmod 0755 "$tmp"
+version=2.3.4
+runner=$tmp/runner
+manager=$tmp/Wine4OfficeManager
+release=$tmp/release
+mkdir -p "$runner/bin" "$runner/share/wine/gecko" "$runner/share/wine/mono"
+cat > "$runner/bin/wine" <<'EOF'
+#!/bin/sh
+echo 'wine4office-2.3.4 (Wine 11.17)'
+EOF
+cat > "$manager" <<'EOF'
+#!/bin/sh
+test "${1:-}" = --smoke-test || true
+exit 0
+EOF
+chmod 0755 "$runner/bin/wine" "$manager"
+printf x > "$runner/share/wine/gecko/wine-gecko-2.47.4-x86.msi"
+printf x > "$runner/share/wine/gecko/wine-gecko-2.47.4-x86_64.msi"
+printf x > "$runner/share/wine/mono/wine-mono-11.3.0-x86.msi"
+"$release_builder" "$runner" "$manager" "$release" "$version" \
+    https://updates.example/releases/release.json \
+    https://updates.example/releases  stable 11.17 >/dev/null
+
+verify_installation() {
+    [[ $(/opt/wine4office/runner/bin/wine --version) == \
+        'wine4office-2.3.4 (Wine 11.17)' ]]
+    /opt/wine4office/bin/Wine4OfficeManager --smoke-test
+    cmp "$manager" /opt/wine4office/bin/Wine4OfficeManager
+    cmp "$runner/bin/wine" /opt/wine4office/runner/bin/wine
+    [[ $(cat /opt/wine4office/WINE_BASE_VERSION) == 11.17 ]]
+    python3 - <<'PY'
+import json
+from pathlib import Path
+data = json.loads(Path("/opt/wine4office/PACKAGE-INSTALLATION.json").read_text())
+assert data["components"] == ["manager", "wine"]
+assert data["package"] == "wine4office"
+PY
+}
+
+case $mode in
+    deb)
+        "$distribution/build-deb.sh" "$release/Wine4OfficeManager-${version}-x86_64" \
+            "$release/wine4office-${version}-x86_64.tar.zst" "$version" \
+            apt wine4office "$tmp/packages"
+        deb=$tmp/packages/wine4office_2.3.4_amd64.deb
+        "$distribution/build-apt-repository.sh" "$tmp/repository" stable "$deb"
+        printf 'deb [trusted=yes] file:%s stable main\n' "$tmp/repository" \
+            > /etc/apt/sources.list.d/wine4office-test.list
+        apt-get update >/dev/null
+        apt-get install -y --no-install-recommends wine4office >/dev/null
+        verify_installation
+        [[ $(python3 -c 'import json; print(json.load(open("/opt/wine4office/PACKAGE-INSTALLATION.json"))["provider"])') == apt ]]
+        ;;
+    rpm)
+        "$distribution/build-rpm.sh" "$release/Wine4OfficeManager-${version}-x86_64" \
+            "$release/wine4office-${version}-x86_64.tar.zst" "$version" \
+            dnf wine4office "$tmp/packages"
+        rpm=$(find "$tmp/packages" -name '*.rpm' -print -quit)
+        "$distribution/build-rpm-repository.sh" "$tmp/repository" "$rpm"
+        cmp "$distribution/wine4office.repo" "$tmp/repository/wine4office.repo"
+        cat > /etc/yum.repos.d/wine4office-test.repo <<EOF
+[wine4office-test]
+name=Wine4Office test
+baseurl=file://$tmp/repository/rpm/x86_64
+enabled=1
+gpgcheck=0
+EOF
+        dnf install -y wine4office >/dev/null
+        verify_installation
+        [[ $(python3 -c 'import json; print(json.load(open("/opt/wine4office/PACKAGE-INSTALLATION.json"))["provider"])') == dnf ]]
+        ;;
+    community)
+        "$distribution/generate-community-packages.py" \
+            "$release/release.json" "$tmp/community"
+        bash -n "$tmp/community/aur/PKGBUILD"
+        grep -F 'pkgname = wine4office-bin' "$tmp/community/aur/.SRCINFO" >/dev/null
+        grep -F 'wineBaseVersion = "11.17";' "$tmp/community/nix/release.nix" >/dev/null
+        if command -v makepkg >/dev/null; then
+            chmod -R a+rwX "$tmp/community/aur"
+            if [[ $EUID -eq 0 ]]; then
+                (cd "$tmp/community/aur" && \
+                    runuser -u nobody -- env HOME=/tmp makepkg --printsrcinfo) \
+                    > "$tmp/generated.SRCINFO"
+            else
+                (cd "$tmp/community/aur" && makepkg --printsrcinfo) \
+                    > "$tmp/generated.SRCINFO"
+            fi
+            diff -u "$tmp/community/aur/.SRCINFO" "$tmp/generated.SRCINFO"
+        fi
+        if command -v nix-instantiate >/dev/null; then
+            nix-instantiate --parse "$tmp/community/nix/flake.nix" >/dev/null
+            nix-instantiate --parse "$tmp/community/nix/package.nix" >/dev/null
+            nix-instantiate --parse "$tmp/community/nix/release.nix" >/dev/null
+        fi
+        ;;
+    *) echo "Unknown mode: $mode" >&2; exit 2 ;;
+esac
+
+echo "$mode distribution package and repository: PASS"

--- a/tools/wine4office-manager/packaging/distribution/tests/test-package-builders.sh
+++ b/tools/wine4office-manager/packaging/distribution/tests/test-package-builders.sh
@@ -16,6 +16,9 @@ mkdir "$fake_sign_bin"
 cat > "$fake_sign_bin/gpg" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
+if [[ ${WINE4OFFICE_TEST_GPG_FAIL:-0} == 1 ]]; then
+    exit 73
+fi
 output=
 input=
 while (($#)); do
@@ -82,6 +85,21 @@ case $mode in
             "$distribution/build-apt-repository.sh" "$tmp/repository" stable "$deb"
         [[ -f $tmp/repository/dists/stable/InRelease ]]
         [[ -f $tmp/repository/dists/stable/Release.gpg ]]
+        apt_metadata_hash=$(sha256sum \
+            "$tmp/repository/dists/stable/Release" \
+            "$tmp/repository/dists/stable/InRelease" \
+            "$tmp/repository/dists/stable/Release.gpg")
+        if WINE4OFFICE_TEST_GPG_FAIL=1 PATH="$fake_sign_bin:$PATH" \
+                WINE4OFFICE_GPG_KEY_ID=test \
+                "$distribution/build-apt-repository.sh" \
+                "$tmp/repository" stable "$deb" >/dev/null 2>&1; then
+            echo "APT repository update ignored a signing failure" >&2
+            exit 1
+        fi
+        [[ $(sha256sum \
+            "$tmp/repository/dists/stable/Release" \
+            "$tmp/repository/dists/stable/InRelease" \
+            "$tmp/repository/dists/stable/Release.gpg") == "$apt_metadata_hash" ]]
         "$distribution/build-apt-repository.sh" "$tmp/repository" stable "$deb"
         [[ ! -e $tmp/repository/dists/stable/InRelease ]]
         [[ ! -e $tmp/repository/dists/stable/Release.gpg ]]
@@ -110,9 +128,26 @@ case $mode in
             PATH="$fake_sign_bin:$PATH" WINE4OFFICE_GPG_KEY_ID=test \
             "$distribution/build-rpm-repository.sh" "$tmp/repository" "$rpm"
         [[ $(sha256sum "$rpm") == "$rpm_hash" ]]
-        grep -Fx "$tmp/repository/rpm/x86_64/Packages/$(basename "$rpm")" \
-            "$tmp/rpmsign.log" >/dev/null
+        signed_rpm=$(tail -n 1 "$tmp/rpmsign.log")
+        case $signed_rpm in
+            "$tmp/repository/rpm/x86_64/".repository.*/Packages/"$(basename "$rpm")") ;;
+            *) echo "rpmsign did not receive a staged repository copy" >&2; exit 1 ;;
+        esac
         [[ -f $tmp/repository/rpm/x86_64/repodata/repomd.xml.asc ]]
+        rpm_metadata_hash=$(sha256sum \
+            "$tmp/repository/rpm/x86_64/repodata/repomd.xml" \
+            "$tmp/repository/rpm/x86_64/repodata/repomd.xml.asc")
+        if WINE4OFFICE_TEST_GPG_FAIL=1 WINE4OFFICE_TEST_RPMSIGN_LOG="$tmp/rpmsign.log" \
+                PATH="$fake_sign_bin:$PATH" WINE4OFFICE_GPG_KEY_ID=test \
+                "$distribution/build-rpm-repository.sh" \
+                "$tmp/repository" "$rpm" >/dev/null 2>&1; then
+            echo "RPM repository update ignored a signing failure" >&2
+            exit 1
+        fi
+        [[ $(sha256sum \
+            "$tmp/repository/rpm/x86_64/repodata/repomd.xml" \
+            "$tmp/repository/rpm/x86_64/repodata/repomd.xml.asc") == \
+            "$rpm_metadata_hash" ]]
         "$distribution/build-rpm-repository.sh" "$tmp/repository" "$rpm"
         [[ ! -e $tmp/repository/rpm/x86_64/repodata/repomd.xml.asc ]]
         cmp "$distribution/wine4office.repo" "$tmp/repository/wine4office.repo"

--- a/tools/wine4office-manager/packaging/distribution/tests/test-package-builders.sh
+++ b/tools/wine4office-manager/packaging/distribution/tests/test-package-builders.sh
@@ -51,6 +51,8 @@ case $mode in
             "$release/wine4office-${version}-x86_64.tar.zst" "$version" \
             apt wine4office "$tmp/packages"
         deb=$tmp/packages/wine4office_2.3.4_amd64.deb
+        dpkg-deb -f "$deb" Depends | grep -F 'libgssapi-krb5-2' >/dev/null
+        dpkg-deb -f "$deb" Depends | grep -F 'libxcb-cursor0' >/dev/null
         "$distribution/build-apt-repository.sh" "$tmp/repository" stable "$deb"
         printf 'deb [trusted=yes] file:%s stable main\n' "$tmp/repository" \
             > /etc/apt/sources.list.d/wine4office-test.list
@@ -64,6 +66,14 @@ case $mode in
             "$release/wine4office-${version}-x86_64.tar.zst" "$version" \
             dnf wine4office "$tmp/packages"
         rpm=$(find "$tmp/packages" -name '*.rpm' -print -quit)
+        rpm -qp --requires "$rpm" | grep -Fx 'krb5-libs' >/dev/null
+        rpm -qp --requires "$rpm" | grep -Fx 'xcb-util-cursor' >/dev/null
+        "$distribution/build-rpm.sh" "$release/Wine4OfficeManager-${version}-x86_64" \
+            "$release/wine4office-${version}-x86_64.tar.zst" \
+            "${version}+build.5" dnf wine4office "$tmp/build-metadata-packages"
+        find "$tmp/build-metadata-packages" \
+            -name 'wine4office-2.3.4-1.build.5*.x86_64.rpm' -print -quit \
+            | grep -q .
         "$distribution/build-rpm-repository.sh" "$tmp/repository" "$rpm"
         cmp "$distribution/wine4office.repo" "$tmp/repository/wine4office.repo"
         cat > /etc/yum.repos.d/wine4office-test.repo <<EOF
@@ -82,6 +92,9 @@ EOF
             "$release/release.json" "$tmp/community"
         bash -n "$tmp/community/aur/PKGBUILD"
         grep -F 'pkgname = wine4office-bin' "$tmp/community/aur/.SRCINFO" >/dev/null
+        grep -F $'\tdepends = krb5' "$tmp/community/aur/.SRCINFO" >/dev/null
+        grep -F $'\tdepends = xcb-util-cursor' \
+            "$tmp/community/aur/.SRCINFO" >/dev/null
         grep -F 'wineBaseVersion = "11.17";' "$tmp/community/nix/release.nix" >/dev/null
         if command -v makepkg >/dev/null; then
             chmod -R a+rwX "$tmp/community/aur"
@@ -99,6 +112,37 @@ EOF
             nix-instantiate --parse "$tmp/community/nix/flake.nix" >/dev/null
             nix-instantiate --parse "$tmp/community/nix/package.nix" >/dev/null
             nix-instantiate --parse "$tmp/community/nix/release.nix" >/dev/null
+        fi
+        python3 - "$release/release.json" "$tmp/adversarial.json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as source:
+    payload = json.load(source)
+payload["manager"]["url"] = "https://updates.example/artifact'${builtins.abort(null)}"
+with open(sys.argv[2], "w", encoding="utf-8") as target:
+    json.dump(payload, target)
+PY
+        "$distribution/generate-community-packages.py" \
+            "$tmp/adversarial.json" "$tmp/adversarial"
+        bash -n "$tmp/adversarial/aur/PKGBUILD"
+        # shellcheck disable=SC2016 # Verify a literal escaped Nix interpolation.
+        grep -F '\${builtins.abort(null)}' \
+            "$tmp/adversarial/nix/release.nix" >/dev/null
+        python3 - "$release/release.json" "$tmp/invalid-base.json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as source:
+    payload = json.load(source)
+payload["wine"]["base_version"] = "11.17;invalid"
+with open(sys.argv[2], "w", encoding="utf-8") as target:
+    json.dump(payload, target)
+PY
+        if "$distribution/generate-community-packages.py" \
+                "$tmp/invalid-base.json" "$tmp/invalid-base" >/dev/null 2>&1; then
+            echo "Community package generator accepted an invalid Wine base version" >&2
+            exit 1
         fi
         ;;
     *) echo "Unknown mode: $mode" >&2; exit 2 ;;

--- a/tools/wine4office-manager/packaging/distribution/tests/test-package-builders.sh
+++ b/tools/wine4office-manager/packaging/distribution/tests/test-package-builders.sh
@@ -89,6 +89,20 @@ case $mode in
             "$tmp/repository/dists/stable/Release" \
             "$tmp/repository/dists/stable/InRelease" \
             "$tmp/repository/dists/stable/Release.gpg")
+        mkdir "$tmp/rebuilt-deb"
+        rebuilt_deb=$tmp/rebuilt-deb/$(basename "$deb")
+        cp "$deb" "$rebuilt_deb"
+        printf 'changed same-version bytes\n' >> "$rebuilt_deb"
+        if "$distribution/build-apt-repository.sh" \
+                "$tmp/repository" stable "$rebuilt_deb" >/dev/null 2>&1; then
+            echo "APT repository replaced an immutable published package" >&2
+            exit 1
+        fi
+        [[ $(sha256sum \
+            "$tmp/repository/dists/stable/Release" \
+            "$tmp/repository/dists/stable/InRelease" \
+            "$tmp/repository/dists/stable/Release.gpg") == "$apt_metadata_hash" ]]
+        cmp "$deb" "$tmp/repository/pool/main/w/wine4office/$(basename "$deb")"
         if WINE4OFFICE_TEST_GPG_FAIL=1 PATH="$fake_sign_bin:$PATH" \
                 WINE4OFFICE_GPG_KEY_ID=test \
                 "$distribution/build-apt-repository.sh" \
@@ -137,6 +151,22 @@ case $mode in
         rpm_metadata_hash=$(sha256sum \
             "$tmp/repository/rpm/x86_64/repodata/repomd.xml" \
             "$tmp/repository/rpm/x86_64/repodata/repomd.xml.asc")
+        mkdir "$tmp/rebuilt-rpm"
+        rebuilt_rpm=$tmp/rebuilt-rpm/$(basename "$rpm")
+        cp "$rpm" "$rebuilt_rpm"
+        printf 'changed same-release bytes\n' >> "$rebuilt_rpm"
+        if WINE4OFFICE_TEST_RPMSIGN_LOG="$tmp/rpmsign.log" \
+                PATH="$fake_sign_bin:$PATH" WINE4OFFICE_GPG_KEY_ID=test \
+                "$distribution/build-rpm-repository.sh" \
+                "$tmp/repository" "$rebuilt_rpm" >/dev/null 2>&1; then
+            echo "RPM repository replaced an immutable published package" >&2
+            exit 1
+        fi
+        [[ $(sha256sum \
+            "$tmp/repository/rpm/x86_64/repodata/repomd.xml" \
+            "$tmp/repository/rpm/x86_64/repodata/repomd.xml.asc") == \
+            "$rpm_metadata_hash" ]]
+        cmp "$rpm" "$tmp/repository/rpm/x86_64/Packages/$(basename "$rpm")"
         if WINE4OFFICE_TEST_GPG_FAIL=1 WINE4OFFICE_TEST_RPMSIGN_LOG="$tmp/rpmsign.log" \
                 PATH="$fake_sign_bin:$PATH" WINE4OFFICE_GPG_KEY_ID=test \
                 "$distribution/build-rpm-repository.sh" \

--- a/tools/wine4office-manager/packaging/distribution/tests/test-package-builders.sh
+++ b/tools/wine4office-manager/packaging/distribution/tests/test-package-builders.sh
@@ -11,10 +11,35 @@ version=2.3.4
 runner=$tmp/runner
 manager=$tmp/Wine4OfficeManager
 release=$tmp/release
+fake_sign_bin=$tmp/fake-sign-bin
+mkdir "$fake_sign_bin"
+cat > "$fake_sign_bin/gpg" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+output=
+input=
+while (($#)); do
+    case $1 in
+        --output) output=${2:?}; shift 2 ;;
+        *) input=$1; shift ;;
+    esac
+done
+if [[ -z $output ]]; then
+    [[ -n $input ]]
+    output=$input.asc
+fi
+printf 'test signature\n' > "$output"
+EOF
+cat > "$fake_sign_bin/rpmsign" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "${!#}" >> "${WINE4OFFICE_TEST_RPMSIGN_LOG:?}"
+EOF
+chmod 0755 "$fake_sign_bin/gpg" "$fake_sign_bin/rpmsign"
 mkdir -p "$runner/bin" "$runner/share/wine/gecko" "$runner/share/wine/mono"
 cat > "$runner/bin/wine" <<'EOF'
 #!/bin/sh
-echo 'wine4office-2.3.4 (Wine 11.17)'
+echo 'wine4office-2.3.4 (Wine 11.17-rc1)'
 EOF
 cat > "$manager" <<'EOF'
 #!/bin/sh
@@ -27,15 +52,15 @@ printf x > "$runner/share/wine/gecko/wine-gecko-2.47.4-x86_64.msi"
 printf x > "$runner/share/wine/mono/wine-mono-11.3.0-x86.msi"
 "$release_builder" "$runner" "$manager" "$release" "$version" \
     https://updates.example/releases/release.json \
-    https://updates.example/releases  stable 11.17 >/dev/null
+    https://updates.example/releases  stable 11.17-rc1 >/dev/null
 
 verify_installation() {
     [[ $(/opt/wine4office/runner/bin/wine --version) == \
-        'wine4office-2.3.4 (Wine 11.17)' ]]
+        'wine4office-2.3.4 (Wine 11.17-rc1)' ]]
     /opt/wine4office/bin/Wine4OfficeManager --smoke-test
     cmp "$manager" /opt/wine4office/bin/Wine4OfficeManager
     cmp "$runner/bin/wine" /opt/wine4office/runner/bin/wine
-    [[ $(cat /opt/wine4office/WINE_BASE_VERSION) == 11.17 ]]
+    [[ $(cat /opt/wine4office/WINE_BASE_VERSION) == 11.17-rc1 ]]
     python3 - <<'PY'
 import json
 from pathlib import Path
@@ -53,7 +78,13 @@ case $mode in
         deb=$tmp/packages/wine4office_2.3.4_amd64.deb
         dpkg-deb -f "$deb" Depends | grep -F 'libgssapi-krb5-2' >/dev/null
         dpkg-deb -f "$deb" Depends | grep -F 'libxcb-cursor0' >/dev/null
+        PATH="$fake_sign_bin:$PATH" WINE4OFFICE_GPG_KEY_ID=test \
+            "$distribution/build-apt-repository.sh" "$tmp/repository" stable "$deb"
+        [[ -f $tmp/repository/dists/stable/InRelease ]]
+        [[ -f $tmp/repository/dists/stable/Release.gpg ]]
         "$distribution/build-apt-repository.sh" "$tmp/repository" stable "$deb"
+        [[ ! -e $tmp/repository/dists/stable/InRelease ]]
+        [[ ! -e $tmp/repository/dists/stable/Release.gpg ]]
         printf 'deb [trusted=yes] file:%s stable main\n' "$tmp/repository" \
             > /etc/apt/sources.list.d/wine4office-test.list
         apt-get update >/dev/null
@@ -74,7 +105,16 @@ case $mode in
         find "$tmp/build-metadata-packages" \
             -name 'wine4office-2.3.4-1.build.5*.x86_64.rpm' -print -quit \
             | grep -q .
+        rpm_hash=$(sha256sum "$rpm")
+        WINE4OFFICE_TEST_RPMSIGN_LOG="$tmp/rpmsign.log" \
+            PATH="$fake_sign_bin:$PATH" WINE4OFFICE_GPG_KEY_ID=test \
+            "$distribution/build-rpm-repository.sh" "$tmp/repository" "$rpm"
+        [[ $(sha256sum "$rpm") == "$rpm_hash" ]]
+        grep -Fx "$tmp/repository/rpm/x86_64/Packages/$(basename "$rpm")" \
+            "$tmp/rpmsign.log" >/dev/null
+        [[ -f $tmp/repository/rpm/x86_64/repodata/repomd.xml.asc ]]
         "$distribution/build-rpm-repository.sh" "$tmp/repository" "$rpm"
+        [[ ! -e $tmp/repository/rpm/x86_64/repodata/repomd.xml.asc ]]
         cmp "$distribution/wine4office.repo" "$tmp/repository/wine4office.repo"
         cat > /etc/yum.repos.d/wine4office-test.repo <<EOF
 [wine4office-test]
@@ -95,10 +135,15 @@ EOF
         grep -F $'\tdepends = krb5' "$tmp/community/aur/.SRCINFO" >/dev/null
         grep -F $'\tdepends = xcb-util-cursor' \
             "$tmp/community/aur/.SRCINFO" >/dev/null
-        grep -F 'wineBaseVersion = "11.17";' "$tmp/community/nix/release.nix" >/dev/null
+        grep -F 'wineBaseVersion = "11.17-rc1";' "$tmp/community/nix/release.nix" >/dev/null
+        if grep -F 'WINE4OFFICE_MANAGER_ROOT' "$tmp/community/nix/package.nix" >/dev/null; then
+            echo "Nix package redirects bundled Manager resource lookup" >&2
+            exit 1
+        fi
         if command -v makepkg >/dev/null; then
-            chmod -R a+rwX "$tmp/community/aur"
             if [[ $EUID -eq 0 ]]; then
+                nobody_group=$(id -gn nobody)
+                chown -R "nobody:$nobody_group" "$tmp/community/aur"
                 (cd "$tmp/community/aur" && \
                     runuser -u nobody -- env HOME=/tmp makepkg --printsrcinfo) \
                     > "$tmp/generated.SRCINFO"

--- a/tools/wine4office-manager/packaging/distribution/tests/test-package-builders.sh
+++ b/tools/wine4office-manager/packaging/distribution/tests/test-package-builders.sh
@@ -137,6 +137,15 @@ case $mode in
         find "$tmp/build-metadata-packages" \
             -name 'wine4office-2.3.4-1.build.5*.x86_64.rpm' -print -quit \
             | grep -q .
+        "$distribution/build-rpm-repository.sh" "$tmp/unsigned-repository" "$rpm"
+        if WINE4OFFICE_TEST_RPMSIGN_LOG="$tmp/unsigned-rpmsign.log" \
+                PATH="$fake_sign_bin:$PATH" WINE4OFFICE_GPG_KEY_ID=test \
+                "$distribution/build-rpm-repository.sh" \
+                "$tmp/unsigned-repository" "$rpm" >/dev/null 2>&1; then
+            echo "RPM repository silently reused an unsigned package in signed mode" >&2
+            exit 1
+        fi
+        [[ ! -e $tmp/unsigned-repository/rpm/x86_64/repodata/repomd.xml.asc ]]
         rpm_hash=$(sha256sum "$rpm")
         WINE4OFFICE_TEST_RPMSIGN_LOG="$tmp/rpmsign.log" \
             PATH="$fake_sign_bin:$PATH" WINE4OFFICE_GPG_KEY_ID=test \

--- a/tools/wine4office-manager/packaging/distribution/tests/test-package-builders.sh
+++ b/tools/wine4office-manager/packaging/distribution/tests/test-package-builders.sh
@@ -265,20 +265,31 @@ PY
         fi
         ;;
     appimage)
-        fake_appimagetool=$tmp/fake-appimagetool
-        cat > "$fake_appimagetool" <<'EOF'
+        fake_mkdwarfs=$tmp/fake-mkdwarfs
+        cat > "$fake_mkdwarfs" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
-appdir=${@: -2:1}
-output=${@: -1}
+appdir=
+output=
+runtime=
+while (($#)); do
+    case $1 in
+        --input) appdir=$2; shift 2 ;;
+        --output) output=$2; shift 2 ;;
+        --header) runtime=$2; shift 2 ;;
+        *) shift ;;
+    esac
+done
+[[ -d $appdir && -n $output && -x $runtime ]]
 tar -C "$appdir" -cf "${WINE4OFFICE_TEST_APPDIR_CAPTURE:?}" .
 : > "$output"
 EOF
-        chmod 0755 "$fake_appimagetool"
+        chmod 0755 "$fake_mkdwarfs"
         : > "$tmp/fake-runtime"
+        chmod 0755 "$tmp/fake-runtime"
         capture=$tmp/AppDir.tar
-        APPIMAGETOOL="$fake_appimagetool" \
         APPIMAGE_RUNTIME="$tmp/fake-runtime" \
+        APPIMAGE_MKDWARFS="$fake_mkdwarfs" \
         WINE4OFFICE_TEST_APPDIR_CAPTURE="$capture" \
             "$distribution/build-appimage.sh" \
             "$release/Wine4OfficeManager-${version}-x86_64" \
@@ -297,6 +308,12 @@ EOF
         [[ $(cat "$tmp/appdir/payload/VERSION") == 2.3.4 ]]
         [[ $(cat "$tmp/appdir/payload/METADATA_URL") == \
             https://updates.example/releases/release.json ]]
+        grep -Fx 'X-AppImage-Name=Wine4Office' \
+            "$tmp/appdir/wine4office.desktop" >/dev/null
+        grep -Fx 'X-AppImage-Version=2.3.4' \
+            "$tmp/appdir/wine4office.desktop" >/dev/null
+        grep -Fx 'X-AppImage-Arch=x86_64' \
+            "$tmp/appdir/wine4office.desktop" >/dev/null
         [[ ! -e $tmp/appdir/payload/PACKAGE-INSTALLATION.json ]]
 
         appimage_home=$tmp/appimage-home

--- a/tools/wine4office-manager/packaging/distribution/wine4office.AppRun
+++ b/tools/wine4office-manager/packaging/distribution/wine4office.AppRun
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Install the bundled Wine4Office release once, then run the durable user installation.
+set -euo pipefail
+
+APPDIR=${APPDIR:-$(cd "$(dirname "$0")" && pwd)}
+PAYLOAD=$APPDIR/payload
+DATA_HOME=${XDG_DATA_HOME:-$HOME/.local/share}
+ROOT=${WINE4OFFICE_HOME:-$DATA_HOME/wine4office}
+MANAGER=$ROOT/bin/Wine4OfficeManager
+INSTALL_ONLY=false
+
+if [[ ${1:-} == --appimage-install-only ]]; then
+    INSTALL_ONLY=true
+    shift
+fi
+
+[[ -r $PAYLOAD/VERSION && -r $PAYLOAD/METADATA_URL ]] || {
+    echo "Wine4Office AppImage payload metadata is missing." >&2
+    exit 1
+}
+BUNDLED_VERSION=$(<"$PAYLOAD/VERSION")
+METADATA_URL=$(<"$PAYLOAD/METADATA_URL")
+
+version_order() {
+    python3 - "$1" "$2" <<'PY'
+import re
+import sys
+
+pattern = re.compile(r"[A-Za-z0-9][A-Za-z0-9._+-]{0,127}")
+
+def split_version(value):
+    if not pattern.fullmatch(value):
+        raise SystemExit(f"invalid installed version: {value!r}")
+    precedence = value.split("+", 1)[0]
+    release, separator, prerelease = precedence.partition("-")
+    release_parts = []
+    for token in re.findall(r"[0-9]+|[A-Za-z]+", release):
+        release_parts.append((1, int(token)) if token.isdigit() else (0, token.lower()))
+    return release_parts, prerelease.split(".") if separator else None
+
+def compare(left, right):
+    left_release, left_pre = split_version(left)
+    right_release, right_pre = split_version(right)
+    for index in range(max(len(left_release), len(right_release))):
+        left_part = left_release[index] if index < len(left_release) else (1, 0)
+        right_part = right_release[index] if index < len(right_release) else (1, 0)
+        if left_part != right_part:
+            return 1 if left_part > right_part else -1
+    if left_pre is None or right_pre is None:
+        if left_pre is right_pre:
+            return 0
+        return 1 if left_pre is None else -1
+    for index in range(max(len(left_pre), len(right_pre))):
+        if index >= len(left_pre):
+            return -1
+        if index >= len(right_pre):
+            return 1
+        left_part, right_part = left_pre[index], right_pre[index]
+        if left_part == right_part:
+            continue
+        left_numeric, right_numeric = left_part.isdigit(), right_part.isdigit()
+        if left_numeric and right_numeric:
+            return 1 if int(left_part) > int(right_part) else -1
+        if left_numeric != right_numeric:
+            return -1 if left_numeric else 1
+        return 1 if left_part.lower() > right_part.lower() else -1
+    return 0
+
+print(compare(sys.argv[1], sys.argv[2]))
+PY
+}
+
+INSTALL=true
+if [[ -x $MANAGER && -x $ROOT/runner/bin/wine && -r $ROOT/VERSION ]]; then
+    INSTALLED_VERSION=$(<"$ROOT/VERSION")
+    if ORDER=$(version_order "$INSTALLED_VERSION" "$BUNDLED_VERSION" 2>/dev/null); then
+        if ((ORDER >= 0)); then
+            INSTALL=false
+            if ((ORDER > 0)); then
+                printf 'Wine4Office %s is already installed; not downgrading to %s.\n' \
+                    "$INSTALLED_VERSION" "$BUNDLED_VERSION"
+            fi
+        fi
+    fi
+fi
+
+if $INSTALL; then
+    PATH="$APPDIR/usr/bin:$PATH" \
+    WINE4OFFICE_BUNDLE_DIR="$PAYLOAD" \
+    WINE4OFFICE_METADATA_URL="$METADATA_URL" \
+    WINE4OFFICE_LAUNCH_MANAGER=no \
+        "$PAYLOAD/install.sh"
+fi
+
+$INSTALL_ONLY && exit 0
+[[ -x $MANAGER ]] || {
+    echo "Wine4Office installation did not provide an executable Manager: $MANAGER" >&2
+    exit 1
+}
+exec "$MANAGER" "$@"

--- a/tools/wine4office-manager/packaging/distribution/wine4office.desktop
+++ b/tools/wine4office-manager/packaging/distribution/wine4office.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Type=Application
+Name=Wine4Office Manager
+Comment=Install and manage Microsoft Office with Wine4Office
+Exec=Wine4OfficeManager
+Icon=wine4office-manager
+Terminal=false
+Categories=Office;Utility;
+StartupNotify=true
+StartupWMClass=Wine4OfficeManager

--- a/tools/wine4office-manager/packaging/distribution/wine4office.repo
+++ b/tools/wine4office-manager/packaging/distribution/wine4office.repo
@@ -1,0 +1,7 @@
+[wine4office]
+name=Wine4Office
+baseurl=https://packages.wine4office.org/rpm/x86_64/
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://packages.wine4office.org/keys/wine4office-packages.asc

--- a/tools/wine4office-manager/requirements-build.txt
+++ b/tools/wine4office-manager/requirements-build.txt
@@ -3,4 +3,7 @@ PyInstaller>=6.10,<7
 PySide6>=6.8,<7
 pefile>=2024.8.26,<2025
 signify>=0.9.2,<1
+# PyPI oscrypto 1.3.0 rejects OpenSSL versions such as 3.0.13. Pin the
+# upstream parser fix until a newer oscrypto release contains it.
+oscrypto @ https://github.com/wbond/oscrypto/archive/d5f3437ed24257895ae1edd9e503cfb352e635a8.tar.gz#sha256=f40d112bb8b5ca8cd424d64d80b3bd39a48bc1d769206f2c4d79fd9b0618ae74
 zstandard>=0.23,<1

--- a/tools/wine4office-manager/requirements-gui.txt
+++ b/tools/wine4office-manager/requirements-gui.txt
@@ -1,4 +1,7 @@
 PySide6>=6.8,<7
 pefile>=2024.8.26,<2025
 signify>=0.9.2,<1
+# PyPI oscrypto 1.3.0 rejects OpenSSL versions such as 3.0.13. Pin the
+# upstream parser fix until a newer oscrypto release contains it.
+oscrypto @ https://github.com/wbond/oscrypto/archive/d5f3437ed24257895ae1edd9e503cfb352e635a8.tar.gz#sha256=f40d112bb8b5ca8cd424d64d80b3bd39a48bc1d769206f2c4d79fd9b0618ae74
 zstandard>=0.23,<1

--- a/tools/wine4office-manager/tests/test_curl_install.sh
+++ b/tools/wine4office-manager/tests/test_curl_install.sh
@@ -44,7 +44,7 @@ write_metadata() {
     release_channel=${4:-stable}
     RELEASE="$RELEASE" MANAGER_DIGEST="$manager_digest" \
         MANAGER_VERSION="$manager_version" WINE_VERSION="$wine_version" \
-        RELEASE_CHANNEL="$release_channel" python3 - <<'PY'
+        RELEASE_CHANNEL="$release_channel" WINE_BASE_VERSION=11.17 python3 - <<'PY'
 import hashlib
 import json
 import os
@@ -64,6 +64,7 @@ payload = {
     },
     "wine": {
         "version": os.environ["WINE_VERSION"],
+        "base_version": os.environ["WINE_BASE_VERSION"],
         "url": "wine.tar.zst",
         "sha256": hashlib.sha256(wine.read_bytes()).hexdigest(),
         "size": wine.stat().st_size,
@@ -125,6 +126,7 @@ export WINE4OFFICE_METADATA_URL=https://example.invalid/release.json
 [[ -x $WINE4OFFICE_HOME/runner/bin/wine ]]
 [[ $(cat "$WINE4OFFICE_HOME/runner/identity") == "runner payload" ]]
 [[ $(cat "$WINE4OFFICE_HOME/WINE_VERSION") == 0.1.0 ]]
+[[ $(cat "$WINE4OFFICE_HOME/WINE_BASE_VERSION") == 11.17 ]]
 [[ -L $WINE4OFFICE_BIN_HOME/Wine4OfficeManager ]]
 if [[ -n $REAL_MANAGER ]]; then
     [[ -f $XDG_DATA_HOME/applications/wine4office-manager.desktop ]]
@@ -196,6 +198,7 @@ write_metadata "$MANAGER_DIGEST" 0.2.0 0.2.0
 PATH="$FAKE_BIN:$PATH" "$HERE/install.sh" >/dev/null
 [[ $(cat "$WINE4OFFICE_HOME/VERSION") == 0.2.0 ]]
 [[ $(cat "$WINE4OFFICE_HOME/WINE_VERSION") == 0.2.0 ]]
+[[ $(cat "$WINE4OFFICE_HOME/WINE_BASE_VERSION") == 11.17 ]]
 [[ $(cat "$WINE4OFFICE_HOME/runner/identity") == "runner payload v2" ]]
 
 BEFORE_MANAGER=$(sha256sum "$WINE4OFFICE_HOME/bin/Wine4OfficeManager")

--- a/tools/wine4office-manager/tests/test_curl_install.sh
+++ b/tools/wine4office-manager/tests/test_curl_install.sh
@@ -167,7 +167,21 @@ fi
 write_metadata "$MANAGER_DIGEST" 0.2.0-beta.1 0.2.0-beta.1 prerelease
 PATH="$FAKE_BIN:$PATH" "$HERE/install.sh" --tag 0.2.0-beta.1 >/dev/null
 [[ $(cat "$WINE4OFFICE_HOME/VERSION") == 0.2.0-beta.1 ]]
-[[ $(cat "$WINE4OFFICE_HOME/UPDATE_CHANNEL") == stable ]]
+[[ $(cat "$WINE4OFFICE_HOME/UPDATE_CHANNEL") == prerelease ]]
+
+BUNDLE_HOME=$TMP/bundle-home
+curl_lines_before=$(wc -l < "$FAKE_CURL_LOG")
+WINE4OFFICE_BUNDLE_DIR="$RELEASE" \
+WINE4OFFICE_METADATA_URL=https://example.invalid/release.json \
+WINE4OFFICE_HOME="$BUNDLE_HOME/data/wine4office" \
+WINE4OFFICE_BIN_HOME="$BUNDLE_HOME/bin" \
+XDG_DATA_HOME="$BUNDLE_HOME/data" HOME="$BUNDLE_HOME" \
+WINE4OFFICE_LAUNCH_MANAGER=no PATH="$FAKE_BIN:$PATH" \
+    "$HERE/install.sh" >/dev/null
+[[ $(cat "$BUNDLE_HOME/data/wine4office/VERSION") == 0.2.0-beta.1 ]]
+[[ $(cat "$BUNDLE_HOME/data/wine4office/UPDATE_CHANNEL") == prerelease ]]
+[[ $(cat "$BUNDLE_HOME/data/wine4office/WINE_BASE_VERSION") == 11.17-rc1 ]]
+[[ $(wc -l < "$FAKE_CURL_LOG") == "$curl_lines_before" ]]
 write_metadata "$MANAGER_DIGEST"
 if [[ -z $REAL_MANAGER ]]; then
     [[ $(grep -c '^<launch>$' "$WINE4OFFICE_TEST_MANAGER_LOG" || true) == 0 ]]

--- a/tools/wine4office-manager/tests/test_curl_install.sh
+++ b/tools/wine4office-manager/tests/test_curl_install.sh
@@ -44,7 +44,7 @@ write_metadata() {
     release_channel=${4:-stable}
     RELEASE="$RELEASE" MANAGER_DIGEST="$manager_digest" \
         MANAGER_VERSION="$manager_version" WINE_VERSION="$wine_version" \
-        RELEASE_CHANNEL="$release_channel" WINE_BASE_VERSION=11.17 python3 - <<'PY'
+        RELEASE_CHANNEL="$release_channel" WINE_BASE_VERSION=11.17-rc1 python3 - <<'PY'
 import hashlib
 import json
 import os
@@ -126,7 +126,7 @@ export WINE4OFFICE_METADATA_URL=https://example.invalid/release.json
 [[ -x $WINE4OFFICE_HOME/runner/bin/wine ]]
 [[ $(cat "$WINE4OFFICE_HOME/runner/identity") == "runner payload" ]]
 [[ $(cat "$WINE4OFFICE_HOME/WINE_VERSION") == 0.1.0 ]]
-[[ $(cat "$WINE4OFFICE_HOME/WINE_BASE_VERSION") == 11.17 ]]
+[[ $(cat "$WINE4OFFICE_HOME/WINE_BASE_VERSION") == 11.17-rc1 ]]
 [[ -L $WINE4OFFICE_BIN_HOME/Wine4OfficeManager ]]
 if [[ -n $REAL_MANAGER ]]; then
     [[ -f $XDG_DATA_HOME/applications/wine4office-manager.desktop ]]
@@ -198,7 +198,7 @@ write_metadata "$MANAGER_DIGEST" 0.2.0 0.2.0
 PATH="$FAKE_BIN:$PATH" "$HERE/install.sh" >/dev/null
 [[ $(cat "$WINE4OFFICE_HOME/VERSION") == 0.2.0 ]]
 [[ $(cat "$WINE4OFFICE_HOME/WINE_VERSION") == 0.2.0 ]]
-[[ $(cat "$WINE4OFFICE_HOME/WINE_BASE_VERSION") == 11.17 ]]
+[[ $(cat "$WINE4OFFICE_HOME/WINE_BASE_VERSION") == 11.17-rc1 ]]
 [[ $(cat "$WINE4OFFICE_HOME/runner/identity") == "runner payload v2" ]]
 
 BEFORE_MANAGER=$(sha256sum "$WINE4OFFICE_HOME/bin/Wine4OfficeManager")

--- a/tools/wine4office-manager/tests/test_qt.py
+++ b/tools/wine4office-manager/tests/test_qt.py
@@ -988,6 +988,40 @@ class QtManagerTests(unittest.TestCase):
             self.window.start_background_update_check()
         check.assert_called_once_with()
 
+    def test_package_installation_hides_feed_controls_and_uses_package_update(self):
+        package = {
+            "schema_version": 1,
+            "provider": "apt",
+            "provider_name": "APT",
+            "package": "wine4office",
+            "components": ("manager", "wine"),
+        }
+        with mock.patch.object(
+            backend, "package_installation", return_value=package
+        ), mock.patch.object(
+            backend, "package_update_command", return_value=["pkexec", "apt-get"]
+        ):
+            self.window.refresh_state()
+
+        self.assertTrue(self.window.update_edit.isHidden())
+        self.assertTrue(self.window.include_prereleases.isHidden())
+        self.assertTrue(self.window.automatic_update_checks.isHidden())
+        self.assertFalse(self.window.package_update_label.isHidden())
+        self.assertIn("APT", self.window.update_button.text())
+
+        with mock.patch.object(
+            backend, "package_update_command", return_value=["pkexec", "apt-get"]
+        ), mock.patch.object(
+            backend, "office_installation_exists", return_value=False
+        ), mock.patch.object(
+            self.state, "start_package_update"
+        ) as start, mock.patch.object(
+            self.window, "_show_task_progress"
+        ), mock.patch.object(self.window, "refresh_state"):
+            self.window.start_update()
+
+        start.assert_called_once_with()
+
     def test_combined_update_prompt_installs_once_and_opens_maintenance(self):
         offer = {
             "id": "manager:0.1.6|wine:11.14",
@@ -1857,6 +1891,7 @@ class QtManagerTests(unittest.TestCase):
 
     def test_close_during_staged_transition_waits_for_rollback(self):
         target = self._make_prefix(self.home / "replacement-prefix")
+        backend.mark_prefix_owned(self.old_prefix)
         staged = self.old_prefix.with_name(".old-staged-for-close")
         staged_ready = threading.Event()
         cancel_observed = threading.Event()

--- a/tools/wine4office-manager/tests/test_qt.py
+++ b/tools/wine4office-manager/tests/test_qt.py
@@ -1000,9 +1000,19 @@ class QtManagerTests(unittest.TestCase):
             backend, "package_installation", return_value=package
         ), mock.patch.object(
             backend, "package_update_command", return_value=["pkexec", "apt-get"]
-        ):
+        ), mock.patch.object(
+            self.window, "_tr", side_effect=lambda text: f"translated:{text}"
+        ) as translate:
             self.window.refresh_state()
 
+        translated_sources = {call.args[0] for call in translate.call_args_list}
+        self.assertTrue({
+            "; package:",
+            "Package updates",
+            "This installation is managed by {provider}. Updates use the system package source.",
+            "Update with {provider}…",
+        }.issubset(translated_sources))
+        self.assertEqual(self.window.update_group.title(), "translated:Package updates")
         self.assertTrue(self.window.update_edit.isHidden())
         self.assertTrue(self.window.include_prereleases.isHidden())
         self.assertTrue(self.window.automatic_update_checks.isHidden())

--- a/tools/wine4office-manager/tests/test_release_artifacts.sh
+++ b/tools/wine4office-manager/tests/test_release_artifacts.sh
@@ -17,7 +17,7 @@ mkdir -p "$RUNNER/bin" "$RUNNER/lib/wine/x86_64-windows" \
     "$RUNNER/share/wine4office" "$RUNNER/share/wine/gecko" "$RUNNER/share/wine/mono"
 cat > "$RUNNER/bin/wine" <<'SH'
 #!/bin/sh
-exit 0
+echo 'wine4office-2.3.4 (Wine 11.17)'
 SH
 chmod 0755 "$RUNNER/bin/wine"
 printf 'runner payload\n' > "$RUNNER/lib/wine/x86_64-windows/kernel32.dll"
@@ -64,14 +64,14 @@ grep -F "Runner is missing bundled Wine Mono:" "$TMP/missing-mono.log" >/dev/nul
 
 "$HERE/packaging/build-release-artifacts.sh" \
     "$RUNNER" "$MANAGER" "$RELEASE" "$VERSION" \
-    "https://updates.example/releases/stable/release.json" "downloads" stable >/dev/null
+    "https://updates.example/releases/stable/release.json" "downloads" stable 11.17 >/dev/null
 # Reading source files may update access times on strict-atime filesystems. Archive
 # reproducibility must not depend on that filesystem policy.
 touch -a -d '@123456789' "$RUNNER/lib/wine/x86_64-windows/kernel32.dll"
 REPEAT_RELEASE="$TMP/release-repeat"
 "$HERE/packaging/build-release-artifacts.sh" \
     "$RUNNER" "$MANAGER" "$REPEAT_RELEASE" "$VERSION" \
-    "https://updates.example/releases/stable/release.json" "downloads" stable >/dev/null
+    "https://updates.example/releases/stable/release.json" "downloads" stable 11.17 >/dev/null
 
 MANAGER_NAME="Wine4OfficeManager-${VERSION}-x86_64"
 WINE_NAME="${ROOT}.tar.zst"
@@ -166,6 +166,7 @@ assert metadata["manager"] == {
 }
 assert metadata["wine"] == {
     "version": version,
+    "base_version": "11.17",
     "url": f"downloads/{wine_name}",
     "sha256": hashlib.sha256((release_dir / wine_name).read_bytes()).hexdigest(),
     "size": (release_dir / wine_name).stat().st_size,

--- a/tools/wine4office-manager/tests/test_release_artifacts.sh
+++ b/tools/wine4office-manager/tests/test_release_artifacts.sh
@@ -17,7 +17,7 @@ mkdir -p "$RUNNER/bin" "$RUNNER/lib/wine/x86_64-windows" \
     "$RUNNER/share/wine4office" "$RUNNER/share/wine/gecko" "$RUNNER/share/wine/mono"
 cat > "$RUNNER/bin/wine" <<'SH'
 #!/bin/sh
-echo 'wine4office-2.3.4 (Wine 11.17)'
+echo 'wine4office-2.3.4 (Wine 11.17-rc1)'
 SH
 chmod 0755 "$RUNNER/bin/wine"
 printf 'runner payload\n' > "$RUNNER/lib/wine/x86_64-windows/kernel32.dll"
@@ -64,14 +64,14 @@ grep -F "Runner is missing bundled Wine Mono:" "$TMP/missing-mono.log" >/dev/nul
 
 "$HERE/packaging/build-release-artifacts.sh" \
     "$RUNNER" "$MANAGER" "$RELEASE" "$VERSION" \
-    "https://updates.example/releases/stable/release.json" "downloads" stable 11.17 >/dev/null
+    "https://updates.example/releases/stable/release.json" "downloads" stable 11.17-rc1 >/dev/null
 # Reading source files may update access times on strict-atime filesystems. Archive
 # reproducibility must not depend on that filesystem policy.
 touch -a -d '@123456789' "$RUNNER/lib/wine/x86_64-windows/kernel32.dll"
 REPEAT_RELEASE="$TMP/release-repeat"
 "$HERE/packaging/build-release-artifacts.sh" \
     "$RUNNER" "$MANAGER" "$REPEAT_RELEASE" "$VERSION" \
-    "https://updates.example/releases/stable/release.json" "downloads" stable 11.17 >/dev/null
+    "https://updates.example/releases/stable/release.json" "downloads" stable 11.17-rc1 >/dev/null
 
 MANAGER_NAME="Wine4OfficeManager-${VERSION}-x86_64"
 WINE_NAME="${ROOT}.tar.zst"
@@ -166,7 +166,7 @@ assert metadata["manager"] == {
 }
 assert metadata["wine"] == {
     "version": version,
-    "base_version": "11.17",
+    "base_version": "11.17-rc1",
     "url": f"downloads/{wine_name}",
     "sha256": hashlib.sha256((release_dir / wine_name).read_bytes()).hexdigest(),
     "size": (release_dir / wine_name).stat().st_size,

--- a/tools/wine4office-manager/tests/test_updater.py
+++ b/tools/wine4office-manager/tests/test_updater.py
@@ -467,6 +467,43 @@ class UpdaterTests(unittest.TestCase):
         self.assertIn("APT failed", task["log"])
         self.assertIn("Restoring the selected Wine environment", task["log"])
 
+    def test_failed_new_package_runner_recovers_with_previous_runner(self):
+        package = {
+            "schema_version": 1, "provider": "apt", "provider_name": "APT",
+            "package": "wine4office", "components": ("manager", "wine"),
+        }
+        new_runner = self.install_root / "runner"
+        with mock.patch.object(
+            backend, "package_installation", return_value=package
+        ), mock.patch.object(
+            backend, "package_update_command", return_value=["pkexec", "apt-get"]
+        ), mock.patch.object(
+            backend, "prepare_preload_runner_update", return_value=None
+        ), mock.patch.object(
+            manager, "stop_wine_confirmed"
+        ), mock.patch.object(
+            backend, "install_package_update", return_value={
+                "changed": True, "components": ("manager", "wine"),
+                "message": "updated",
+            }
+        ), mock.patch.object(
+            backend, "runner_update_target", return_value=new_runner
+        ), mock.patch.object(
+            backend, "update_wine_prefix",
+            side_effect=[RuntimeError("new runner failed"), "previous runner restored"],
+        ) as update_prefix:
+            state = manager.ManagerState()
+            previous_wine = state.config["wine"]
+            state.start_package_update()
+            self._wait_for(lambda: not state.snapshot()["task"]["running"])
+
+        self.assertEqual(update_prefix.call_count, 2)
+        self.assertEqual(
+            update_prefix.call_args_list[0].args[1], str(new_runner / "bin/wine")
+        )
+        self.assertEqual(update_prefix.call_args_list[1].args[1], previous_wine)
+        self.assertEqual(state.snapshot()["task"]["status"], "failed")
+
     def test_package_installation_rejects_executable_metadata(self):
         package_file = self.install_root / backend.PACKAGE_INSTALLATION_FILE
         package_file.write_text(__import__("json").dumps({

--- a/tools/wine4office-manager/tests/test_updater.py
+++ b/tools/wine4office-manager/tests/test_updater.py
@@ -330,8 +330,10 @@ class UpdaterTests(unittest.TestCase):
                 "/usr/bin/pkexec", "/usr/bin/apt-get", "install",
                 "--only-upgrade", "-y", "wine4office",
             ]
+        ), mock.patch.object(
+            backend, "package_installation", return_value=apt
         ), mock.patch.object(backend.subprocess, "run", return_value=completed) as run:
-            backend.install_package_update(lambda _line: None, apt)
+            result = backend.install_package_update(lambda _line: None, apt)
         self.assertEqual([call.args[0] for call in run.call_args_list], [
             ["/usr/bin/pkexec", "/usr/bin/apt-get", "update"],
             [
@@ -339,6 +341,99 @@ class UpdaterTests(unittest.TestCase):
                 "--only-upgrade", "-y", "wine4office",
             ],
         ])
+        self.assertFalse(result["changed"])
+        self.assertIn("already current", result["message"])
+
+    def test_package_update_verifies_every_owned_component_changed(self):
+        apt = {
+            "schema_version": 1, "provider": "apt", "provider_name": "APT",
+            "package": "wine4office", "components": ("manager", "wine"),
+        }
+        (self.install_root / "VERSION").write_text("1.0.0\n")
+        (self.install_root / "WINE_VERSION").write_text("1.0.0\n")
+
+        def update_package(*_args, **_kwargs):
+            (self.install_root / "VERSION").write_text("2.0.0\n")
+            (self.install_root / "WINE_VERSION").write_text("2.0.0\n")
+            return mock.Mock(returncode=0, stdout="updated\n")
+
+        with mock.patch.object(
+            backend, "package_update_command",
+            return_value=["/usr/bin/pkexec", "/usr/bin/apt-get", "install"],
+        ), mock.patch.object(
+            backend, "package_installation", return_value=apt
+        ), mock.patch.object(backend.subprocess, "run", side_effect=update_package):
+            result = backend.install_package_update(lambda _line: None, apt)
+
+        self.assertTrue(result["changed"])
+        self.assertEqual(set(result["components"]), {"manager", "wine"})
+
+    def test_package_update_detects_build_metadata_replacement(self):
+        apt = {
+            "schema_version": 1, "provider": "apt", "provider_name": "APT",
+            "package": "wine4office", "components": ("manager", "wine"),
+        }
+        (self.install_root / "VERSION").write_text("1.0.0+build.4\n")
+        (self.install_root / "WINE_VERSION").write_text("1.0.0+build.4\n")
+
+        def update_package(*_args, **_kwargs):
+            (self.install_root / "VERSION").write_text("1.0.0+build.5\n")
+            (self.install_root / "WINE_VERSION").write_text("1.0.0+build.5\n")
+            return mock.Mock(returncode=0, stdout="updated\n")
+
+        with mock.patch.object(
+            backend, "package_update_command",
+            return_value=["/usr/bin/pkexec", "/usr/bin/apt-get", "install"],
+        ), mock.patch.object(
+            backend, "package_installation", return_value=apt
+        ), mock.patch.object(backend.subprocess, "run", side_effect=update_package):
+            result = backend.install_package_update(lambda _line: None, apt)
+
+        self.assertTrue(result["changed"])
+        self.assertEqual(set(result["components"]), {"manager", "wine"})
+
+    def test_package_installation_skips_feed_checks_and_install_lock(self):
+        package_file = self.install_root / backend.PACKAGE_INSTALLATION_FILE
+        package_file.write_text(__import__("json").dumps({
+            "schema_version": 1,
+            "provider": "apt",
+            "package": "wine4office",
+            "components": ["manager", "wine"],
+        }))
+        state = manager.ManagerState()
+        with mock.patch.object(backend, "check_for_updates") as check:
+            self.assertFalse(state.start_update_check())
+        check.assert_not_called()
+        self.assertTrue(state.snapshot()["updater"]["checked"])
+        with mock.patch.object(backend, "_install_update_lock") as lock:
+            backend.wait_for_install_update()
+        lock.assert_not_called()
+
+    def test_unchanged_package_update_does_not_migrate_wine_prefix(self):
+        package = {
+            "schema_version": 1, "provider": "apt", "provider_name": "APT",
+            "package": "wine4office", "components": ("manager", "wine"),
+        }
+        with mock.patch.object(
+            backend, "package_installation", return_value=package
+        ), mock.patch.object(
+            backend, "package_update_command", return_value=["pkexec", "apt-get"]
+        ), mock.patch.object(
+            backend, "prepare_preload_runner_update", return_value=None
+        ), mock.patch.object(
+            manager, "stop_wine_confirmed"
+        ), mock.patch.object(
+            backend, "install_package_update", return_value={
+                "changed": False, "components": (), "message": "already current",
+            }
+        ), mock.patch.object(backend, "update_wine_prefix") as update_prefix:
+            state = manager.ManagerState()
+            state.start_package_update()
+            self._wait_for(lambda: not state.snapshot()["task"]["running"])
+
+        update_prefix.assert_not_called()
+        self.assertEqual(state.snapshot()["task"]["status"], "completed")
+        self.assertFalse(state.snapshot()["task"]["wine_update_completed"])
 
     def test_package_installation_rejects_executable_metadata(self):
         package_file = self.install_root / backend.PACKAGE_INSTALLATION_FILE
@@ -350,6 +445,46 @@ class UpdaterTests(unittest.TestCase):
         }))
         with self.assertRaisesRegex(ValueError, "package name"):
             backend.package_installation()
+
+    def test_nix_package_wrapper_is_embedded_in_persistent_commands(self):
+        package_file = self.install_root / backend.PACKAGE_INSTALLATION_FILE
+        package_file.write_text(__import__("json").dumps({
+            "schema_version": 1,
+            "provider": "nix",
+            "package": "wine4office",
+            "components": ["manager", "wine"],
+        }))
+        wrapper = self.root / "profile/bin/wine4office"
+        wrapper.parent.mkdir(parents=True)
+        wrapper.write_text("#!/bin/sh\nexec \"$@\"\n")
+        wrapper.chmod(0o755)
+        with mock.patch.dict(
+            os.environ, {"WINE4OFFICE_PACKAGE_WRAPPER": str(wrapper)}
+        ):
+            self.assertEqual(
+                backend.package_wrap_command(["/nix/store/raw-wine", "wineboot"]),
+                [str(wrapper), "--exec", "/nix/store/raw-wine", "wineboot"],
+            )
+            launcher = backend._shortcut_launcher_text(
+                "excel", self.home / ".wine4office",
+                Path("/nix/store/raw-runner/bin/wine"),
+                self.home / "EXCEL.EXE", None,
+            )
+            with mock.patch.object(
+                backend, "_preload_manager_executable",
+                return_value=Path("/nix/store/raw-manager"),
+            ), mock.patch.object(
+                backend, "_preload_worker_executable",
+                return_value=Path("/nix/store/raw-worker"),
+            ):
+                update_unit = backend._automatic_update_service_text()
+                preload_unit = backend._preload_unit_text(
+                    self.home / "binding.json", self.home / "status.json"
+                )
+
+        self.assertIn(f"wine_command=({wrapper} --exec ", launcher)
+        self.assertIn(f'ExecStart="{wrapper}" "--exec" ', update_unit)
+        self.assertIn(f'ExecStart="{wrapper}" "--exec" ', preload_unit)
 
     def test_equal_or_downgrade_is_rejected_before_download(self):
         parsed = backend.parse_release_metadata(

--- a/tools/wine4office-manager/tests/test_updater.py
+++ b/tools/wine4office-manager/tests/test_updater.py
@@ -87,8 +87,10 @@ class UpdaterTests(unittest.TestCase):
         create.assert_called_once_with(cafile="/bundle/cacert.pem")
 
     def test_schema_v1_resolves_artifacts_and_canonical_metadata_url(self):
+        payload = self.metadata()
+        payload["wine"]["base_version"] = "11.17"
         parsed = backend.parse_release_metadata(
-            self.metadata(), "https://current.example/downloads/release.json"
+            payload, "https://current.example/downloads/release.json"
         )
         self.assertEqual(parsed["schema_version"], 1)
         self.assertEqual(
@@ -99,6 +101,7 @@ class UpdaterTests(unittest.TestCase):
             parsed["wine"]["url"],
             "https://current.example/downloads/wine4office-11.2.0-x86_64.tar.zst",
         )
+        self.assertEqual(parsed["wine"]["base_version"], "11.17")
         self.assertEqual(
             parsed["metadata_url"], "https://future.example/releases/release.json"
         )
@@ -223,6 +226,17 @@ class UpdaterTests(unittest.TestCase):
         invalid["manager"]["url"] = "http://updates.example/manager"
         with self.assertRaisesRegex(ValueError, "HTTPS"):
             backend.parse_release_metadata(invalid, "https://updates.example/release.json")
+        invalid = self.metadata()
+        invalid["wine"]["base_version"] = "11.17;invalid"
+        with self.assertRaisesRegex(ValueError, "Wine base version"):
+            backend.parse_release_metadata(invalid, "https://updates.example/release.json")
+
+    def test_current_wine_base_version_reads_only_valid_metadata(self):
+        version = self.install_root / "WINE_BASE_VERSION"
+        version.write_text("11.17\n")
+        self.assertEqual(backend.current_wine_base_version(), "11.17")
+        version.write_text("11.17;invalid\n")
+        self.assertEqual(backend.current_wine_base_version(), "unknown")
 
     def test_channel_mismatch_is_rejected_before_update_offers(self):
         payload = self.metadata()
@@ -256,6 +270,86 @@ class UpdaterTests(unittest.TestCase):
              mock.patch.object(backend, "current_wine_version", return_value="11.1.0"):
             updates = backend.available_updates(parsed, {"wine": "11.2.0"})
         self.assertEqual(set(updates), {"manager"})
+
+    def test_package_installation_marks_updates_and_blocks_self_replacement(self):
+        package_file = self.install_root / backend.PACKAGE_INSTALLATION_FILE
+        package_file.write_text(__import__("json").dumps({
+            "schema_version": 1,
+            "provider": "apt",
+            "package": "wine4office",
+            "components": ["manager", "wine"],
+        }))
+        (self.install_root / "VERSION").write_text("1.0.0\n")
+        (self.install_root / "WINE_VERSION").write_text("1.0.0\n")
+        parsed = backend.parse_release_metadata(
+            self.metadata(), "https://updates.example/release.json"
+        )
+
+        updates = backend.available_updates(parsed)
+
+        self.assertEqual(set(updates), {"manager", "wine"})
+        self.assertTrue(all(
+            update["install_method"] == "package" for update in updates.values()
+        ))
+        self.assertEqual(updates["manager"]["package"]["provider_name"], "APT")
+        with mock.patch.object(backend, "_download_artifact") as download:
+            with self.assertRaisesRegex(RuntimeError, "package manager"):
+                backend.install_release_updates(
+                    parsed, ["manager"], lambda _line: None
+                )
+        download.assert_not_called()
+
+    def test_package_update_commands_are_constructed_from_allowlisted_fields(self):
+        apt = {
+            "schema_version": 1, "provider": "apt", "provider_name": "APT",
+            "package": "wine4office", "components": ("manager", "wine"),
+        }
+        with mock.patch.object(
+            backend.shutil, "which",
+            side_effect=lambda command: f"/usr/bin/{command}" if command in {
+                "pkexec", "apt-get"
+            } else None,
+        ):
+            self.assertEqual(backend.package_update_command(apt), [
+                "/usr/bin/pkexec", "/usr/bin/apt-get", "install",
+                "--only-upgrade", "-y", "wine4office",
+            ])
+        self.assertEqual(
+            backend.package_update_instructions(apt),
+            "sudo apt update && sudo apt install --only-upgrade wine4office",
+        )
+
+    def test_apt_package_update_refreshes_metadata_before_installing(self):
+        apt = {
+            "schema_version": 1, "provider": "apt", "provider_name": "APT",
+            "package": "wine4office", "components": ("manager", "wine"),
+        }
+        completed = mock.Mock(returncode=0, stdout="")
+        with mock.patch.object(
+            backend, "package_update_command", return_value=[
+                "/usr/bin/pkexec", "/usr/bin/apt-get", "install",
+                "--only-upgrade", "-y", "wine4office",
+            ]
+        ), mock.patch.object(backend.subprocess, "run", return_value=completed) as run:
+            backend.install_package_update(lambda _line: None, apt)
+        self.assertEqual([call.args[0] for call in run.call_args_list], [
+            ["/usr/bin/pkexec", "/usr/bin/apt-get", "update"],
+            [
+                "/usr/bin/pkexec", "/usr/bin/apt-get", "install",
+                "--only-upgrade", "-y", "wine4office",
+            ],
+        ])
+
+    def test_package_installation_rejects_executable_metadata(self):
+        package_file = self.install_root / backend.PACKAGE_INSTALLATION_FILE
+        package_file.write_text(__import__("json").dumps({
+            "schema_version": 1,
+            "provider": "apt",
+            "package": "wine4office;touch-owned",
+            "components": ["manager", "wine"],
+        }))
+        with self.assertRaisesRegex(ValueError, "package name"):
+            backend.package_installation()
 
     def test_equal_or_downgrade_is_rejected_before_download(self):
         parsed = backend.parse_release_metadata(

--- a/tools/wine4office-manager/tests/test_updater.py
+++ b/tools/wine4office-manager/tests/test_updater.py
@@ -88,7 +88,7 @@ class UpdaterTests(unittest.TestCase):
 
     def test_schema_v1_resolves_artifacts_and_canonical_metadata_url(self):
         payload = self.metadata()
-        payload["wine"]["base_version"] = "11.17"
+        payload["wine"]["base_version"] = "9.0-rc1"
         parsed = backend.parse_release_metadata(
             payload, "https://current.example/downloads/release.json"
         )
@@ -101,7 +101,7 @@ class UpdaterTests(unittest.TestCase):
             parsed["wine"]["url"],
             "https://current.example/downloads/wine4office-11.2.0-x86_64.tar.zst",
         )
-        self.assertEqual(parsed["wine"]["base_version"], "11.17")
+        self.assertEqual(parsed["wine"]["base_version"], "9.0-rc1")
         self.assertEqual(
             parsed["metadata_url"], "https://future.example/releases/release.json"
         )
@@ -233,8 +233,8 @@ class UpdaterTests(unittest.TestCase):
 
     def test_current_wine_base_version_reads_only_valid_metadata(self):
         version = self.install_root / "WINE_BASE_VERSION"
-        version.write_text("11.17\n")
-        self.assertEqual(backend.current_wine_base_version(), "11.17")
+        version.write_text("9.0-rc1\n")
+        self.assertEqual(backend.current_wine_base_version(), "9.0-rc1")
         version.write_text("11.17;invalid\n")
         self.assertEqual(backend.current_wine_base_version(), "unknown")
 
@@ -409,7 +409,7 @@ class UpdaterTests(unittest.TestCase):
             backend.wait_for_install_update()
         lock.assert_not_called()
 
-    def test_unchanged_package_update_does_not_migrate_wine_prefix(self):
+    def test_unchanged_package_update_restarts_stopped_wine_prefix(self):
         package = {
             "schema_version": 1, "provider": "apt", "provider_name": "APT",
             "package": "wine4office", "components": ("manager", "wine"),
@@ -426,14 +426,46 @@ class UpdaterTests(unittest.TestCase):
             backend, "install_package_update", return_value={
                 "changed": False, "components": (), "message": "already current",
             }
-        ), mock.patch.object(backend, "update_wine_prefix") as update_prefix:
+        ), mock.patch.object(
+            backend, "update_wine_prefix", return_value="Wine environment restarted"
+        ) as update_prefix:
             state = manager.ManagerState()
             state.start_package_update()
             self._wait_for(lambda: not state.snapshot()["task"]["running"])
 
-        update_prefix.assert_not_called()
+        update_prefix.assert_called_once()
+        self.assertEqual(update_prefix.call_args.args[1], state.config["wine"])
         self.assertEqual(state.snapshot()["task"]["status"], "completed")
         self.assertFalse(state.snapshot()["task"]["wine_update_completed"])
+
+    def test_failed_package_update_restarts_stopped_wine_prefix(self):
+        package = {
+            "schema_version": 1, "provider": "apt", "provider_name": "APT",
+            "package": "wine4office", "components": ("manager", "wine"),
+        }
+        with mock.patch.object(
+            backend, "package_installation", return_value=package
+        ), mock.patch.object(
+            backend, "package_update_command", return_value=["pkexec", "apt-get"]
+        ), mock.patch.object(
+            backend, "prepare_preload_runner_update", return_value=None
+        ), mock.patch.object(
+            manager, "stop_wine_confirmed"
+        ), mock.patch.object(
+            backend, "install_package_update", side_effect=RuntimeError("APT failed")
+        ), mock.patch.object(
+            backend, "update_wine_prefix", return_value="Wine environment restored"
+        ) as update_prefix:
+            state = manager.ManagerState()
+            state.start_package_update()
+            self._wait_for(lambda: not state.snapshot()["task"]["running"])
+
+        update_prefix.assert_called_once()
+        self.assertEqual(update_prefix.call_args.args[1], state.config["wine"])
+        task = state.snapshot()["task"]
+        self.assertEqual(task["status"], "failed")
+        self.assertIn("APT failed", task["log"])
+        self.assertIn("Restoring the selected Wine environment", task["log"])
 
     def test_package_installation_rejects_executable_metadata(self):
         package_file = self.install_root / backend.PACKAGE_INSTALLATION_FILE
@@ -985,6 +1017,37 @@ class UpdaterTests(unittest.TestCase):
             (self.install_root / "WINE_VERSION").read_text(), "1.4.0\n"
         )
         self.assertEqual(target.read_bytes(), b"new-manager")
+
+    def test_runner_update_without_base_version_replaces_stale_metadata(self):
+        runner_target = self.install_root / "runner"
+        (runner_target / "bin").mkdir(parents=True)
+        old_wine = runner_target / "bin/wine"
+        old_wine.write_bytes(b"old-wine")
+        old_wine.chmod(0o755)
+        (self.install_root / "WINE_VERSION").write_text("11.1.0\n")
+        (self.install_root / "WINE_BASE_VERSION").write_text("11.16\n")
+
+        wine_download = self.root / "wine-download.tar.zst"
+        with tarfile.open(wine_download, "w") as bundle:
+            contents = b"new-wine"
+            member = tarfile.TarInfo("wine4office/bin/wine")
+            member.mode = 0o755
+            member.size = len(contents)
+            bundle.addfile(member, io.BytesIO(contents))
+
+        fake = types.SimpleNamespace(ZstdDecompressor=PassthroughZstd)
+        with mock.patch.dict(sys.modules, {"zstandard": fake}), \
+             mock.patch.object(
+                 backend, "_download_artifact", return_value=wine_download
+             ):
+            backend.install_release_updates(
+                self.metadata(), ["wine"], lambda _line: None
+            )
+
+        self.assertEqual((runner_target / "bin/wine").read_bytes(), b"new-wine")
+        self.assertEqual(
+            (self.install_root / "WINE_BASE_VERSION").read_text(), "unknown\n"
+        )
 
     def test_second_component_failure_rolls_back_all_targets_and_versions(self):
         manager_target = self.install_root / "lib/wine4office-manager-qt"

--- a/tools/wine4office-manager/wine4office_backend.py
+++ b/tools/wine4office-manager/wine4office_backend.py
@@ -291,6 +291,14 @@ MAX_WINE_FILE_SIZE = 4 * 1024**3
 MAX_WINE_EXTRACTED_SIZE = 16 * 1024**3
 DEFAULT_UPDATE_CHANNEL = "stable"
 VERSION_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._+-]{0,127}")
+PACKAGE_NAME_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9+_.-]{0,127}")
+PACKAGE_INSTALLATION_FILE = "PACKAGE-INSTALLATION.json"
+PACKAGE_PROVIDERS = {
+    "apt": "APT",
+    "dnf": "DNF",
+    "aur": "AUR",
+    "nix": "Nix",
+}
 PREFIX_MARKER_NAME = ".wine4office-managed-prefix"
 PREFIX_MARKER_CONTENT = b"Wine4OfficeManager prefix v1\n"
 _STANDALONE_VERSION_CACHE = None
@@ -328,6 +336,109 @@ def installed_root() -> Path | None:
                 pass
     here = Path(__file__).resolve().parent
     return here.parent if here.name == "lib" else None
+
+
+def package_installation() -> dict | None:
+    """Return validated package ownership recorded beside the installed payload."""
+    override = os.environ.get("WINE4OFFICE_PACKAGE_INSTALLATION")
+    root = installed_root()
+    path = Path(override).expanduser() if override else (
+        root / PACKAGE_INSTALLATION_FILE if root is not None else None
+    )
+    if path is None or not path.is_file():
+        return None
+    try:
+        if path.stat().st_size > 16 * 1024:
+            raise ValueError("Package installation metadata is too large.")
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError("Package installation metadata is unreadable.") from error
+    if not isinstance(payload, dict) or payload.get("schema_version") != 1:
+        raise ValueError("Package installation metadata has an invalid schema.")
+    provider = payload.get("provider")
+    package = payload.get("package")
+    components = payload.get("components")
+    if provider not in PACKAGE_PROVIDERS:
+        raise ValueError("Package installation metadata has an unknown provider.")
+    if not isinstance(package, str) or not PACKAGE_NAME_PATTERN.fullmatch(package):
+        raise ValueError("Package installation metadata has an invalid package name.")
+    if (not isinstance(components, list) or not components
+            or any(name not in ("manager", "wine") for name in components)
+            or len(set(components)) != len(components)):
+        raise ValueError("Package installation metadata has invalid components.")
+    return {
+        "schema_version": 1,
+        "provider": provider,
+        "provider_name": PACKAGE_PROVIDERS[provider],
+        "package": package,
+        "components": tuple(components),
+    }
+
+
+def package_update_instructions(installation: dict | None = None) -> str:
+    installation = installation or package_installation()
+    if installation is None:
+        raise RuntimeError("Wine4Office is not managed by a system package.")
+    package = installation["package"]
+    provider = installation["provider"]
+    if provider == "apt":
+        return f"sudo apt update && sudo apt install --only-upgrade {package}"
+    if provider == "dnf":
+        return f"sudo dnf upgrade {package}"
+    if provider == "aur":
+        return f"paru -S {package}  # or: yay -S {package}"
+    return "Update the Wine4Office input in your NixOS configuration or Nix profile."
+
+
+def package_update_command(installation: dict | None = None) -> list[str] | None:
+    """Build an allowlisted noninteractive package update command."""
+    installation = installation or package_installation()
+    if installation is None:
+        return None
+    package = installation["package"]
+    provider = installation["provider"]
+    pkexec = shutil.which("pkexec")
+    if provider == "apt" and pkexec:
+        apt_get = shutil.which("apt-get")
+        if apt_get:
+            return [pkexec, apt_get, "install", "--only-upgrade", "-y", package]
+    if provider == "dnf" and pkexec:
+        dnf = shutil.which("dnf5") or shutil.which("dnf")
+        if dnf:
+            return [pkexec, dnf, "upgrade", "-y", package]
+    return None
+
+
+def install_package_update(output: Output,
+                           installation: dict | None = None) -> str:
+    installation = installation or package_installation()
+    command = package_update_command(installation)
+    if installation is None:
+        raise RuntimeError("Wine4Office is not managed by a system package.")
+    if command is None:
+        raise RuntimeError(
+            f"Update Wine4Office through {installation['provider_name']}: "
+            f"{package_update_instructions(installation)}"
+        )
+    output(f"Requesting a Wine4Office update through {installation['provider_name']}.")
+    commands = [command]
+    if installation["provider"] == "apt":
+        commands.insert(0, command[:2] + ["update"])
+    for package_command in commands:
+        process = subprocess.run(
+            package_command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            text=True, errors="replace", check=False,
+        )
+        if process.stdout:
+            for line in process.stdout.splitlines():
+                output(line)
+        if process.returncode:
+            raise RuntimeError(
+                f"{installation['provider_name']} exited with status "
+                f"{process.returncode}."
+            )
+    return f"Wine4Office was updated through {installation['provider_name']}."
+
 
 def standalone_manager_version_path(target: Path | None = None) -> Path | None:
     if target is None:
@@ -403,6 +514,20 @@ def current_wine_version() -> str:
             if value:
                 return value
     return "development"
+
+
+def current_wine_base_version() -> str:
+    """Return the upstream Wine version used for the installed runner."""
+    root = installed_root()
+    candidates = [root / "WINE_BASE_VERSION"] if root else [
+        data_home() / "wine4office/WINE_BASE_VERSION"
+    ]
+    for version in candidates:
+        if version.is_file():
+            value = version.read_text(errors="replace").strip()
+            if re.fullmatch(r"[0-9]+(?:[.][0-9A-Za-z]+)+", value):
+                return value
+    return "unknown"
 
 
 def configured_update_url() -> str:
@@ -2578,6 +2703,12 @@ def _parse_component(payload: object, name: str, metadata_url: str) -> dict:
     }
     if name == "wine":
         result["format"] = "tar.zst"
+        base_version = payload.get("base_version")
+        if base_version is not None:
+            if (not isinstance(base_version, str)
+                    or not re.fullmatch(r"[0-9]+(?:[.][0-9A-Za-z]+)+", base_version)):
+                raise ValueError("Release metadata has an invalid Wine base version.")
+            result["base_version"] = base_version
     return result
 
 
@@ -2775,6 +2906,7 @@ def available_updates(metadata: dict, skipped: dict | None = None,
     _validate_update_channel(metadata, expected_channel)
     skipped = skipped if isinstance(skipped, dict) else {}
     installed = {"manager": current_version(), "wine": current_wine_version()}
+    package = package_installation()
     updates: dict[str, dict] = {}
     for name in ("manager", "wine"):
         candidate = metadata[name]
@@ -2788,6 +2920,9 @@ def available_updates(metadata: dict, skipped: dict | None = None,
         if compare_versions(candidate["version"], current) <= 0:
             continue
         updates[name] = dict(candidate)
+        if package is not None and name in package["components"]:
+            updates[name]["install_method"] = "package"
+            updates[name]["package"] = dict(package)
     return updates
 
 
@@ -4211,6 +4346,10 @@ def install_release_updates(metadata: dict, components: Iterable[str], output: O
     offered = available_updates(metadata, expected_channel=expected_channel)
     if any(name not in offered for name in selected):
         raise ValueError("Refusing an equal, older, or unknown-version component update.")
+    if any(offered[name].get("install_method") == "package" for name in selected):
+        raise RuntimeError(
+            "A system-package installation must be updated through its package manager."
+        )
 
     root = installed_root()
     manager_target = manager_update_target() if "manager" in selected else None
@@ -4280,6 +4419,9 @@ def install_release_updates(metadata: dict, components: Iterable[str], output: O
             if runner_staged is not None:
                 text_updates[version_root / "WINE_VERSION"] = \
                     metadata["wine"]["version"] + "\n"
+                if metadata["wine"].get("base_version"):
+                    text_updates[version_root / "WINE_BASE_VERSION"] = \
+                        metadata["wine"]["base_version"] + "\n"
             if root is not None:
                 text_updates[root / "UPDATE_URL"] = metadata["metadata_url"] + "\n"
             _commit_update_transaction(replacements, text_updates)

--- a/tools/wine4office-manager/wine4office_backend.py
+++ b/tools/wine4office-manager/wine4office_backend.py
@@ -291,6 +291,9 @@ MAX_WINE_FILE_SIZE = 4 * 1024**3
 MAX_WINE_EXTRACTED_SIZE = 16 * 1024**3
 DEFAULT_UPDATE_CHANNEL = "stable"
 VERSION_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._+-]{0,127}")
+WINE_BASE_VERSION_PATTERN = re.compile(
+    r"[0-9]+(?:[.][0-9A-Za-z]+)+(?:[-+][0-9A-Za-z][0-9A-Za-z.-]*)?"
+)
 PACKAGE_NAME_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9+_.-]{0,127}")
 PACKAGE_INSTALLATION_FILE = "PACKAGE-INSTALLATION.json"
 PACKAGE_PROVIDERS = {
@@ -591,7 +594,7 @@ def current_wine_base_version() -> str:
     for version in candidates:
         if version.is_file():
             value = version.read_text(errors="replace").strip()
-            if re.fullmatch(r"[0-9]+(?:[.][0-9A-Za-z]+)+", value):
+            if WINE_BASE_VERSION_PATTERN.fullmatch(value):
                 return value
     return "unknown"
 
@@ -2778,7 +2781,7 @@ def _parse_component(payload: object, name: str, metadata_url: str) -> dict:
         base_version = payload.get("base_version")
         if base_version is not None:
             if (not isinstance(base_version, str)
-                    or not re.fullmatch(r"[0-9]+(?:[.][0-9A-Za-z]+)+", base_version)):
+                    or not WINE_BASE_VERSION_PATTERN.fullmatch(base_version)):
                 raise ValueError("Release metadata has an invalid Wine base version.")
             result["base_version"] = base_version
     return result
@@ -4497,9 +4500,8 @@ def install_release_updates(metadata: dict, components: Iterable[str], output: O
             if runner_staged is not None:
                 text_updates[version_root / "WINE_VERSION"] = \
                     metadata["wine"]["version"] + "\n"
-                if metadata["wine"].get("base_version"):
-                    text_updates[version_root / "WINE_BASE_VERSION"] = \
-                        metadata["wine"]["base_version"] + "\n"
+                text_updates[version_root / "WINE_BASE_VERSION"] = \
+                    metadata["wine"].get("base_version", "unknown") + "\n"
             if root is not None:
                 text_updates[root / "UPDATE_URL"] = metadata["metadata_url"] + "\n"
             _commit_update_transaction(replacements, text_updates)

--- a/tools/wine4office-manager/wine4office_backend.py
+++ b/tools/wine4office-manager/wine4office_backend.py
@@ -409,8 +409,25 @@ def package_update_command(installation: dict | None = None) -> list[str] | None
     return None
 
 
+def package_wrap_command(command: Iterable[str | Path]) -> list[str]:
+    """Route a persisted command back through its package runtime when required."""
+    values = [os.fspath(part) for part in command]
+    installation = package_installation()
+    if installation is None or installation["provider"] != "nix":
+        return values
+    configured = os.environ.get("WINE4OFFICE_PACKAGE_WRAPPER", "").strip()
+    if not configured or any(character in configured for character in "\0\n\r"):
+        raise RuntimeError("The Nix package runtime wrapper is unavailable.")
+    wrapper = Path(configured).expanduser()
+    if not wrapper.is_absolute():
+        wrapper = Path.cwd() / wrapper
+    if not wrapper.is_file() or not os.access(wrapper, os.X_OK):
+        raise RuntimeError(f"The Nix package runtime wrapper is unavailable: {wrapper}")
+    return [str(wrapper), "--exec", *values]
+
+
 def install_package_update(output: Output,
-                           installation: dict | None = None) -> str:
+                           installation: dict | None = None) -> dict:
     installation = installation or package_installation()
     command = package_update_command(installation)
     if installation is None:
@@ -420,6 +437,10 @@ def install_package_update(output: Output,
             f"Update Wine4Office through {installation['provider_name']}: "
             f"{package_update_instructions(installation)}"
         )
+    before = {
+        "manager": current_version(),
+        "wine": current_wine_version(),
+    }
     output(f"Requesting a Wine4Office update through {installation['provider_name']}.")
     commands = [command]
     if installation["provider"] == "apt":
@@ -437,7 +458,52 @@ def install_package_update(output: Output,
                 f"{installation['provider_name']} exited with status "
                 f"{process.returncode}."
             )
-    return f"Wine4Office was updated through {installation['provider_name']}."
+    current_installation = package_installation()
+    if (current_installation is None
+            or current_installation["provider"] != installation["provider"]
+            or current_installation["package"] != installation["package"]
+            or current_installation["components"] != installation["components"]):
+        raise RuntimeError("The package transaction did not preserve package ownership metadata.")
+    after = {
+        "manager": current_version(),
+        "wine": current_wine_version(),
+    }
+    changed = []
+    for name in installation["components"]:
+        if not VERSION_PATTERN.fullmatch(after[name]):
+            raise RuntimeError(
+                f"The package transaction installed an invalid {name} version: {after[name]}"
+            )
+        if VERSION_PATTERN.fullmatch(before[name]):
+            comparison = compare_versions(after[name], before[name])
+            if comparison < 0:
+                raise RuntimeError(
+                    f"The package transaction downgraded {name} to {after[name]}"
+                )
+            # SemVer build metadata does not affect precedence, but the package
+            # manager may still replace one distribution build with another.
+            if comparison > 0 or after[name] != before[name]:
+                changed.append(name)
+        elif after[name] != before[name]:
+            changed.append(name)
+    changed_components = tuple(changed)
+    if changed_components and set(changed_components) != set(installation["components"]):
+        raise RuntimeError(
+            "The package transaction updated only part of the combined Wine4Office package."
+        )
+    if not changed_components:
+        return {
+            "changed": False,
+            "components": (),
+            "message": (
+                f"{installation['provider_name']} reports that Wine4Office is already current."
+            ),
+        }
+    return {
+        "changed": True,
+        "components": changed_components,
+        "message": f"Wine4Office was updated through {installation['provider_name']}.",
+    }
 
 
 def standalone_manager_version_path(target: Path | None = None) -> Path | None:
@@ -2236,6 +2302,10 @@ def _shortcut_launcher_text(app: str, prefix: Path, wine: Path, executable: Path
     wine_value = shlex.quote(str(wine))
     executable_value = shlex.quote(str(executable))
     helper_value = shlex.quote(str(font_helper)) if font_helper else "''"
+    wine_command = package_wrap_command([wine])
+    winepath_command = package_wrap_command([wine.parent / "winepath"])
+    wine_command_value = " ".join(shlex.quote(part) for part in wine_command)
+    winepath_command_value = " ".join(shlex.quote(part) for part in winepath_command)
     winappsdk_runtime = office_winappsdk_runtime_environment(prefix)
     lines = [
         "#!/usr/bin/env bash",
@@ -2244,6 +2314,8 @@ def _shortcut_launcher_text(app: str, prefix: Path, wine: Path, executable: Path
         "set -euo pipefail",
         f"prefix={prefix_value}",
         f"wine={wine_value}",
+        f"wine_command=({wine_command_value})",
+        f"winepath_command=({winepath_command_value})",
         f"executable={executable_value}",
         f"font_helper={helper_value}",
         'if [[ ! -x "$wine" ]]; then',
@@ -2350,15 +2422,15 @@ def _shortcut_launcher_text(app: str, prefix: Path, wine: Path, executable: Path
         lines.extend([
             'if [[ $managed_prefix == true ]]; then',
             r"outlook_key='HKCU\Software\Microsoft\Office\16.0\Outlook'",
-            'outlook_query=$("$wine" reg query "$outlook_key" /v LastUILanguage 2>/dev/null || true)',
+            'outlook_query=$("${wine_command[@]}" reg query "$outlook_key" /v LastUILanguage 2>/dev/null || true)',
             'if [[ $outlook_query != *LastUILanguage* ]]; then',
-            r'''    locale_query=$("$wine" reg query 'HKCU\Control Panel\International' /v Locale 2>/dev/null || true)''',
+            r'''    locale_query=$("${wine_command[@]}" reg query 'HKCU\Control Panel\International' /v Locale 2>/dev/null || true)''',
             r"    if [[ $locale_query =~ ([[:xdigit:]]{8}) ]]; then",
             '        lcid=$((16#${BASH_REMATCH[1]}))',
             "    else",
             "        lcid=1033",
             "    fi",
-            '    "$wine" reg add "$outlook_key" /v LastUILanguage /t REG_DWORD /d "$lcid" /f >/dev/null',
+            '    "${wine_command[@]}" reg add "$outlook_key" /v LastUILanguage /t REG_DWORD /d "$lcid" /f >/dev/null',
             "fi",
             "outlook_overrides=()",
             "IFS=';' read -r -a override_items <<< \"$WINEDLLOVERRIDES\"",
@@ -2443,9 +2515,9 @@ def _shortcut_launcher_text(app: str, prefix: Path, wine: Path, executable: Path
         '        local_document=${downloaded[0]}',
         '    fi',
         '    if [[ -x "$winepath" ]]; then',
-        '        windows_document=$("$winepath" -w "$local_document")',
+        '        windows_document=$("${winepath_command[@]}" -w "$local_document")',
         "    else",
-        '        windows_document=$("$wine" winepath.exe -w "$local_document")',
+        '        windows_document=$("${wine_command[@]}" winepath.exe -w "$local_document")',
         "    fi",
         '    if [[ -z "$windows_document" ]]; then',
         '        printf \'Wine4Office launcher: could not convert document path: %s\\n\' "$document" >&2',
@@ -2453,7 +2525,7 @@ def _shortcut_launcher_text(app: str, prefix: Path, wine: Path, executable: Path
         "    fi",
         '    documents+=("$windows_document")',
         "done",
-        'exec "$wine" "$executable" "${documents[@]}"',
+        'exec "${wine_command[@]}" "$executable" "${documents[@]}"',
         "",
     ])
     return "\n".join(lines)
@@ -2987,6 +3059,8 @@ def show_automatic_update_notification(updates: dict[str, dict]) -> str:
 
 def run_scheduled_update_check() -> dict:
     """Check for updates only when the user opted into the systemd schedule."""
+    if package_installation() is not None:
+        return {"checked": False, "updates": {}, "action": ""}
     config = load_config()
     if config.get("automatic_update_checks") is not True:
         return {"checked": False, "updates": {}, "action": ""}
@@ -3015,7 +3089,9 @@ def run_scheduled_update_check() -> dict:
         disable_automatic_update_schedule()
     elif action == "update":
         subprocess.Popen(
-            [str(_preload_manager_executable()), "--open-maintenance"],
+            package_wrap_command([
+                str(_preload_manager_executable()), "--open-maintenance"
+            ]),
             env=os.environ.copy(),
             stdin=subprocess.DEVNULL,
             stdout=subprocess.DEVNULL,
@@ -4267,6 +4343,8 @@ def wait_for_install_update() -> None:
             root = executable.parent.parent
     if root is None:
         return
+    if package_installation() is not None:
+        return
     with _install_update_lock(root, manager_update_target(), root / "runner"):
         pass
 
@@ -4931,9 +5009,9 @@ def _preload_worker_executable() -> Path:
 
 def _automatic_update_service_text() -> str:
     arguments = " ".join(
-        _systemd_quote(value) for value in (
+        _systemd_quote(value) for value in package_wrap_command([
             _preload_manager_executable(), "--scheduled-update-check"
-        )
+        ])
     )
     return (
         f"{_AUTOMATIC_UPDATE_UNIT_MARKER}\n"
@@ -5042,9 +5120,9 @@ def uninstall_automatic_update_schedule() -> None:
 
 def _preload_unit_text(binding_path: Path, status_path: Path) -> str:
     arguments = " ".join(
-        _systemd_quote(value) for value in (
+        _systemd_quote(value) for value in package_wrap_command([
             _preload_worker_executable(), binding_path, status_path
-        )
+        ])
     )
     return (
         f"{_PRELOAD_UNIT_MARKER}\n"

--- a/tools/wine4office-manager/wine4office_manager.py
+++ b/tools/wine4office-manager/wine4office_manager.py
@@ -902,7 +902,6 @@ class ManagerState:
                 if "wine" in changed:
                     self.set_progress("Updating the Wine environment", None)
                     new_wine = str(backend.runner_update_target() / "bin/wine")
-                    recovery_wine = new_wine
                     self.output(backend.update_wine_prefix(
                         config["prefix"], new_wine, active_use_x11,
                         self.output, self.cancel_event, self.set_process,

--- a/tools/wine4office-manager/wine4office_manager.py
+++ b/tools/wine4office-manager/wine4office_manager.py
@@ -44,7 +44,7 @@ FONT_HELPER = (INSTALL_ROOT / "lib/register-office-cloud-fonts.sh"
 
 def manager_restart_command() -> list[str]:
     if FROZEN:
-        return [str(Path(sys.executable).resolve())]
+        return backend.package_wrap_command([str(Path(sys.executable).resolve())])
     if INSTALL_ROOT != HERE:
         return [str(INSTALL_ROOT / "bin/wine4office-manager")]
     return [str(Path(sys.executable).resolve()), str(HERE / "wine4office_manager.py")]
@@ -684,6 +684,14 @@ class ManagerState:
         with self.lock:
             if self.updater["checking"]:
                 return False
+            if backend.package_installation() is not None:
+                self.updater = {
+                    "checking": False,
+                    "checked": True,
+                    "offer": None,
+                    "error": "",
+                }
+                return False
             metadata_url = str(self.config["update_url"]).strip()
             if not metadata_url:
                 return False
@@ -778,10 +786,10 @@ class ManagerState:
                 raise RuntimeError(
                     "Package-managed and standalone updates must be installed separately."
                 )
-            package = (
-                offer["updates"][package_updates[0]]["package"]
-                if package_updates else None
-            )
+            if package_updates:
+                raise RuntimeError(
+                    "Package-managed Wine4Office must be updated as one package."
+                )
 
         def install() -> str:
             preload_update = None
@@ -797,21 +805,15 @@ class ManagerState:
                         use_x11=active_use_x11,
                     )
                     self.output("Stopped the selected Wine environment before updating.")
-                if package is not None:
-                    self.set_progress(
-                        f"Updating through {package['provider_name']}", None
-                    )
-                    result = backend.install_package_update(self.output, package)
-                else:
-                    result = backend.install_release_updates(
-                        metadata, selected, self.output, self.cancel_event,
-                        expected_channel=backend.accepted_update_channels(
-                            include_prereleases=(
-                                config.get("include_prereleases") is True
-                            )
-                        ),
-                        progress=self.set_progress,
-                    )
+                result = backend.install_release_updates(
+                    metadata, selected, self.output, self.cancel_event,
+                    expected_channel=backend.accepted_update_channels(
+                        include_prereleases=(
+                            config.get("include_prereleases") is True
+                        )
+                    ),
+                    progress=self.set_progress,
+                )
                 if "wine" in selected:
                     self.set_progress("Updating the Wine environment", None)
                     new_wine = str(backend.runner_update_target() / "bin/wine")
@@ -852,6 +854,77 @@ class ManagerState:
         self.start_task("update", install)
         with self.lock:
             self.updater["offer"] = None
+
+    def start_package_update(self) -> None:
+        """Update every component owned by one system package."""
+        with self.lock:
+            package = backend.package_installation()
+            if package is None:
+                raise RuntimeError("Wine4Office is not managed by a system package.")
+            if backend.package_update_command(package) is None:
+                raise RuntimeError(backend.package_update_instructions(package))
+            config = dict(self.config)
+            active_use_x11, _active_use_vulkan = backend.active_graphics_settings(config)
+            components = tuple(package["components"])
+
+        def install() -> str:
+            preload_update = None
+            try:
+                if "wine" in components:
+                    self.set_progress("Stopping background services", None)
+                    preload_update = backend.prepare_preload_runner_update(
+                        config["prefix"], active_use_x11,
+                        wine_value=config["wine"],
+                    )
+                    stop_wine_confirmed(
+                        config["prefix"], config["wine"],
+                        use_x11=active_use_x11,
+                    )
+                    self.output("Stopped the selected Wine environment before updating.")
+                self.set_progress(
+                    f"Updating through {package['provider_name']}", None
+                )
+                result = backend.install_package_update(self.output, package)
+                if not result["changed"]:
+                    return result["message"]
+                changed = set(result["components"])
+                if "wine" in changed:
+                    self.set_progress("Updating the Wine environment", None)
+                    new_wine = str(backend.runner_update_target() / "bin/wine")
+                    self.output(backend.update_wine_prefix(
+                        config["prefix"], new_wine, active_use_x11,
+                        self.output, self.cancel_event, self.set_process,
+                    ))
+                    if preload_update is not None:
+                        backend.finish_preload_runner_update(preload_update, new_wine)
+                        preload_update = None
+                        self.output(
+                            "Updated the background services to use the new Wine runner."
+                        )
+                    with self.lock:
+                        candidate = dict(self.config)
+                        candidate["wine"] = new_wine
+                        backend.save_config(candidate)
+                        self.config = candidate
+                        config.update(candidate)
+                        self.task["wine_update_completed"] = True
+                if "manager" in changed:
+                    self.set_progress("Finishing the Manager update", None)
+                    with self.lock:
+                        self.task["restart_required"] = True
+                    self._run_updated_manager_post_install(config)
+                return result["message"]
+            finally:
+                if preload_update is not None:
+                    try:
+                        backend.restore_preload_after_runner_update(preload_update)
+                    except RuntimeError as error:
+                        self.output(
+                            "WARNING: Could not resume background services after the "
+                            f"package update: {error}"
+                        )
+
+        self.start_task("update", install)
 
     def _run_updated_manager_post_install(self, config: dict) -> None:
         target = backend.manager_update_target()
@@ -1499,7 +1572,8 @@ def main() -> int:
 
     if args.install_shortcut:
         path = backend.install_manager_shortcut(
-            LAUNCHER if FROZEN else LAUNCHER.with_name("wine4office-manager"), ICONS
+            MANAGER_RESTART_COMMAND if FROZEN else LAUNCHER.with_name("wine4office-manager"),
+            ICONS,
         )
         print(path)
         return 0

--- a/tools/wine4office-manager/wine4office_manager.py
+++ b/tools/wine4office-manager/wine4office_manager.py
@@ -869,6 +869,9 @@ class ManagerState:
 
         def install() -> str:
             preload_update = None
+            wine_stopped = False
+            wine_restarted = False
+            recovery_wine = config["wine"]
             try:
                 if "wine" in components:
                     self.set_progress("Stopping background services", None)
@@ -880,21 +883,31 @@ class ManagerState:
                         config["prefix"], config["wine"],
                         use_x11=active_use_x11,
                     )
+                    wine_stopped = True
                     self.output("Stopped the selected Wine environment before updating.")
                 self.set_progress(
                     f"Updating through {package['provider_name']}", None
                 )
                 result = backend.install_package_update(self.output, package)
                 if not result["changed"]:
+                    if wine_stopped:
+                        self.set_progress("Restarting the Wine environment", None)
+                        self.output(backend.update_wine_prefix(
+                            config["prefix"], recovery_wine, active_use_x11,
+                            self.output, process_callback=self.set_process,
+                        ))
+                        wine_restarted = True
                     return result["message"]
                 changed = set(result["components"])
                 if "wine" in changed:
                     self.set_progress("Updating the Wine environment", None)
                     new_wine = str(backend.runner_update_target() / "bin/wine")
+                    recovery_wine = new_wine
                     self.output(backend.update_wine_prefix(
                         config["prefix"], new_wine, active_use_x11,
                         self.output, self.cancel_event, self.set_process,
                     ))
+                    wine_restarted = True
                     if preload_update is not None:
                         backend.finish_preload_runner_update(preload_update, new_wine)
                         preload_update = None
@@ -915,6 +928,20 @@ class ManagerState:
                     self._run_updated_manager_post_install(config)
                 return result["message"]
             finally:
+                if wine_stopped and not wine_restarted:
+                    try:
+                        self.output(
+                            "Restoring the selected Wine environment after the failed update."
+                        )
+                        self.output(backend.update_wine_prefix(
+                            config["prefix"], recovery_wine, active_use_x11,
+                            self.output, process_callback=self.set_process,
+                        ))
+                    except Exception as error:
+                        self.output(
+                            "WARNING: Could not restore the selected Wine environment after "
+                            f"the package update: {error}"
+                        )
                 if preload_update is not None:
                     try:
                         backend.restore_preload_after_runner_update(preload_update)

--- a/tools/wine4office-manager/wine4office_manager.py
+++ b/tools/wine4office-manager/wine4office_manager.py
@@ -770,6 +770,18 @@ class ManagerState:
             metadata = offer["metadata"]
             config = dict(self.config)
             active_use_x11, _active_use_vulkan = backend.active_graphics_settings(config)
+            package_updates = [
+                name for name in selected
+                if offer["updates"][name].get("install_method") == "package"
+            ]
+            if package_updates and len(package_updates) != len(selected):
+                raise RuntimeError(
+                    "Package-managed and standalone updates must be installed separately."
+                )
+            package = (
+                offer["updates"][package_updates[0]]["package"]
+                if package_updates else None
+            )
 
         def install() -> str:
             preload_update = None
@@ -785,15 +797,21 @@ class ManagerState:
                         use_x11=active_use_x11,
                     )
                     self.output("Stopped the selected Wine environment before updating.")
-                result = backend.install_release_updates(
-                    metadata, selected, self.output, self.cancel_event,
-                    expected_channel=backend.accepted_update_channels(
-                        include_prereleases=(
-                            config.get("include_prereleases") is True
-                        )
-                    ),
-                    progress=self.set_progress,
-                )
+                if package is not None:
+                    self.set_progress(
+                        f"Updating through {package['provider_name']}", None
+                    )
+                    result = backend.install_package_update(self.output, package)
+                else:
+                    result = backend.install_release_updates(
+                        metadata, selected, self.output, self.cancel_event,
+                        expected_channel=backend.accepted_update_channels(
+                            include_prereleases=(
+                                config.get("include_prereleases") is True
+                            )
+                        ),
+                        progress=self.set_progress,
+                    )
                 if "wine" in selected:
                     self.set_progress("Updating the Wine environment", None)
                     new_wine = str(backend.runner_update_target() / "bin/wine")
@@ -1078,6 +1096,8 @@ class ManagerState:
             "status": backend.environment_status(config["prefix"], config["wine"]),
             "version": backend.current_version(),
             "wine_version": backend.current_wine_version(),
+            "wine_base_version": backend.current_wine_base_version(),
+            "package_installation": backend.package_installation(),
             "task": task,
             "updater": updater,
             "preload": preload,

--- a/tools/wine4office-manager/wine4office_qt.py
+++ b/tools/wine4office-manager/wine4office_qt.py
@@ -3052,14 +3052,17 @@ class ManagerWindow(QMainWindow):
             f"{self._tr('; Wine4Office:')} {snapshot['wine_version']}"
             f"{self._tr('; Wine base:')} {snapshot['wine_base_version']}"
             + (
-                f"; package: {snapshot['package_installation']['provider_name']}"
+                f"{self._tr('; package:')} "
+                f"{snapshot['package_installation']['provider_name']}"
                 if snapshot.get("package_installation") else ""
             )
         )
         package = snapshot.get("package_installation")
         self.package_installation = dict(package) if package else None
         package_managed = self.package_installation is not None
-        self.update_group.setTitle("Package updates" if package_managed else "Updates")
+        self.update_group.setTitle(self._tr(
+            "Package updates" if package_managed else "Updates"
+        ))
         self.update_url_label.setVisible(not package_managed)
         self.update_edit.setVisible(not package_managed)
         self.automatic_update_checks.setVisible(not package_managed)
@@ -3069,17 +3072,20 @@ class ManagerWindow(QMainWindow):
             provider = self.package_installation["provider_name"]
             instructions = backend.package_update_instructions(self.package_installation)
             self.package_update_label.setText(
-                f"This installation is managed by {provider}. Updates use the system "
-                f"package source.\n\n{instructions}"
+                self._tr(
+                    "This installation is managed by {provider}. Updates use the system "
+                    "package source."
+                ).format(provider=provider)
+                + f"\n\n{instructions}"
             )
             self.update_button.setText(
-                f"Update with {provider}…"
+                self._tr("Update with {provider}…").format(provider=provider)
                 if backend.package_update_command(self.package_installation) else
-                "Copy update instructions"
+                self._tr("Copy update instructions")
             )
         else:
             self.package_update_label.clear()
-            self.update_button.setText("Check for updates…")
+            self.update_button.setText(self._tr("Check for updates…"))
         updater = snapshot["updater"]
         automatic_enabled = (
             snapshot["config"].get("automatic_update_checks") is True

--- a/tools/wine4office-manager/wine4office_qt.py
+++ b/tools/wine4office-manager/wine4office_qt.py
@@ -2672,16 +2672,39 @@ class ManagerWindow(QMainWindow):
             f"{labels[name]}: {offer['updates'][name]['version']}"
             for name in selected
         )
+        package = next((
+            offer["updates"][name].get("package") for name in selected
+            if offer["updates"][name].get("install_method") == "package"
+        ), None)
+        package_command = backend.package_update_command(package) if package else None
+        package_instructions = (
+            backend.package_update_instructions(package) if package else ""
+        )
         dialog = QMessageBox(self)
         dialog.setIcon(QMessageBox.Icon.Question)
         dialog.setWindowTitle(self._tr("Wine4Office update available"))
         dialog.setText(self._tr("Updates are available."))
-        dialog.setInformativeText(
-            f"{versions}\n\n{self._tr('Nothing downloads until you approve this update.')}"
-        )
-        install_button = dialog.addButton(
-            self._tr("Download and install"), QMessageBox.ButtonRole.AcceptRole
-        )
+        if package:
+            dialog.setInformativeText(
+                f"{versions}\n\nThis installation is managed by "
+                f"{package['provider_name']}. Wine4Office will not replace package-owned "
+                f"files itself.\n\n{package_instructions}"
+            )
+            install_button = dialog.addButton(
+                f"Update with {package['provider_name']}",
+                QMessageBox.ButtonRole.AcceptRole,
+            ) if package_command else None
+            copy_button = dialog.addButton(
+                "Copy update instructions", QMessageBox.ButtonRole.ActionRole
+            ) if not package_command else None
+        else:
+            dialog.setInformativeText(
+                f"{versions}\n\n{self._tr('Nothing downloads until you approve this update.')}"
+            )
+            install_button = dialog.addButton(
+                self._tr("Download and install"), QMessageBox.ButtonRole.AcceptRole
+            )
+            copy_button = None
         later_button = dialog.addButton(self._tr("Later"), QMessageBox.ButtonRole.RejectRole)
         skip_button = dialog.addButton(
             self._tr("Skip these versions"), QMessageBox.ButtonRole.DestructiveRole
@@ -2701,9 +2724,12 @@ class ManagerWindow(QMainWindow):
         clicked = dialog.clickedButton()
         if clicked is skip_button:
             self.state.skip_offered_updates(selected)
+        elif copy_button is not None and clicked is copy_button:
+            QApplication.clipboard().setText(package_instructions)
+            self.notify("Package update instructions copied.")
         elif disable_button is not None and clicked is disable_button:
             self._apply_automatic_update_checks(False, prompted=True)
-        elif clicked is install_button:
+        elif install_button is not None and clicked is install_button:
             update_started = False
             try:
                 if "manager" in selected:
@@ -3008,7 +3034,12 @@ class ManagerWindow(QMainWindow):
 
         self.version_label.setText(
             f"{self._tr('Manager:')} {snapshot['version']}"
-            f"{self._tr('; Wine:')} {snapshot['wine_version']}"
+            f"{self._tr('; Wine4Office:')} {snapshot['wine_version']}"
+            f"{self._tr('; Wine base:')} {snapshot['wine_base_version']}"
+            + (
+                f"; package: {snapshot['package_installation']['provider_name']}"
+                if snapshot.get("package_installation") else ""
+            )
         )
         updater = snapshot["updater"]
         automatic_enabled = (

--- a/tools/wine4office-manager/wine4office_qt.py
+++ b/tools/wine4office-manager/wine4office_qt.py
@@ -199,6 +199,7 @@ class ManagerWindow(QMainWindow):
         self.handled_offer_id = ""
         self.manual_update_check = False
         self.reported_update_error = ""
+        self.package_installation: dict | None = None
         self.restart_prompted = False
         self.task_sensitive_buttons: list[QPushButton | QCommandLinkButton] = []
         self.installed_apps: set[str] = set()
@@ -1626,16 +1627,21 @@ class ManagerWindow(QMainWindow):
             self.incident_ask.toggled.connect(self.set_incident_reporting_mode)
             layout.addWidget(reliability)
 
-        update = QGroupBox("Updates")
-        update_layout = QVBoxLayout(update)
+        self.update_group = QGroupBox("Updates")
+        update_layout = QVBoxLayout(self.update_group)
         update_form = self._form()
         self.update_edit = QLineEdit()
         self.update_edit.setPlaceholderText("HTTPS release metadata URL")
         self.update_edit.setAccessibleName("Release metadata address")
         self.version_label = QLabel("Manager: development; Wine: development")
         update_form.addRow("Installed versions:", self.version_label)
-        update_form.addRow("Metadata URL:", self.update_edit)
+        self.update_url_label = QLabel("Metadata URL:")
+        update_form.addRow(self.update_url_label, self.update_edit)
         update_layout.addLayout(update_form)
+        self.package_update_label = QLabel()
+        self.package_update_label.setWordWrap(True)
+        self.package_update_label.hide()
+        update_layout.addWidget(self.package_update_label)
         self.automatic_update_checks = QCheckBox(
             "Check in the background at login and every 24 hours"
         )
@@ -1666,7 +1672,7 @@ class ManagerWindow(QMainWindow):
         )
         update_buttons.addWidget(self.update_button)
         update_layout.addLayout(update_buttons)
-        layout.addWidget(update)
+        layout.addWidget(self.update_group)
 
         removal = QGroupBox("Removal")
         removal_layout = QVBoxLayout(removal)
@@ -2644,6 +2650,41 @@ class ManagerWindow(QMainWindow):
         config = self.save_config()
         if not config:
             return
+        package = self.package_installation
+        if package is not None:
+            instructions = backend.package_update_instructions(package)
+            if backend.package_update_command(package) is None:
+                QApplication.clipboard().setText(instructions)
+                self.notify("Package update instructions copied.")
+                return
+            update_started = False
+            try:
+                self.restart_prompted = False
+                self.pending_runner_update_repair = (
+                    "wine" in package["components"]
+                    and backend.office_installation_exists(config["prefix"])
+                )
+                self.state.start_package_update()
+                update_started = True
+                self._show_task_progress(
+                    "update",
+                    f"Updating with {package['provider_name']}",
+                    "Wine4Office Manager and Wine runner",
+                    f"Preparing {package['provider_name']} package update…",
+                    {
+                        "completed": "Package update completed.",
+                        "cancelled": "Package update cancelled.",
+                        "failed": "Package update failed. Review the details below.",
+                    },
+                    cancellable=False,
+                )
+                self.notify(f"{package['provider_name']} package update started.")
+                self.refresh_state()
+            except Exception as error:
+                if not update_started:
+                    self.pending_runner_update_repair = False
+                self.show_error(error)
+            return
         if not config["update_url"]:
             self.show_error("Configure an HTTPS release metadata address first.")
             return
@@ -2672,39 +2713,16 @@ class ManagerWindow(QMainWindow):
             f"{labels[name]}: {offer['updates'][name]['version']}"
             for name in selected
         )
-        package = next((
-            offer["updates"][name].get("package") for name in selected
-            if offer["updates"][name].get("install_method") == "package"
-        ), None)
-        package_command = backend.package_update_command(package) if package else None
-        package_instructions = (
-            backend.package_update_instructions(package) if package else ""
-        )
         dialog = QMessageBox(self)
         dialog.setIcon(QMessageBox.Icon.Question)
         dialog.setWindowTitle(self._tr("Wine4Office update available"))
         dialog.setText(self._tr("Updates are available."))
-        if package:
-            dialog.setInformativeText(
-                f"{versions}\n\nThis installation is managed by "
-                f"{package['provider_name']}. Wine4Office will not replace package-owned "
-                f"files itself.\n\n{package_instructions}"
-            )
-            install_button = dialog.addButton(
-                f"Update with {package['provider_name']}",
-                QMessageBox.ButtonRole.AcceptRole,
-            ) if package_command else None
-            copy_button = dialog.addButton(
-                "Copy update instructions", QMessageBox.ButtonRole.ActionRole
-            ) if not package_command else None
-        else:
-            dialog.setInformativeText(
-                f"{versions}\n\n{self._tr('Nothing downloads until you approve this update.')}"
-            )
-            install_button = dialog.addButton(
-                self._tr("Download and install"), QMessageBox.ButtonRole.AcceptRole
-            )
-            copy_button = None
+        dialog.setInformativeText(
+            f"{versions}\n\n{self._tr('Nothing downloads until you approve this update.')}"
+        )
+        install_button = dialog.addButton(
+            self._tr("Download and install"), QMessageBox.ButtonRole.AcceptRole
+        )
         later_button = dialog.addButton(self._tr("Later"), QMessageBox.ButtonRole.RejectRole)
         skip_button = dialog.addButton(
             self._tr("Skip these versions"), QMessageBox.ButtonRole.DestructiveRole
@@ -2724,12 +2742,9 @@ class ManagerWindow(QMainWindow):
         clicked = dialog.clickedButton()
         if clicked is skip_button:
             self.state.skip_offered_updates(selected)
-        elif copy_button is not None and clicked is copy_button:
-            QApplication.clipboard().setText(package_instructions)
-            self.notify("Package update instructions copied.")
         elif disable_button is not None and clicked is disable_button:
             self._apply_automatic_update_checks(False, prompted=True)
-        elif install_button is not None and clicked is install_button:
+        elif clicked is install_button:
             update_started = False
             try:
                 if "manager" in selected:
@@ -3041,6 +3056,30 @@ class ManagerWindow(QMainWindow):
                 if snapshot.get("package_installation") else ""
             )
         )
+        package = snapshot.get("package_installation")
+        self.package_installation = dict(package) if package else None
+        package_managed = self.package_installation is not None
+        self.update_group.setTitle("Package updates" if package_managed else "Updates")
+        self.update_url_label.setVisible(not package_managed)
+        self.update_edit.setVisible(not package_managed)
+        self.automatic_update_checks.setVisible(not package_managed)
+        self.include_prereleases.setVisible(not package_managed)
+        self.package_update_label.setVisible(package_managed)
+        if package_managed:
+            provider = self.package_installation["provider_name"]
+            instructions = backend.package_update_instructions(self.package_installation)
+            self.package_update_label.setText(
+                f"This installation is managed by {provider}. Updates use the system "
+                f"package source.\n\n{instructions}"
+            )
+            self.update_button.setText(
+                f"Update with {provider}…"
+                if backend.package_update_command(self.package_installation) else
+                "Copy update instructions"
+            )
+        else:
+            self.package_update_label.clear()
+            self.update_button.setText("Check for updates…")
         updater = snapshot["updater"]
         automatic_enabled = (
             snapshot["config"].get("automatic_update_checks") is True


### PR DESCRIPTION
## Problem and result

Wine4Office releases currently install as standalone archives, so distro package managers cannot own upgrades and the Manager may try to replace package-owned files itself. Release builds also need to distinguish the Wine4Office product version from the upstream Wine version.

This change adds Debian, RPM, AUR, Nix, and AppImage distribution paths around the same Manager and Wine release artifacts. Package installs record their provider. APT and DNF updates run through a root-owned helper that enforces deadlines, monitors cancellation, terminates the full privileged process group, and remains supervised until exit. AUR and Nix show provider-specific instructions.

The AppImage is a one-file installer. It verifies and installs its bundled release into the existing durable per-user layout, then launches the installed Manager. This keeps Office shortcuts, Wine services, and updates valid after the AppImage is moved or deleted and avoids persisting a temporary AppImage mount path. Re-running the same AppImage is idempotent, and an older AppImage does not downgrade a complete newer installation.

The image uses reproducible DwarFS packaging with tagged `mkdwarfs` 0.15.6 and `uruntime` 0.7.1 assets whose SHA-256 hashes are pinned in the release workflow.

Wine builds now receive the release product version and report it separately from the upstream base, for example `wine4office-0.2.2 (Wine 11.17)`. Release metadata and installed package markers preserve both values.

## Validation

- Built a real 576 MB AppImage from the published 0.2.1-beta.1 Manager and Wine artifacts; an independent rebuild produced the same SHA-256, `71bc820aeba35de79ae3ba100d14fd9848c83428f6a113eaf6a4da7bd303635d`.
- Completed the full release workflow for `0.2.2-appimage-ci.5`, including Wine and Manager builds, DEB/RPM packaging, AppImage installation and post-move smoke tests, APT/Fedora repository installs, and artifact uploads.
- Downloaded the CI AppImage and verified its sidecar checksum: `7e77f8460aa2cb69e20527471e995bbb82ec8a985a97c2d48599dd231c873f23` for 578,867,753 bytes.
- Verified bundled artifact sizes and SHA-256 hashes before packaging and installation.
- Installed from the AppImage in an isolated home, moved the AppImage away, then ran the installed Manager smoke test and `wine --version` successfully.
- AppImage packaging tests cover payload identity, durable installation, idempotence, downgrade prevention, channel persistence, and operation after removing the AppDir.
- Passed 289 Manager, backend, and updater tests in a temporary Python 3.13 container with the signing dependencies installed.
- Repeated the descendant-process termination regression 20 times after adding its PID and signal-handler handshake.
- Verified curl and bundled installer paths, release artifact packaging, ShellCheck, Bash syntax, Python compilation, YAML parsing, and `git diff --check`.
- Built, published to local repositories, and installed the DEB on Ubuntu 24.04 and the RPM on Fedora 44 in temporary containers without Office. The Ubuntu test also cancels the installed root helper and confirms its package process exited.

## Risks and limits

- The AppImage is an installer rather than a stateless Wine runtime. Wine4Office writes an Office prefix, desktop entries, and user services, so a durable user installation is required for correct operation.
- AppImage installation still requires the baseline tools used by the existing standalone installer, including Bash and Python 3. `zstd` and its direct libraries are bundled.
- Production APT and RPM repositories still need signing keys and HTTPS hosting.
- Optional Unix Wine modules can remain tied to library ABIs from the Ubuntu release builder; the AppImage uses the same verified runner rather than creating a format-specific Wine build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DEB, RPM, AUR, Nix, and AppImage distribution options.
  * Package-managed installations receive coordinated Manager and Wine updates through supported package managers.
  * Release builds display separate Wine4Office and upstream Wine versions.
  * Installers support bundled offline artifacts and stable or prerelease channels.

* **Bug Fixes**
  * Improved Authenticode verification for multi-digit OpenSSL versions.
  * Added validation for packaged Wine versions and release metadata.
  * Package updates now support cancellation, timeouts, and recovery.

* **Documentation**
  * Added distribution packaging and installation guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->